### PR TITLE
Response codes and errors graph correction in report

### DIFF
--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -348,21 +348,27 @@ var chartData = l.map(
 //
 
 if (l.size(Report.aggregate.codes) > 0) {
-  var codesData = l.foldl(Report.intermediate, function(acc, o, i) {
-    var res = {};
-    res.timestamp = i*10+10;
-    l.each(o.codes, function(count, code) {
-      res[code] = count;
-    });
-    acc.push(res);
-    return acc;
-  }, []);
-  var uniqueCodes = l.foldl(Report.intermediate, function(acc, o) {
-    l.each(o.codes, function(count, code) {
+  var uniqueCodes = l.foldl(Report.intermediate, function (acc, o) {
+    l.each(o.codes, function (count, code) {
       if (l.indexOf(acc, code) === -1) {
         acc.push(code);
       }
     });
+    return acc;
+  }, []);
+
+  var codesData = l.foldl(Report.intermediate, function (acc, o, i) {
+    var res = {};
+    res.timestamp = i * 10 + 10;
+    for (var code of uniqueCodes) {
+      if (o.codes[code] === undefined) {
+        o.codes[code] = 0;
+      }
+    }
+    l.each(o.codes, function (count, code) {
+      res[code] = count;
+    });
+    acc.push(res);
     return acc;
   }, []);
 
@@ -389,21 +395,27 @@ if (l.size(Report.aggregate.codes) > 0) {
 //
 
 if (l.size(Report.aggregate.errors) > 0) {
-  var errorData = l.foldl(Report.intermediate, function(acc, o, i) {
-    var res = {};
-    res.timestamp = i*10+10;
-    l.each(o.errors, function(count, name) {
-      res[name] = count;
-    });
-    acc.push(res);
-    return acc;
-  }, []);
-  var uniqueErrors = l.foldl(Report.intermediate, function(acc, o) {
-    l.each(o.errors, function(count, name) {
+  var uniqueErrors = l.foldl(Report.intermediate, function (acc, o) {
+    l.each(o.errors, function (count, name) {
       if (l.indexOf(acc, name) === -1) {
         acc.push(name);
       }
     });
+    return acc;
+  }, []);
+
+  var errorData = l.foldl(Report.intermediate, function (acc, o, i) {
+    var res = {};
+    res.timestamp = i * 10 + 10;
+    for (var error of uniqueErrors) {
+      if (o.errors[error] === undefined) {
+        o.errors[error] = 0;
+      }
+    }
+    l.each(o.errors, function (count, name) {
+      res[name] = count;
+    });
+    acc.push(res);
     return acc;
   }, []);
 


### PR DESCRIPTION
Response Codes and Errors graphs are being interpolated wrongly because there were missing 0 values. This PR is adding zeros to the places with missing values in these graphs. I had to fix it in the report manually, so I thought it would be nice to contribute to here.

This is what it looked like before fix:
![Screenshot from 2019-09-12 08-38-28](https://user-images.githubusercontent.com/8911091/64760633-789ec000-d53a-11e9-926e-b45880ffed47.png)