### PR TITLE
feat: cast string-valued phase configs

### DIFF
--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -19,6 +19,13 @@ function phaser(phaseSpecs) {
   let ee = new EventEmitter();
 
   let tasks = _.map(phaseSpecs, function(spec, i) {
+    // Cast defined but non-number (eg: from ENV) values
+    ['arrivalRate', 'arrivalCount', 'pause', 'rampTo', 'duration'].forEach(function(k) {
+      if (!isUndefined(spec[k]) && typeof spec[k] !== 'number') {
+        spec[k] = _.toNumber(spec[k]);
+      }
+    });
+
     if (isUndefined(spec.index)) {
       spec.index = i;
     }

--- a/test/core/unit/phases.test.js
+++ b/test/core/unit/phases.test.js
@@ -119,6 +119,14 @@ test('rampDown', function(t) {
   });
 });
 
+test.only('ramp with string inputs', function(t) {
+  testRamp(t, {
+    duration: "15",
+    arrivalRate: "20",
+    rampTo: "1.0"
+  });
+});
+
 function testRamp(t, phaseSpec) {
   let phaser = createPhaser([phaseSpec]);
 
@@ -132,7 +140,7 @@ function testRamp(t, phaseSpec) {
   }
   expected = Math.floor(expected);
 
-  t.plan(5);
+  t.plan(6);
 
   let startedAt;
   let phaseStartedTimestamp;
@@ -142,6 +150,11 @@ function testRamp(t, phaseSpec) {
     t.assert(
       _.isEqual(spec, phaseSpec),
       'phaseStarted event emitted with correct spec');
+    t.assert(
+      _.filter(['arrivalRate', 'arrivalCount', 'pause', 'rampTo', 'duration'], function(k) {
+        return !_.isUndefined(spec[k]) && typeof spec[k] != 'number'
+      }).length === 0,
+      'spec integer keys are correctly typed');
   });
   phaser.on('phaseCompleted', function(spec) {
     t.assert(

--- a/test/core/unit/phases.test.js
+++ b/test/core/unit/phases.test.js
@@ -154,7 +154,7 @@ function testRamp(t, phaseSpec) {
       _.filter(['arrivalRate', 'arrivalCount', 'pause', 'rampTo', 'duration'], function(k) {
         return !_.isUndefined(spec[k]) && typeof spec[k] != 'number'
       }).length === 0,
-      'spec integer keys are correctly typed');
+      'spec numeric values are correctly typed');
   });
   phaser.on('phaseCompleted', function(spec) {
     t.assert(


### PR DESCRIPTION
Allows for (eg: ENV-based) phase configuration values which are strings
by checking their definedness and casting them to numbers as necessary.
Previously, implementation was breaking under some (eg: rampTo) string
value configs. Addresses GH #977 