### PR TITLE
feat(http): allow non-strict captures

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -55,7 +55,10 @@ function isAcknowledgeRequired(spec) {
 function processResponse(ee, data, response, context, callback) {
   // Do we have supplied data to validate?
   if (response.data && !deepEqual(data, response.data)) {
+    debug('data is not valid:');
     debug(data);
+    debug(response);
+
     let err = 'data is not valid';
     ee.emit('error', err);
     return callback(err, context);
@@ -78,31 +81,33 @@ function processResponse(ee, data, response, context, callback) {
       return callback(err, context);
     }
 
-    // Do we have any failed matches?
-    let failedMatches = _.filter(result.matches, (v, k) => {
-      return !v.success;
-    });
-
-    // How to handle failed matches?
-    if (failedMatches.length > 0) {
-      debug(failedMatches);
-      // TODO: Should log the details of the match somewhere
-      ee.emit('error', 'Failed match');
-      return callback(new Error('Failed match'), context);
-    } else {
-      // Emit match events...
-      // _.each(result.matches, function(v, k) {
-      //   ee.emit('match', v.success, {
-      //     expected: v.expected,
-      //     got: v.got,
-      //     expression: v.expression
-      //   });
-      // });
-
-      // Populate the context with captured values
-      _.each(result.captures, function(v, k) {
-        context.vars[k] = v;
+    if (result !== null) {
+      // Do we have any failed matches?
+      let failedMatches = _.filter(result.matches, (v, k) => {
+        return !v.success;
       });
+
+      // How to handle failed matches?
+      if (failedMatches.length > 0) {
+        debug(failedMatches);
+        // TODO: Should log the details of the match somewhere
+        ee.emit('error', 'Failed match');
+        return callback(new Error('Failed match'), context);
+      } else {
+        // Emit match events...
+        // _.each(result.matches, function(v, k) {
+        //   ee.emit('match', v.success, {
+        //     expected: v.expected,
+        //     got: v.got,
+        //     expression: v.expression
+        //   });
+        // });
+
+        // Populate the context with captured values
+        _.each(result.captures, function(v, k) {
+          context.vars[k] = v.value;
+        });
+      }
 
       // Replace the base object context
       // Question: Should this be JSON object or String?

--- a/test/core/scripts/captures.json
+++ b/test/core/scripts/captures.json
@@ -28,7 +28,8 @@
             }, {
               "json": "$.doesnotexist",
               "transform": "this.doesnotexist.toUpperCase()",
-              "as": "doesnotexist"
+              "as": "doesnotexist",
+              "strict": false
             }, {
               "regexp": ".+",
               "as": "id2"

--- a/test/core/scripts/captures3.json
+++ b/test/core/scripts/captures3.json
@@ -2,7 +2,7 @@
   "config": {
       "target": "http://127.0.0.1:3003",
       "phases": [
-        { "duration": 10, "arrivalRate": 1 }
+        { "duration": 1, "arrivalRate": 1 }
       ],
       "payload": {
         "fields": ["species", "name"]
@@ -28,7 +28,8 @@
             }, {
               "json": "$.doesnotexist",
               "transform": "this.doesnotexist.toUpperCase()",
-              "as": "doesnotexist"
+              "as": "doesnotexist",
+              "strict": false
             }, {
               "regexp": ".+",
               "as": "id2"
@@ -38,7 +39,7 @@
         {"get": {
           "url": "/pets/{{ pet.id }}",
           "match": {"json": "$.name", "value": "{{ name }}"}
-        }}        
+        }}
       ]
     }
   ]


### PR DESCRIPTION
Allow the user to turn off the default strict-capture behavior,
which aborts the scenario if any of the capture actions fail.

Non-strict capture can be set by either:

- Setting config.defaults.strictCapture to false to make all
  captures non-strict
- Setting "strict" attribute on a capture action to false, to
  make that particular capture non-strict.

Fixes #812 