### PR TITLE
core, lib: Expose ee, and allow IPC from worker processes

### DIFF
--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -263,7 +263,7 @@ function run(script, ee, options, runState) {
     if (runState.pendingScenarios >= spec.maxVusers) {
       intermediate.avoidedScenario();
     } else {
-      runScenario(script, intermediate, runState);
+      runScenario(script, intermediate, runState, ee);
     }
   });
   phaser.on('phaseStarted', function(spec) {
@@ -311,7 +311,7 @@ function run(script, ee, options, runState) {
   phaser.run();
 }
 
-function runScenario(script, intermediate, runState) {
+function runScenario(script, intermediate, runState, ee) {
   const start = process.hrtime();
 
   //
@@ -373,7 +373,10 @@ function runScenario(script, intermediate, runState) {
 
       runState.pendingRequests--;
     });
-
+    runState.scenarioEvents.on('custom', function(payload) {
+      // Bubble up custom events from a scenario's processor function(s)
+      ee.emit('custom', payload);
+    })
     runState.compiledScenarios = _.map(
         script.scenarios,
         function(scenarioSpec) {

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -69,7 +69,7 @@ module.exports.getConfig = function(callback) {
   }
 };
 
-function run(scriptPath, options) {
+function run(scriptPath, options, callback) {
   debug('defaultOptions: ', JSON.stringify(defaultOptions, null, 4));
 
   async.waterfall(
@@ -103,6 +103,12 @@ function run(scriptPath, options) {
         scriptPath: scriptPath,
         plugins: defaultOptions.plugins || []
       });
+
+      if (callback) {
+        // Expose the runner for things like runner.events
+        callback(runner)
+      }
+
       let intermediates = [];
 
       // This is where the default console output is produced:

--- a/lib/runner-sp.js
+++ b/lib/runner-sp.js
@@ -73,6 +73,10 @@ Runner.prototype.run = function() {
       self.events.emit('done', Stats.combine(self._allIntermediates));
     });
 
+    runner.on('custom', (payload) => {
+      self.events.emit('custom', payload);
+    })
+
     runner.run();
 
     const MELTING_POINT = process.env.ARTILLERY_CPU_THRESHOLD || 90;

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -243,6 +243,10 @@ Runner.prototype._onWorkerMessage = function _onWorkerMessage(message) {
       this.events.emit('done', stats.combine(this._allIntermediates));
     }
   }
+
+  if (message.event === 'custom') {
+    this.events.emit('custom', message.payload);
+  }
 };
 
 Runner.prototype._activeWorkerCount = function _activeWorkerCount() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -90,6 +90,7 @@ function run(opts) {
     runner.on('phaseCompleted', onPhaseCompleted);
     runner.on('stats', onStats);
     runner.on('done', onDone);
+    runner.on('custom', onCustom);
 
     runner.run();
   }).catch(function(err) {
@@ -110,6 +111,10 @@ function run(opts) {
 
   function onDone(report) {
     send({ event: 'done', report: report });
+  }
+
+  function onCustom(payload) {
+    send({ event: 'custom', payload: payload });
   }
 }
 


### PR DESCRIPTION
The hooks in the http engine were very useful, but they didn't provide outbound
communication to the parent process.  Users should be able to have the master
process handle things like file handles and external services such as rabbitmq.
By allowing `processor` functions to emit a 'custom' event to the master proc,
this can be bubbled up to the caller an allow extensibility such that the caller
can interface with other systems and tap into `.on('done')` to do things like
graceful shutdown, or even firing off other scenarios.