### PR TITLE
Set path to Artillery when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ COPY package*.json ./
 RUN npm --ignore-scripts --production install
 
 COPY . ./
+ENV PATH="/home/node/artillery/bin:${PATH}"
 
 ENTRYPOINT ["/home/node/artillery/bin/artillery"]


### PR DESCRIPTION
This pull request updates the `Dockerfile` to update the `PATH` inside of the image when building the image and include the Artillery binary path.  This will allow for an easier way to access the binary when using the image directly, such as in a CI/CD environment.