### PR TITLE
feat: Add custom functions that can be called inside test script

### DIFF
--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -18,6 +18,7 @@ const createPhaser = require('./phases');
 const createReader = require('./readers');
 const engineUtil = require('./engine_util');
 const wl = require('./weighted-pick');
+const {$randomNumber, $randomString, $uuid, $dateNow} = require('./template-strings');
 
 const Engines = {
   http: {},
@@ -35,7 +36,9 @@ module.exports = {
   stats: Stats,
   contextFuncs: {
     $randomString,
-    $randomNumber
+    $randomNumber,
+    $uuid,
+    $dateNow
   }
 };
 
@@ -399,8 +402,10 @@ function createContext(script) {
       $processEnvironment: process.env
     },
     funcs: {
-      $randomNumber: $randomNumber,
-      $randomString: $randomString,
+      $randomNumber,
+      $randomString,
+      $uuid,
+      $dateNow,
       $template: input => engineUtil.template(input, { vars: result.vars })
     }
   };
@@ -438,15 +443,4 @@ function createContext(script) {
   result._uid = uuid.v4();
   result.vars.$uuid = result._uid;
   return result;
-}
-
-//
-// Generator functions for template strings:
-//
-function $randomNumber(min, max) {
-  return _.random(min, max);
-}
-
-function $randomString(length) {
-  return Math.random().toString(36).substr(2, length);
 }

--- a/core/lib/template-strings.js
+++ b/core/lib/template-strings.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const uuid = require('uuid');
+const _ = require('lodash');
+
+function $randomNumber(min, max) {
+  return _.random(min, max);
+}
+
+function $randomString(length) {
+  return Math.random().toString(36).substr(2, length);
+}
+
+function $uuid() {
+  return uuid.v4();
+}
+
+function $dateNow() {
+  return Date.now();
+}
+
+module.exports = {
+  $randomNumber,
+  $randomString,
+  $uuid,
+  $dateNow
+};

--- a/test/core/scripts/express_socketio.json
+++ b/test/core/scripts/express_socketio.json
@@ -39,6 +39,8 @@
         {"think": 1},
         {"emit": { "channel": "echo", "data": "random number: {{ $randomNumber(1, 20) }}" }},
         {"emit": { "channel": "echo", "data": "random string: {{ $randomString(10) }}" }},
+        {"emit": { "channel": "echo", "data": "random uuid: {{ $uuid() }}" }},
+        {"emit": { "channel": "echo", "data": "date now: {{ $dateNow() }}" }},
         {"post": { "url": "/test-post?param1=value1&param2={{ $randomNumber(1, 20) }}" }},
         {"post": { "url": "/test-post?param1=value1&param2={{ $randomString(10) }}" }},
         {"think": 1}

--- a/test/core/scripts/hello_socketio.json
+++ b/test/core/scripts/hello_socketio.json
@@ -22,6 +22,8 @@
         {"think": 1},
         {"emit": { "channel": "echo", "data": "random number: {{ $randomNumber(1, 20) }}" }},
         {"emit": { "channel": "echo", "data": {"key": "{{ $randomString(10) }}"}, "response": { "channel": "echoed", "capture": {"json": "$.key", "as": "rand" } }}},
+        {"emit": { "channel": "echo", "data": "random uuid: {{ $uuid() }}" }},
+        {"emit": { "channel": "echo", "data": "date now: {{ $dateNow() }}" }},
         {"think": 1},
         {"emit": { "channel": "echo", "data": {"key": "{{ rand }}"}, "response": { "channel": "echoed", "match": {"json": "$.key", "value": "{{ rand }}" } }}},
         {"think": 1},


### PR DESCRIPTION
This feature enables dynamically adding functions to the contextFuncs object in core/lib/runner, which are functions that the Runner knows how to execute if they are called in the Artillery script. Currently, the only functions there are $randomString and $randomNumber, which might not be enough for some tests. We, for example, needed to randomly generate uuid and dates, and therefore needed new functions that support this. By having this feature, we could easily add these functions (and more if needed) to our test.

An example of usage can be seen in the test provided.