### PR TITLE
fix: pass scenario context vars

### DIFF
--- a/test/core/scripts/after_test.json
+++ b/test/core/scripts/after_test.json
@@ -1,18 +1,16 @@
 {
   "config": {
-      "target": "http://127.0.0.1:3003",
-      "phases": [
-        { "duration": 1, "arrivalRate": 1 }
-      ]
+    "target": "http://127.0.0.1:3003",
+    "phases": [{ "duration": 1, "arrivalRate": 1 }]
   },
   "scenarios": [
     {
-      "name": "Get the same pet in every scenario, as the pet was created once before the test started. ",
+      "name": "Create a new pet",
       "flow": [
-        {"post":
-          {
+        {
+          "post": {
             "url": "/pets",
-            "json": {"name": "MickeyTheDog", "species": "Dog"},
+            "json": { "name": "MickeyTheDog", "species": "Dog" },
             "capture": {
               "json": "$.id",
               "as": "petId"
@@ -24,13 +22,15 @@
   ],
   "after": {
     "flow": [
-      {"get": {
-        "url": "/pets/{{ petId }}",
-        "match": {
-          "json": "$.name",
-          "value": "MickeyTheDog"
+      {
+        "get": {
+          "url": "/pets/{{ petId }}",
+          "match": {
+            "json": "$.name",
+            "value": "MickeyTheDog"
+          }
         }
-      }}
+      }
     ]
   }
 }

--- a/test/core/test_capture.js
+++ b/test/core/test_capture.js
@@ -134,13 +134,10 @@ test('Capture after test - JSON', (t) => {
   runner(script).then(function(ee) {
     ee.on('done', function(nr) {
       const report = SSMS.legacyReport(nr).report();
-      let c200 = report.codes[200];
       let expectedAmountRequests = script.config.phases[0].duration * script.config.phases[0].arrivalRate;
-      t.assert(c200 === expectedAmountRequests,
-        'There should be ' + expectedAmountRequests + ' responses with status code 200; got ' + c200);
 
       let c201 = report.codes[201];
-      t.assert(c201 === undefined, 'There should be no 201 response codes');
+      t.assert(c201 === expectedAmountRequests, `There should be ${expectedAmountRequests} response with status code 201; got ${c201}`);
 
       ee.stop(() => {
         t.end();


### PR DESCRIPTION
this fixes a bug introduced by merging #1084 where the context vars from a scenario were not passed to the `after` hook, breaking the tests