### PR TITLE
fix(http): Return an error early if URL is not valid

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -342,6 +342,12 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           requestParams.agent = context._httpAgent;
         }
 
+        if (!requestParams.url.startsWith('http')) {
+          let err = new Error(`Invalid URL - ${requestParams.url}`);
+          ee.emit('error', err.message);
+          return callback(err, context);
+        }
+
         function requestCallback(err, res, body) {
           if (err) {
             return;


### PR DESCRIPTION
Fixes #512

The solution runs a simple sanity check on the URL after all templating has been done and custom functions that may re-write the URL have been run. See the bug report for reasons why this specific error isn't caught by existing error-handling code.

Always passing the callback to `request.js` which is another possible solution has the drawback of `request.js` loading the entire response into memory (to provide as an argument to the callback function), which is problematic with many concurrent requests which return large response payloads.