### PR TITLE
Fixed typo in engine_util.js

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -371,7 +371,7 @@ function ensurePropertyIsAList(obj, prop) {
 
 function captureOrMatch(params, response, context, done) {
   if ((!params.capture || params.capture.length === 0) &&
-      (!params.match || params.match.lenth === 0)) {
+      (!params.match || params.match.length === 0)) {
     return done(null, null);
   }
 


### PR DESCRIPTION
Changed `params.match.lenth` to `params.match.length`