### PR TITLE
fix(template): retain keys with periods

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -258,7 +258,13 @@ function templateObjectOrArray(o, context) {
       newValue = template(value, context, true);
     }
 
-    L.set(o, newPath, newValue);
+    if (newPath.endsWith(key)) {
+      const keyIndex = newPath.indexOf(key);
+      const prefix = newPath.substr(0, keyIndex - 1);
+      L.set(o, `${prefix}["${key}"]`, newValue)
+    } else {
+      L.set(o, newPath, newValue);
+    }
   });
 }
 

--- a/test/core/unit/templates.test.js
+++ b/test/core/unit/templates.test.js
@@ -18,7 +18,7 @@ var mediumObject = require('./large-json-payload-669kb.json');
 
 var emptyContext = { vars: {} };
 
-test('strings - templating a plain string should return the same string', function(t) {
+test.test('strings - templating a plain string should return the same string', function(t) {
   t.assert(template('string', emptyContext) === 'string', '');
   t.assert(template('string {}', emptyContext) === 'string {}', '');
   t.end();
@@ -30,7 +30,7 @@ test.test('strings - variables can be substituted', function(t) {
   t.end();
 });
 
-test('strings - huge strings are OK', function(t) {
+test.test('strings - huge strings are OK', function(t) {
   const s1 = JSON.stringify(bigObject);
   const start = Date.now();
   const s2 = template(s1, { vars: {} });
@@ -123,6 +123,14 @@ test.test('template functions', (t) => {
   t.assert(
     template('{{ greeting}} {{ $randomString(5) }}! {{ foo }}', context).length === 16,
     'functions and variable substitutions may be mixed'
+  );
+
+  t.end();
+});
+
+test.test('keys with periods retain their structure', (t) => {
+  t.assert(
+    template({ 'hello.world': true }, {})['hello.world'] === true, 'keys with periods are preserved'
   );
 
   t.end();


### PR DESCRIPTION
Preserves a situation where we have keys that could contain periods in it.

For example, `{ "hello.world": 1 }` would be templated as `{ "hello": { "world": 1 } }`, which could cause problems. One scenario I've encountered is when this effect mangles the request body for a request that expects keys that contain periods.