### PR TITLE
feat: Add headers to quick

### DIFF
--- a/lib/commands/quick.js
+++ b/lib/commands/quick.js
@@ -29,7 +29,8 @@ module.exports.getConfig = function(callback) {
       ['-o, --output <path>', 'Set file to write stats to (will output ' +
         'to stdout by default)'],
       ['-k, --insecure', 'Allow insecure TLS connections, e.g. with a self-signed cert'],
-      ['-q, --quiet', 'Do not print anything to stdout']
+      ['-q, --quiet', 'Do not print anything to stdout'],
+      ['--headers <string>', 'Able to pass in arbitrary headers as a json string']
     ]
   };
 
@@ -44,6 +45,7 @@ function quick(url, options) {
   var rate = options.r || options.rate;
   var duration = options.d || options.duration;
   var arrivalCount = options.c || options.count;
+  var headers = options.headers
 
   let script = {
     config: {
@@ -122,6 +124,11 @@ function quick(url, options) {
   script.scenarios[0].flow.push(requestSpec);
   if (p.protocol.match(/ws/)) {
     script.scenarios[0].engine = 'ws';
+  }
+
+  if (headers) {
+    var headerObj = JSON.parse(headers)
+    script.config.defaults = {headers: headerObj}
   }
 
   let tmpf = tmp.fileSync();


### PR DESCRIPTION
I've added a `--headers` option to the `artillery quick` command.

Sorry I've not added tests; that batch file stuff is a little beyond me.  I have manually tested this with an authorisation token, and it seems to work fine.