### PR TITLE
#1065 Add ability to use hooks with socketio scenarios

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -31,6 +31,33 @@ SocketIoEngine.prototype.createScenario = function(scenarioSpec, ee) {
   // Adds scenario overridden configuration into the static config
   this.socketioOpts = {...this.socketioOpts, ...scenarioSpec.socketio}
 
+  ensurePropertyIsAList(scenarioSpec, 'beforeRequest');
+  ensurePropertyIsAList(scenarioSpec, 'afterResponse');
+  ensurePropertyIsAList(scenarioSpec, 'beforeScenario');
+  ensurePropertyIsAList(scenarioSpec, 'afterScenario');
+  ensurePropertyIsAList(scenarioSpec, 'onError');
+
+  // Add scenario-level hooks if needed:
+  // For now, just turn them into function steps and insert them
+  // directly into the flow array.
+  // TODO: Scenario-level hooks will probably want access to the
+  // entire scenario spec rather than just the userContext.
+  const beforeScenarioFns = _.map(
+    scenarioSpec.beforeScenario,
+    function(hookFunctionName) {
+      return {'function': hookFunctionName};
+    });
+  const afterScenarioFns = _.map(
+    scenarioSpec.afterScenario,
+    function(hookFunctionName) {
+      return {'function': hookFunctionName};
+    });
+
+  const newFlow = beforeScenarioFns.concat(
+    scenarioSpec.flow.concat(afterScenarioFns));
+
+  scenarioSpec.flow = newFlow;
+
   let tasks = _.map(scenarioSpec.flow, function(rs) {
     if (rs.think) {
       return engineUtil.createThink(rs, _.get(self.config, 'defaults.think', {}));


### PR DESCRIPTION
Being able to make use of hooks in socketio scenarios. Code stolen from the http engine and pasted here. I have tested locally and found that at least the `beforeScenario` hook is working just fine. 

Happy to add tests and refine if you're happy with conceptually doing this - but not a nodejs dev so lots to get up to speed with.