### PR TITLE
feat(http): add support for forwarding proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "filtrex": "^0.5.4",
     "got": "^11.1.2",
     "hdr-histogram-js": "^1.1.4",
+    "hpagent": "^0.1.1",
     "js-yaml": "^3.13.1",
     "jsck": "^0.3.2",
     "jsonpath": "^1.0.2",

--- a/test/tinyproxy.conf
+++ b/test/tinyproxy.conf
@@ -1,0 +1,9 @@
+Port 10111
+Listen 127.0.0.1
+BindSame yes
+Timeout 600
+Allow 127.0.0.1
+StartServers 1
+MaxClients 10
+ConnectPort 8080
+ConnectPort 10111


### PR DESCRIPTION
Add support for using forwarding proxies via HTTP_PROXY and HTTPS_PROXY
environnment variables like Request.js [1]

1. https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables