### PR TITLE
feat: Support ramp-down as well as ramp-up

### DIFF
--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -83,9 +83,11 @@ function createPause(spec, ee) {
 }
 
 function createRamp(spec, ee) {
-  const tick = 1000 / spec.rampTo; // smallest tick
+  const tick = 1000 / Math.max(spec.arrivalRate, spec.rampTo); // smallest tick
   const r0 = spec.arrivalRate; // initial arrival rate
-  const periods = spec.rampTo - spec.arrivalRate + 1;
+  const difference = spec.rampTo - spec.arrivalRate;
+  const offset = difference < 0 ? -1 : 1;
+  const periods = Math.abs(difference) + 1;
   const ticksPerPeriod = (spec.duration / periods) * 1000 / tick;
   const periodLenSec = spec.duration / periods;
 
@@ -113,8 +115,8 @@ function createRamp(spec, ee) {
       let startedAt = Date.now();
       if(++ticksElapsed > ticksPerPeriod) {
         debug(`ticksElapsed: ${ticksElapsed}; upping probability or stopping`);
-        if (currentRate < spec.rampTo) {
-          currentRate++;
+        if (offset === -1 ? currentRate > spec.rampTo : currentRate < spec.rampTo) {
+          currentRate += offset;
           ticksElapsed = 0;
 
           p = (periodLenSec * currentRate) / ticksPerPeriod;

--- a/test/core/unit/phases.test.js
+++ b/test/core/unit/phases.test.js
@@ -103,17 +103,28 @@ test('arrivalCount', function(t) {
   phaser.run();
 });
 
-test('ramp', function(t) {
-  const phaseSpec = {
+test('rampUp', function(t) {
+  testRamp(t, {
     duration: 15,
     arrivalRate: 1,
     rampTo: 20
-  };
+  });
+});
+
+test('rampDown', function(t) {
+  testRamp(t, {
+    duration: 15,
+    arrivalRate: 20,
+    rampTo: 1
+  });
+});
+
+function testRamp(t, phaseSpec) {
   let phaser = createPhaser([phaseSpec]);
 
 
   let expected = 0;
-  let periods = phaseSpec.rampTo - phaseSpec.arrivalRate + 1;
+  let periods = Math.abs(phaseSpec.rampTo - phaseSpec.arrivalRate) + 1;
   let periodLenSec = phaseSpec.duration / periods;
   for(let i = 1; i <= periods; i++) {
     let expectedInPeriod = periodLenSec * i;
@@ -159,4 +170,4 @@ test('ramp', function(t) {
   });
   startedAt = Date.now();
   phaser.run();
-});
+}


### PR DESCRIPTION
The rampTo option can now also be set to a value lower than arrivalRate, and it will ramp from the starting arrivalRate down to the rampTo value.

Implements #205