### PR TITLE
Update CI scripts for building Docker image and publishing NPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm run commitlint-last-commit
       - run: npm test
 
-  maybe_npm_publish:
+  npm_publish:
     working_directory: ~/repo
     docker:
       - image: circleci/node:12
@@ -43,7 +43,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
       - run: bash .circleci/npm-publish.sh
 
-  maybe_build_docker_image:
+  build_docker_image:
     working_directory: ~/repo
     docker:
       - image: docker:18
@@ -51,14 +51,21 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: sh .circleci/docker-build.sh
+
 workflows:
   version: 2
   test:
     jobs:
       - run_tests
-      - maybe_build_docker_image:
+      - build_docker_image:
           requires:
             - run_tests
-      - maybe_npm_publish:
+          filters:
+            tags:
+              only: /^v.*/
+      - npm_publish:
           requires:
             - run_tests
+          filters:
+            tags:
+              only: /^v.*/

--- a/.circleci/docker-build.sh
+++ b/.circleci/docker-build.sh
@@ -7,17 +7,19 @@ if [ -z ${CIRCLE_TAG:-""} ] ; then
     exit 0
 fi
 
-echo "Building Docker image for tag $CIRCLE_TAG"
+DOCKER_TAG=${CIRCLE_TAG#v}
 
-docker build -t artilleryio/artillery:$CIRCLE_TAG .
+echo "Building Docker image for tag $DOCKER_TAG"
 
-docker run --rm -it artilleryio/artillery:$CIRCLE_TAG dino
+docker build -t artilleryio/artillery:$DOCKER_TAG .
+
+docker run --rm -it artilleryio/artillery:$DOCKER_TAG dino
 
 echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
 
 # If the tagged release is not a dev release, tag it as the latest.
-if [[ ${CIRCLE_TAG} != *"-dev"* ]] ; then
-    docker tag artilleryio/artillery:$CIRCLE_TAG artilleryio/artillery:latest
+if [[ ${DOCKER_TAG} != *"-dev"* ]] ; then
+    docker tag artilleryio/artillery:$DOCKER_TAG artilleryio/artillery:latest
 fi
 
 docker push artilleryio/artillery --all-tags

--- a/.circleci/docker-build.sh
+++ b/.circleci/docker-build.sh
@@ -2,20 +2,17 @@
 
 set -eu -o pipefail
 
-if [ -z ${CIRCLE_TAG:-""} ] ; then
-    exit 0
-fi
-
-if [ $CIRCLE_BRANCH != "master" ] ; then
-    exit 0
-fi
-
-echo "Building Docker image for tag $CIRCLE_TAG on $CIRCLE_BRANCH"
+echo "Building Docker image for tag $CIRCLE_TAG"
 
 docker build -t artilleryio/artillery:$CIRCLE_TAG .
 
-docker run --rm -it artilleryio/artillery:$CIRCLE_TAG quick -d 20 -c 10 -n 20 https://artillery.io/
+docker run --rm -it artilleryio/artillery:$CIRCLE_TAG dino
 
 echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
 
-docker push artilleryio/artillery:$CIRCLE_TAG
+# If the tagged release is not a dev release, tag it as the latest.
+if [[ ${CIRCLE_TAG} != *"-dev"* ]] ; then
+    docker tag artilleryio/artillery:$CIRCLE_TAG artilleryio/artillery:latest
+fi
+
+docker push artilleryio/artillery --all-tags

--- a/.circleci/docker-build.sh
+++ b/.circleci/docker-build.sh
@@ -2,6 +2,11 @@
 
 set -eu -o pipefail
 
+if [ -z ${CIRCLE_TAG:-""} ] ; then
+    echo "No tag, not doing anything"
+    exit 0
+fi
+
 echo "Building Docker image for tag $CIRCLE_TAG"
 
 docker build -t artilleryio/artillery:$CIRCLE_TAG .

--- a/.circleci/npm-publish.sh
+++ b/.circleci/npm-publish.sh
@@ -2,16 +2,11 @@
 
 set -eu -o pipefail
 
-if [ -z ${CIRCLE_TAG:-""} ] ; then
-    echo "No tag, not doing anything"
-    exit 0
+echo "Publishing package on npm for $CIRCLE_TAG"
+
+if [[ ${CIRCLE_TAG} == *"-dev"* ]] ; then
+    npm publish --tag dev
+else
+    echo "npm publish"
+    npm publish
 fi
-
-if [ $CIRCLE_BRANCH != "master" ] ; then
-    echo "Not on main branch, not doing anything"
-    exit 0
-fi
-
-echo "Publishing package on npm for $CIRCLE_TAG on $CIRCLE_BRANCH"
-
-npm publish

--- a/.circleci/npm-publish.sh
+++ b/.circleci/npm-publish.sh
@@ -2,6 +2,11 @@
 
 set -eu -o pipefail
 
+if [ -z ${CIRCLE_TAG:-""} ] ; then
+    echo "No tag, not doing anything"
+    exit 0
+fi
+
 echo "Publishing package on npm for $CIRCLE_TAG"
 
 if [[ ${CIRCLE_TAG} == *"-dev"* ]] ; then


### PR DESCRIPTION
This pull request contains a few updates to the CI scripts to help automate the Docker build and NPM publishing workflows.

By default, CircleCI doesn't execute workflows for any pushed tags unless specified, so pushing any Git tags never triggered the CI process. It's now updated to trigger those workflows when any tag starting with `v`, which is the current naming convention for releases.

I also updated the Docker build and NPM publish scripts that get executed with these CI workflows:

- The conditional check for `CIRCLE_BRANCH` was removed, since tagged pushes won't have this information.
- The command to check that the Docker image is working properly was changed, since `artillery quick` doesn't seem to valid command anymore. It's now going to use the `artillery dino` command, just to make sure we're not getting a non-zero exit code.
- In the Docker build script, if the pushed tag does not contain `-dev` as part of the string, we're assuming it's a stable release, so the built Docker image will get tagged as `latest`.
- Push all images (tagged build + `latest` if tagged) to Docker Hub.
- In the NPM publish script, if the pushed tag contains `-dev` as part of the string, we're assuming it's a development release, so the package will get published with the `dev` dist-tag. Otherwise, publish the package as the latest release.
- The Docker build will get tagged with the version number only according to the tag (e.g. if `CIRCLE_TAG` is `v1.7.0`, the image will be built and tagged as `artilleryio/artillery:1.7.0`).

I'm assuming that the Docker Hub and NPM credentials are set correctly on CircleCI.