### PR TITLE
#1066 delay loading of context socket until it is actually used.

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -329,14 +329,8 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   function zero(callback, context) {
     context.__receivedMessageCount = 0;
     ee.emit('started');
-    self.loadContextSocket('', context, function done(err) {
-      if (err) {
-        ee.emit('error', err);
-        return callback(err, context);
-      }
 
-      return callback(null, context);
-    });
+    return callback(null, context);
   }
 
   return function scenario(initialContext, callback) {


### PR DESCRIPTION
This allows running of custom logic before the connection that might effect the connection options. i.e. see #1065 and related PR: #1067.

This has been tested locally on a simple scenario and does not appear to adversely effect running of socketio tests. The connection will be made eventually when needed.