### PR TITLE
Feature/v1.6.x support case sensitive headers

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -308,7 +308,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         // Assign default headers then overwrite as needed
         let defaultHeaders;
         let combinedHeaders;
-        if(self.caseSensitive) {
+        if(config.caseSensitive) {
           defaultHeaders = (config.defaults && config.defaults.headers) ?
               config.defaults.headers : 
               {'user-agent': USER_AGENT};


### PR DESCRIPTION
Allows for case sensitive headers, so long as config has below:
`caseSensitive: true`

If the above is not configured, default will be set to false, and prior functionality will persist