### PR TITLE
Fix to start csv-parse from_line parameter from 1.

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -249,7 +249,7 @@ function readPayload(script, callback) {
       let csvOpts = {
         skip_empty_lines: typeof payloadSpec.skipEmptyLines === 'undefined' ? true : payloadSpec.skipEmptyLines,
         cast: typeof payloadSpec.cast === 'undefined' ? true : payloadSpec.cast,
-        from_line: typeof payloadSpec.skipHeader === true ? 1 : 0,
+        from_line: typeof payloadSpec.skipHeader === true ? 2 : 1,
         delimiter: payloadSpec.delimiter || ','
       };
       // Defaults may still be overridden:


### PR DESCRIPTION
CSV parsing was breaking with version 4.3.0 of csv-parse, which introduced some validation refinements. Changing the from_line parameter to 1 when not skipping headers, and 2 when skipping headers fixes the problem. Fixes #622 