### PR TITLE
Fix #1027: Don't fail capture on false boolean values

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -342,7 +342,7 @@ function parseLoopCount(countSpec) {
 }
 
 function isCaptureFailed(v, defaultStrict) {
-  const noValue = ((!v.value || v.value === '') || typeof v.error !== 'undefined');
+  const noValue = ((typeof v.value === 'undefined' || v.value === '') || typeof v.error !== 'undefined');
 
   if (!noValue) {
     return false;


### PR DESCRIPTION
Closes #1027