### PR TITLE
fix: pass spec headers to beforeRequest processors

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -254,8 +254,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     requestParams = _.extend(requestParams, {
       url: maybePrependBase(params.url || params.uri, config), // *NOT* templating here
       method: method,
-      headers: {
-      },
       timeout: timeout * 1000,
     });
 


### PR DESCRIPTION
Steps to reproduce
1. yaml set headers and processor
2. beforeRequest function executed
3. first argument(requestParams) has headers

Actual result
- requestParams.headers is always empty

Expected result
- requestParams.headers include ones from yaml headers spec

Possible application
- ~pass csv payload to processor~ (this can be done with context)
  1. ~yaml load user ids from csv~
  2. ~yaml set headers with user id variable~
  3. ~beforeRequest processor gets dynamic user id and produce JWT~
  4. ~target application (requiring JWT auth) handle dynamic users~
- pass global default headers to processor

Description
- open issues seems not be to relative.
- git blame shows those lines were from quite old code. so I think that this might be an unexplored bug.
- after this modification, npm run test succeed.