### PR TITLE
Split CircleCI into two separate workflows for tests and publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,15 +57,17 @@ workflows:
   test:
     jobs:
       - run_tests
+  publish:
+    jobs:
+      - run_tests:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - build_docker_image:
           requires:
             - run_tests
-          filters:
-            tags:
-              only: /^v.*/
       - npm_publish:
           requires:
             - run_tests
-          filters:
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
A few days ago I submitted an update to CircleCI to build and publish a Docker image and NPM package when a version is tagged (#997). However, I noticed this wasn't working as intended because I misunderstood how CircleCI runs different workflows.

This pull request fixes the issue by splitting up the CircleCI configuration into two separate workflows:

- When pushing any branch, it will run the `test` workflow, which will only run the test suite. CircleCI will run this workflow for all branches, and ignore all tags (which is CircleCI's default behavior).
- When pushing any tag starting with `v`, it will run the `publish` workflow. It will first run tests, and if they pass it will build and publish the Docker image for that version, and also publish the package on NPM. CircleCI will only run this for tags starting with `v`, and will not run when a branch is pushed (which needs to be explicitly specified in the configuration).