### PR TITLE
feat: allow plugins to run code before Artillery exits

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -11,3 +11,42 @@ module.exports = {
   convert: require('./convert'),
   dino: require('./dino')
 };
+
+const version = require('../../package.json').version;
+
+const chalk = require('chalk');
+
+function createGlobalObject(opts) {
+  if (typeof global.artillery === 'object') {
+    return;
+  }
+
+  global.artillery = {
+    version: version,
+
+    metrics: {
+      event: async function(msg, opts) {
+        if (opts.level === 'error') {
+          console.log(chalk.red(msg));
+        } else {
+          console.log(msg);
+        }
+      }
+    },
+
+    util: {
+      template: require('../util').template
+    },
+
+    plugins: [],
+
+    extensionEvents: [],
+    ext: async function(event) {
+      // TODO: Validate events object
+      this.extensionEvents.push(event);
+    },
+    suggestedExitCode: 0
+  };
+}
+
+createGlobalObject();

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -88,7 +88,7 @@ function run(scriptPath, options) {
       checkIfXPathIsUsed,
       readPayload
     ],
-    function done(err, script) {
+    async function done(err, script) {
       if (err) {
         console.log(err.message);
         process.exit(1);
@@ -128,7 +128,7 @@ function run(scriptPath, options) {
         intermediates.push(report);
       });
 
-      runner.events.on('done', function(allStats) {
+      runner.events.on('done', async function(allStats) {
         let report = allStats.report();
 
         delete report.concurrency;
@@ -159,29 +159,9 @@ function run(scriptPath, options) {
           );
         }
 
-        if (script.config.ensure && typeof process.env.ARTILLERY_DISABLE_ENSURE === 'undefined') {
-          const latency = report.latency;
-          _.each(script.config.ensure, function(max, k) {
-            let bucket = k === 'p50' ? 'median' : k;
-            if (latency[bucket]) {
-              if (latency[bucket] > max) {
-                if (!options.quiet) {
-                  console.log(chalk.red(`ensure condition failed: ensure.${bucket} < ${max}`));
-                }
-                process.exit(1);
-              }
-            }
-          });
-
-          if (typeof script.config.ensure.maxErrorRate !== 'undefined') {
-            const failRate = Math.round((report.scenariosCreated - report.scenariosCompleted) / report.scenariosCreated * 100);
-
-            if (failRate > script.config.ensure.maxErrorRate) {
-              if (!options.quiet) {
-                console.log(chalk.red(`ensure condition failed: ensure.maxErrorRate <= ${script.config.ensure.maxErrorRate}`));
-              }
-              process.exit(1);
-            }
+        for (const e of global.artillery.extensionEvents) {
+          if (e.ext === 'beforeExit') {
+            await e.method({ report: report });
           }
         }
 
@@ -223,7 +203,7 @@ function run(scriptPath, options) {
             },
             function done() {
               debug('All done');
-              process.exit(0);
+              process.exit(global.artillery.suggestedExitCode);
             }
           );
         });

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -5,21 +5,5 @@
 'use strict';
 
 const core = require('../core');
-const version = require('../package.json').version;
-
-function createGlobalObject(opts) {
-  if (typeof global.artillery !== 'undefined') {
-    return;
-  }
-
-  global.artillery = {
-    version: version,
-    util: {
-      template: require('../util').template
-    }
-  };
-}
-
-createGlobalObject();
 
 module.exports = core;


### PR DESCRIPTION
- Add support for adding extension points via the global `artillery` object
- Add a `beforeExit` extension point to run code before Artillery exits
- Add a way to suggest Artillery's exit code from plugins
- Remove current `config.ensure` code (to be replaced by a plugin)