### PR TITLE
feat: Add request path to response entries

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -256,6 +256,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           requestParams.uri = template(requestParams.uri, context);
         }
         if (requestParams.url) {
+          requestParams.requestEntryPath = params.url || params.uri;
           requestParams.url = template(requestParams.url, context);
         }
 
@@ -471,10 +472,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
             req.on('response', function updateLatency(res) {
               let code = res.statusCode;
+              let path = res.req.method + ' ' + requestParams.requestEntryPath;
               const endedAt = process.hrtime(startedAt);
               let delta = (endedAt[0] * 1e9) + endedAt[1];
               debugRequests('request end: %s', req.path);
-              ee.emit('response', delta, code, context._uid);
+              ee.emit('response', delta, code, context._uid, path);
             });
           }).on('end', function() {
             context._successCount++;

--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -339,12 +339,12 @@ function runScenario(script, intermediate, runState) {
     runState.scenarioEvents.on('match', function() {
       intermediate.addMatch();
     });
-    runState.scenarioEvents.on('response', function(delta, code, uid) {
+    runState.scenarioEvents.on('response', function(delta, code, uid, requestPath) {
       intermediate.completedRequest();
       intermediate.addLatency(delta);
       intermediate.addCode(code);
 
-      let entry = [Date.now(), uid, delta, code];
+      let entry = [Date.now(), uid, delta, code, requestPath];
       intermediate.addEntry(entry);
 
       runState.pendingRequests--;

--- a/test/core/index.js
+++ b/test/core/index.js
@@ -13,6 +13,7 @@ require('./ws/test_options');
 require('./test_think');
 require('./test_basic_auth');
 require('./test_cookies');
+require('./test_request_path_in_entry');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/core/test_request_path_in_entry.js
+++ b/test/core/test_request_path_in_entry.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const test = require('tape');
+const runner = require('../../core/lib/runner').runner;
+
+test('arrival phases', function(t) {
+  var script = require('./scripts/hello.json');
+
+  runner(script).then(function(ee) {
+    ee.on('phaseStarted', function(info) {
+      console.log('Starting phase: %j - %s', info, new Date());
+    });
+    ee.on('phaseCompleted', function() {
+      console.log('Phase completed - %s', new Date());
+    });
+    ee.on('stats', function(stats) {
+      t.assert(stats._entries[0].length === 5, 'entry should have 5 fields');
+      t.assert(stats._entries[0][4] === 'GET /', 'first entry request path');
+      t.assert(stats._entries[1][4] === 'POST /pets', 'second entry request path');
+    });
+    ee.on('done', function() {
+      t.end();
+    });
+    ee.run();
+  });
+});


### PR DESCRIPTION
Adds the request path to each response entry. This feature is useful when looking at the test as a whole, or at periods of time, to narrow down which requests returned 2xx/4xx/5xx as well as their latencies. This enhancement of metrics allows for better understanding of each endpoint the test loads.