### PR TITLE
Fix: prevent sanitize form converting null/undefined to ''

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -644,6 +644,6 @@ function randomInt (low, high) {
 }
 
 function sanitiseValue (value) {
-  if (value === 0 || value === false) return value;
+  if (value === 0 || value === false || value === null || value === undefined) return value;
   return value ? value : '';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,6 +2913,11 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ=="
+    },
     "htmlparser2": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "good": "^8.1.1",
     "good-console": "^7.1.0",
     "hapi-auth-basic": "^5.0.0",
+    "hpagent": "0.1.1",
     "husky": "^4.2.5",
     "nock": "^11.8.2",
     "prettier": "^1.5.2",

--- a/test/core/unit/templates.test.js
+++ b/test/core/unit/templates.test.js
@@ -50,6 +50,8 @@ test.test('arrays can be substituted', function(t) {
 
   t.same(template(['{{name}}', [1, 2, '{{ count }}', {}, {'{{count}}': 3}]], { vars: { name: 'Hassy', count: 'three'} }),  [ 'Hassy', [1,2,'three', {}, {'three': 3}] ], '');
 
+  t.same(template(['{{ nullVar }}', '{{ undefinedVar }}'], { vars: { nullVar: null, undefinedVar: undefined } }), [ null, undefined ]);
+
   t.same(template(['hello {{name}}'], emptyContext),  ['hello undefined'], '');
 
   t.end();
@@ -78,6 +80,7 @@ test.test('buffers - huge buffers are OK', function(t) {
 test.test('objects can be substituted', function(t) {
   t.same(template({'{{ k1 }}': '{{ v1 }}', '{{ k2 }}': '{{ v2 }}', foo: null}, { vars: { k1: 'name', v1: 'Hassy', k2: 'nickname', v2: 'Has'} }),  {name: 'Hassy', nickname: 'Has', foo: null}, '');
   t.same(template({'{{ k1 }}': '{{ v1 }}', '{{ k2 }}': 'hello {{ v2 }}'}, { vars: { k1: 'name', v1: 'Hassy', k2: 'nickname'} }),  {name: 'Hassy', nickname: 'hello undefined'}, '');
+  t.same(template({'{{ k1 }}': '{{ v1 }}', '{{ k2 }}': '{{ v2 }}'}, { vars: { k1: 'k1', v1: null, k2: 'k2', v2: undefined } }), { k1: null, k2: undefined });
   t.end();
 });
 

--- a/test/core/unit/templates.test.js
+++ b/test/core/unit/templates.test.js
@@ -10,7 +10,6 @@ var template = require('../../../core/lib/engine_util').template;
 const { contextFuncs } = require('../../../core/lib/runner');
 
 var bigObject = require('./large-json-payload-7.2mb.json');
-var mediumObject = require('./large-json-payload-669kb.json');
 
 // TODO:
 // variables that aren't defined
@@ -42,13 +41,6 @@ test('strings - huge strings are OK', function(t) {
 });
 
 test.test('arrays can be substituted', function(t) {
-
-  // console.log(
-  //   template(
-  //     [1, {'{{k}}': '{{v}}'}],
-  //     {vars: {k: 'foo', v: 'bar' }})
-  // );
-
   t.same(
     [1, {'foo': 'bar'}, null, { foo: null }],
     template(

--- a/test/core/unit/util.test.js
+++ b/test/core/unit/util.test.js
@@ -115,8 +115,8 @@ test('rendering variables', function(t) {
   );
 
   t.assert(
-    render('{{favoriteThings.dayOfTheWeek}}', vars) === '',
-    'Non-existent property lookup returns an empty string'
+    render('{{favoriteThings.dayOfTheWeek}}', vars) === undefined,
+    'Non-existent property lookup returns undefined'
   );
 
   t.assert(


### PR DESCRIPTION
# Context:

See #904 
This PR fixes #904

# What

- the first two commits clean existing tests (remove dead code and add missing dep, that was creating warnings)
- then I have a test commit
- then the fix

# Contributing

- ✅ I read contributing.md
- ✅ Commit should respect given convention 
- ✅ I make the PR small (but if you want the first two commits 4acd507 and 624abad, which are fix / clean of the actual tests before any work, I can split the PR)
- ✅ I did some test
- ✅ I opened an issue, as requested