### PR TITLE
Update Dockerfile to use Node.js 12 and some cleanup to help build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,12 @@
-node_modules
-test
+# Exclude everything by default.
+*
+
+# Explicitly include only the necessary files we want in the Docker image.
+!bin
+!core
+!lib
+!LICENSE.txt
+!README.md
+!console-reporter.js
+!util.js
+!package*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
-FROM node:10-alpine
+FROM node:12-alpine
 LABEL maintainer="team@artillery.io"
 
 WORKDIR /home/node/artillery
 
-COPY bin bin
-COPY core core
-COPY lib lib
-COPY LICENSE.txt LICENSE.txt
-COPY README.md README.md
-COPY console-reporter.js console-reporter.js
-COPY util.js util.js
-COPY package.json package.json
-
+COPY package*.json ./
 RUN npm --ignore-scripts --production install
+
+COPY . ./
 
 ENTRYPOINT ["/home/node/artillery/bin/artillery"]


### PR DESCRIPTION
This pull request contains a few updates to the Dockerfile for Artillery:
- The base image has been updated to `node:12-alpine`, since Artillery now requires Node.js 12 and above.
- The `.dockerignore` file has been modified to exclude all files except the ones needed for the Artillery CLI to work inside the Docker image. This helps keep the built image as slim as possible and avoids accidentally copying unnecessary files over when they're added in the future.
- The build process was slightly modified to first copy the `package.json` and `package-lock.json` files into the image, then install dependencies. This will help speed up the build process by avoiding running `npm install` if the dependencies haven't changed.