### PR TITLE
Allow scenarios to override socketio configs

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -28,6 +28,9 @@ function SocketIoEngine(script) {
 
 SocketIoEngine.prototype.createScenario = function(scenarioSpec, ee) {
   var self = this;
+  // Adds scenario overridden configuration into the static config
+  this.socketioOpts = {...this.socketioOpts, ...scenarioSpec.socketio}
+
   let tasks = _.map(scenarioSpec.flow, function(rs) {
     if (rs.think) {
       return engineUtil.createThink(rs, _.get(self.config, 'defaults.think', {}));


### PR DESCRIPTION
To the best of my knowledge, the current implementation doesn't allow us to use different config (ie.: query params) in each test connection. This can prevent certain use cases from being properly supported as commented here: https://spectrum.chat/artillery-io/general/how-to-add-dynamic-query-string-to-target-in-ws-engine~d86f0f53-506f-42ee-93de-b30aa2f01f09

With this PR, you could do the following:
``` yaml
config:  
  socketio:
    transports: ["websocket"]
...
scenarios:
  - name: Socket connection
    engine: socketio
    socketio:    
      query: "userId={{$randomString()}}" # each connection will have a different user id
    flow:
      - think: 3
```