### PR TITLE
test(template): add case for when the dotted key appears as actual path

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -259,7 +259,7 @@ function templateObjectOrArray(o, context) {
     }
 
     if (newPath.endsWith(key)) {
-      const keyIndex = newPath.indexOf(key);
+      const keyIndex = newPath.lastIndexOf(key);
       const prefix = newPath.substr(0, keyIndex - 1);
       L.set(o, `${prefix}["${key}"]`, newValue)
     } else {

--- a/test/core/unit/templates.test.js
+++ b/test/core/unit/templates.test.js
@@ -133,5 +133,10 @@ test.test('keys with periods retain their structure', (t) => {
     template({ 'hello.world': true }, {})['hello.world'] === true, 'keys with periods are preserved'
   );
 
+  const nestedTemplate = template({ hello: { world: { 'hello.world': true } } }, {});
+
+  t.assert(nestedTemplate.hello.world['hello.world'] === true && nestedTemplate['hello.world'] === undefined,
+    'the template only creates it at the end');
+
   t.end();
 });


### PR DESCRIPTION
Apologies for bringing in a PR so soon. This PR resolves an edge case when the path is something like `hello.world["hello.world"]`.

Beforehand, the template `{ hello: { world: { "hello.world": true } } }` would generate the object `{ hello: { world: { "hello.world": true } }, "hello.world": true }`. This fix ensures that the key isn't duplicated.