### PR TITLE
fix(ci): add filters to publish workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ workflows:
   publish:
     jobs:
       - run_tests:
-          filters:
+          filters: &filters-publish
             branches:
               ignore: /.*/
             tags:
@@ -68,6 +68,10 @@ workflows:
       - build_docker_image:
           requires:
             - run_tests
+          filters:
+            <<: *filters-publish
       - npm_publish:
           requires:
             - run_tests
+          filters:
+            <<: *filters-publish


### PR DESCRIPTION
fixes the publish workflow by [explicitly adding](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag) filter tags to its jobs so it runs the required additional steps when a tag is pushed