### PR TITLE
 fix: Remove faulty "typeof"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@
 
 ---
 
-- **Source**: [https://github.com/shoreditch-ops/artillery](https://github.com/shoreditch-ops/artillery)
-- **Issues**: [https://github.com/shoreditch-ops/artillery/issues](https://github.com/shoreditch-ops/artillery/issues)
-- **Chat**: [https://gitter.im/shoreditch-ops/artillery](https://gitter.im/shoreditch-ops/artillery)
+- **Source**: [https://github.com/artilleryio/artillery](https://github.com/artilleryio/artillery)
+- **Issues**: [https://github.com/artilleryio/artillery/issues](https://github.com/artilleryio/artillery/issues)
+- **Chat**: [https://gitter.im/shoreditch-ops/artillery](https://gitter.im/artilleryio/artillery)
 - **Docs**: [https://artillery.io/docs/](https://artillery.io/docs/)
 - **Website**: [https://artillery.io](https://artillery.io)
-- **Twitter**: [@ShoreditchOps](https://twitter.com/shoreditchops)
+- **Twitter**: [@artilleryio](https://twitter.com/artilleryio)
 
 ---
 
 - **Enterprise**: Use [Artillery Pro](https://artillery.io/pro/) to run large-scale distributed tests from your own AWS account, integrate with CI/CD easily, test SOAP services, extra authentication methods (SSL client auth, NTLM).
 - For training, custom integrations, and performance consulting services see our [professional services page](https://artillery.io/services-support.html).
 
-[![Build Status](https://travis-ci.org/shoreditch-ops/artillery.svg?branch=master)](https://travis-ci.org/shoreditch-ops/artillery) [![gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/shoreditch-ops/artillery)
+[![Build Status](https://travis-ci.org/artilleryio/artillery.svg?branch=master)](https://travis-ci.org/artilleryio/artillery) [![CircleCI](https://circleci.com/gh/artilleryio/artillery.svg?style=svg)](https://circleci.com/gh/artilleryio/artillery)
 
 # Use Cases
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -249,7 +249,7 @@ function readPayload(script, callback) {
       let csvOpts = {
         skip_empty_lines: typeof payloadSpec.skipEmptyLines === 'undefined' ? true : payloadSpec.skipEmptyLines,
         cast: typeof payloadSpec.cast === 'undefined' ? true : payloadSpec.cast,
-        from_line: typeof payloadSpec.skipHeader === true ? 2 : 1,
+        from_line: payloadSpec.skipHeader === true ? 2 : 1,
         delimiter: payloadSpec.delimiter || ','
       };
       // Defaults may still be overridden:


### PR DESCRIPTION
```js
from_line: typeof payloadSpec.skipHeader === true ? 2 : 1
```
The above always evaluates to `1`, as `typeof payloadSpec.skipHeader` is `boolean`, which doesn't `=== true`.