### PR TITLE
fix: set default to empty object

### DIFF
--- a/lib/console-reporter.js
+++ b/lib/console-reporter.js
@@ -164,6 +164,7 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
       return name;
     }
 
+    report.rates = report.rates || {}
     const coreRates = Object.keys(report.rates).filter(name => name.startsWith('core.'));
     const engineRates = Object.keys(report.rates).filter(name => name.startsWith('engine.'));
     const otherRates = Object.keys(report.rates).filter(name => coreRates.indexOf(name) === -1 && engineRates.indexOf(name) === -1);
@@ -175,9 +176,10 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
       });
     });
 
-    const coreCounters = Object.keys(report.counters).filter(name => name.startsWith('core.'));
-    const engineCounters = Object.keys(report.counters).filter(name => name.startsWith('engine.'));
-    const otherCounters = Object.keys(report.counters).filter(name => coreCounters.indexOf(name) === -1 && engineCounters.indexOf(name) === -1);
+    report.counters = report.counters || {}
+    const coreCounters = Object.keys(report.counters ).filter(name => name.startsWith('core.'));
+    const engineCounters = Object.keys(report.counters ).filter(name => name.startsWith('engine.'));
+    const otherCounters = Object.keys(report.counters ).filter(name => coreCounters.indexOf(name) === -1 && engineCounters.indexOf(name) === -1);
 
     [coreCounters, engineCounters, otherCounters].forEach((coll) => {
       coll.forEach(function(name) {
@@ -186,6 +188,7 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
       });
     });
 
+    report.summaries = report.summaries || {}
     const coreSummaries = Object.keys(report.summaries).filter(name => name.startsWith('core.'));
     const engineSummaries = Object.keys(report.summaries).filter(name => name.startsWith('engine.'));
     const otherSummaries = Object.keys(report.summaries).filter(name => coreSummaries.indexOf(name) === -1 && engineSummaries.indexOf(name) === -1);


### PR DESCRIPTION
This fixes #982 and further log errors from `report` empty object.