### PR TITLE
feat: allow running an after test flow

### DIFF
--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -516,10 +516,10 @@ function handleScriptHook(hook, script, engines, hookEvents, contextVars) {
   let ee = new EventEmitter();
   return new Promise(function(resolve, reject){
     ee.on('request', function() {
-      hookEvents.emit(`${hook}ScriptHookRequest`);
+      hookEvents.emit(`${hook}TestRequest`);
     });
     ee.on('error', function(error) {
-      hookEvents.emit(`${hook}ScriptHookError`, error);
+      hookEvents.emit(`${hook}TestError`, error);
     });
 
     let name = script[hook].engine || 'http';

--- a/core/lib/schemas/artillery_test_script.json
+++ b/core/lib/schemas/artillery_test_script.json
@@ -37,7 +37,19 @@
         "flow": {
           "type": "array",
           "items": {
-            "type": "object"            
+            "type": "object"
+          }
+        }
+      },
+      "required": ["flow"]
+    },
+    "after": {
+      "type": "object",
+      "properties": {
+        "flow": {
+          "type": "array",
+          "items": {
+            "type": "object"
           }
         }
       },

--- a/test/core/scripts/after_test.json
+++ b/test/core/scripts/after_test.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 1, "arrivalRate": 1 }
+      ]
+  },
+  "scenarios": [
+    {
+      "name": "Get the same pet in every scenario, as the pet was created once before the test started. ",
+      "flow": [
+        {"post":
+          {
+            "url": "/pets",
+            "json": {"name": "MickeyTheDog", "species": "Dog"},
+            "capture": {
+              "json": "$.id",
+              "as": "petId"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "after": {
+    "flow": [
+      {"get": {
+        "url": "/pets/{{ petId }}",
+        "match": {
+          "json": "$.name",
+          "value": "MickeyTheDog"
+        }
+      }}
+    ]
+  }
+}

--- a/test/core/test_capture.js
+++ b/test/core/test_capture.js
@@ -128,6 +128,30 @@ test('Capture before test - JSON', (t) => {
   });
 });
 
+test('Capture after test - JSON', (t) => {
+  const fn = path.resolve(__dirname, './scripts/after_test.json');
+  const script = require(fn);
+  runner(script).then(function(ee) {
+    ee.on('done', function(nr) {
+      const report = SSMS.legacyReport(nr).report();
+      let c200 = report.codes[200];
+      let expectedAmountRequests = script.config.phases[0].duration * script.config.phases[0].arrivalRate;
+      t.assert(c200 === expectedAmountRequests,
+        'There should be ' + expectedAmountRequests + ' responses with status code 200; got ' + c200);
+
+      let c201 = report.codes[201];
+      t.assert(c201 === undefined, 'There should be no 201 response codes');
+
+      ee.stop(() => {
+        t.end();
+      });
+
+    });
+
+    ee.run();
+  });
+});
+
 test('Capture - XML', (t) => {
   if (!xmlCapture) {
     console.log('artillery-xml-capture does not seem to be installed, skipping XML capture test.');


### PR DESCRIPTION
There is already a (seemingly undocumented) way to run a flow before the actual test scenarios using the "[before](https://github.com/artilleryio/artillery/issues/842#issuecomment-765496311)" hook, which was added in https://github.com/artilleryio/artillery/commit/37bbe3b9319bf60063db32dbed369f57dd8d102f.

This MR addresses a similar need that seems to be requested by others as well (see https://github.com/artilleryio/artillery/issues/842#issuecomment-803206740 and https://github.com/artilleryio/artillery/issues/751) by adding a way to run a flow after the test scenarios have finished running. This can, for example, be useful to clean up test-only related data,

