### PR TITLE
Switch from '%s' to '%o'

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -371,8 +371,8 @@ function captureOrMatch(params, response, context, done) {
               result.captures,
               spec.transform);
 
-            debug('transform: %s = %o', spec.as, result.captures[spec.as]);
             result.captures[spec.as] = transformedValue !== null ? transformedValue : extractedValue;
+            debug('transform: %s = %o', spec.as, result.captures[spec.as]);
           }
         }
 


### PR DESCRIPTION
Making this change in the debug format string declaration ensures that `util.inspect` is used to serialize the `extractedValue` and `result.captures[spec.as]` results.

This avoids an error:
`TypeError: Cannot convert object to primitive value`

that occurs with some non-object entities that can be returned by the cheerioExtractor (i.e. DOM Elements which are not native objects).