### PR TITLE
feat(run): add solo mode

### DIFF
--- a/lib/cmds/run.js
+++ b/lib/cmds/run.js
@@ -189,7 +189,7 @@ RunCommand.flags = {
   }),
   quiet: flags.boolean({
     char: 'q',
-    description: 'Silent mode'
+    description: 'Quiet mode'
   }),
   overrides: flags.string({
     description: 'Dynamically override values in the test script; a JSON object'
@@ -197,10 +197,6 @@ RunCommand.flags = {
   variables: flags.string({
     char: 'v',
     description: 'Set variables available to vusers during the test; a JSON object'
-  }),
-  script: flags.string({
-    char: 's',
-    description: 'Path to test script to run'
   }),
   // TODO: Deprecation notices for commands below:
 
@@ -227,6 +223,10 @@ RunCommand.flags = {
     description: 'Input script file',
     multiple: true,
     hidden: true
+  }),
+  solo: flags.boolean({
+    char: 's',
+    description: 'Create only one virtual user',
   })
 };
 
@@ -249,6 +249,13 @@ async function prepareTestExecutionPlan(inputFiles, flags) {
 
   if (!script5.config.target) {
     throw new Error('No target specified and no environment chosen');
+  }
+
+  if (typeof script5.config.phases === 'undefined' || flags.solo) {
+    script5.config.phases = [{
+      duration: 1,
+      arrivalCount: 1
+    }];
   }
 
   script5.config.statsInterval = script5.config.statsInterval || 30;

--- a/lib/cmds/run.js
+++ b/lib/cmds/run.js
@@ -111,7 +111,9 @@ class RunCommand extends Command {
         gracefulShutdown();
       });
 
-      telemetry.capture('test run')
+      telemetry.capture('test run', {
+        solo: flags.solo
+      });
       runner.run();
 
 


### PR DESCRIPTION
This adds the ability to run a script in "solo" mode, i.e. run a script with just one virtual user.

This is handy for debugging and testing your test scripts, and also for running functional tests. At the moment, you have to include a separate environment definition, with a phase definition that creates exactly one user.

This also means that it's now possible to run just a scenario on its own (no `config` required), with something like:

```sh
artillery run --target http://my-api.acme-corp.dev --solo scenario1.yml
```