### PR TITLE
feat: Run a before test flow

### DIFF
--- a/core/lib/schemas/artillery_test_script.json
+++ b/core/lib/schemas/artillery_test_script.json
@@ -31,6 +31,18 @@
         }
       }
     },
+    "before": {
+      "type": "object",
+      "properties": {
+        "flow": {
+          "type": "array",
+          "items": {
+            "type": "object"            
+          }
+        }
+      },
+      "required": ["flow"]
+    },
     "scenarios": {
       "type": "array"
     }

--- a/test/core/scripts/before_test.json
+++ b/test/core/scripts/before_test.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 1 }
+      ]
+  },
+  "before": {
+    "flow": [
+      {"post":
+        {
+          "url": "/pets",
+          "json": {"name": "MickeyTheDog", "species": "Dog"},
+          "capture": {
+            "json": "$.id",
+            "as": "petId"
+          }
+        }
+      }
+    ]
+  },
+  "scenarios": [
+    {
+      "name": "Get the same pet in every scenario, as the pet was created once before the test started. ",
+      "flow": [
+        {"get": {
+          "url": "/pets/{{ petId }}",
+          "match": {"json": "$.name", "value": "MickeyTheDog"}
+        }}
+      ]
+    }
+  ]
+}

--- a/test/core/test_capture.js
+++ b/test/core/test_capture.js
@@ -60,6 +60,27 @@ test('Capture - JSON', (t) => {
   });
 });
 
+test('Capture before test - JSON', (t) => {
+  const fn = path.resolve(__dirname, './scripts/before_test.json');
+  const script = require(fn);
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      let c200 = report.codes[200];
+      let expectedAmountRequests = script.config.phases[0].duration * script.config.phases[0].arrivalRate;
+      t.assert(c200 === expectedAmountRequests,
+        'There should be ' + expectedAmountRequests + ' responses with status code 200');
+      t.assert(report.matches === expectedAmountRequests, 'All responses match expectation value');
+
+      let c201 = report.codes[201];
+      t.assert(c201 === undefined, 'There should be no 201 response codes');
+
+      t.end();
+    });
+
+    ee.run();
+  });
+});
+
 test('Capture - XML', (t) => {
   if (!xmlCapture) {
     console.log('artillery-xml-capture does not seem to be installed, skipping XML capture test.');


### PR DESCRIPTION
Adds a "Before" section to the artillery test schema. This feature enables configuring a flow which will run once before the test and capture variables into the context that can be used in later scenarios in the test.

This is a very useful feature as it allows the user to easily add a before requests flow using the syntax of artillery, without having to load external JS files.

A relevant use-case that this feature can solve: https://github.com/artilleryio/artillery/issues/629