### PR TITLE
Ramp Phase hangs when parameters are strings (for example env vars)

### DIFF
--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -84,7 +84,7 @@ function createPause(spec, ee) {
 
 function createRamp(spec, ee) {
   const tick = 1000 / Math.max(spec.arrivalRate, spec.rampTo); // smallest tick
-  const r0 = spec.arrivalRate; // initial arrival rate
+  const r0 = parseInt(spec.arrivalRate); // initial arrival rate
   const difference = spec.rampTo - spec.arrivalRate;
   const offset = difference < 0 ? -1 : 1;
   const periods = Math.abs(difference) + 1;

--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -84,7 +84,7 @@ function createPause(spec, ee) {
 
 function createRamp(spec, ee) {
   const tick = 1000 / Math.max(spec.arrivalRate, spec.rampTo); // smallest tick
-  const r0 = parseInt(spec.arrivalRate); // initial arrival rate
+  const r0 = parseInt(spec.arrivalRate, 10); // initial arrival rate
   const difference = spec.rampTo - spec.arrivalRate;
   const offset = difference < 0 ? -1 : 1;
   const periods = Math.abs(difference) + 1;


### PR DESCRIPTION
If the arrival rate is a string, the offset gets concatenated to it instead of being summed. Therefore, the rate never reaches the rampTo value.