### PR TITLE
Websocket "connect" action

### DIFF
--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -197,7 +197,17 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
       ee.emit('started');
 
-      let ws = new WebSocket(config.target, subprotocols, options);
+      debug('Creating new WebSocket', config.target)
+
+      let ws;
+
+      if (config.ws.connect && typeof config.processor[config.ws.connect] === 'function') {
+        const fn = config.processor[config.ws.connect]
+
+        ws = new WebSocket(...Object.values(fn({ target: config.target, subprotocols, options })));
+      } else {
+        ws = new WebSocket(config.target, subprotocols, options);
+      }
 
       ws.on('open', function() {
         initialContext.ws = ws;

--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -20,10 +20,13 @@ function WSEngine(script) {
 }
 
 WSEngine.prototype.createScenario = function(scenarioSpec, ee) {
-  var self = this;
-  let tasks = _.map(scenarioSpec.flow, function(rs) {
+  const self = this;
+  const tasks = _.map(scenarioSpec.flow, function(rs) {
     if (rs.think) {
-      return engineUtil.createThink(rs, _.get(self.config, 'defaults.think', {}));
+      return engineUtil.createThink(
+        rs,
+        _.get(self.config, 'defaults.think', {})
+      );
     }
 
     return self.step(rs, ee);
@@ -32,52 +35,126 @@ WSEngine.prototype.createScenario = function(scenarioSpec, ee) {
   return self.compile(tasks, scenarioSpec.flow, ee);
 };
 
-WSEngine.prototype.step = function (requestSpec, ee) {
-  let self = this;
+function getMessageHandler(context, params, ee, callback) {
+  return function messageHandler(event) {
+    const { data } = event;
+
+    debug('WS receive: %s', data);
+
+    if (!data) {
+      return callback(new Error('Empty response from WS server'), context);
+    }
+
+    let fauxResponse;
+    try {
+      fauxResponse = { body: JSON.parse(data) };
+    } catch (err) {
+      fauxResponse = { body: event.data };
+    }
+
+    engineUtil.captureOrMatch(params, fauxResponse, context, function captured(
+      err,
+      result
+    ) {
+      if (err) {
+        ee.emit('error', err.message || err.code);
+        return callback(err, context);
+      }
+
+      const { captures = {}, matches = {} } = result;
+
+      debug('captures and matches:');
+      debug(matches);
+      debug(captures);
+
+      // match and capture are strict by default:
+      const haveFailedMatches = _.some(result.matches, function(v) {
+        return !v.success && v.strict !== false;
+      });
+
+      const haveFailedCaptures = _.some(result.captures, function(v) {
+        return v.failed;
+      });
+
+      if (haveFailedMatches || haveFailedCaptures) {
+        // TODO: Emit the details of each failed capture/match
+        return callback(new Error('Failed capture or match'), context);
+      }
+
+      _.each(result.matches, function(v) {
+        ee.emit('match', v.success, {
+          expected: v.expected,
+          got: v.got,
+          expression: v.expression,
+          strict: v.strict,
+        });
+      });
+
+      _.each(result.captures, function(v, k) {
+        _.set(context.vars, k, v.value);
+      });
+
+      return callback(null, context);
+    });
+  };
+}
+
+WSEngine.prototype.step = function(requestSpec, ee) {
+  const self = this;
 
   if (requestSpec.loop) {
-    let steps = _.map(requestSpec.loop, function(rs) {
+    const steps = _.map(requestSpec.loop, function(rs) {
       return self.step(rs, ee);
     });
 
-    return engineUtil.createLoopWithCount(
-      requestSpec.count || -1,
-      steps,
-      {
-        loopValue: requestSpec.loopValue || '$loopCount',
-        overValues: requestSpec.over,
-        whileTrue: self.config.processor ?
-          self.config.processor[requestSpec.whileTrue] : undefined
-      });
+    return engineUtil.createLoopWithCount(requestSpec.count || -1, steps, {
+      loopValue: requestSpec.loopValue || '$loopCount',
+      overValues: requestSpec.over,
+      whileTrue: self.config.processor
+        ? self.config.processor[requestSpec.whileTrue]
+        : undefined,
+    });
   }
 
   if (requestSpec.think) {
-    return engineUtil.createThink(requestSpec, _.get(self.config, 'defaults.think', {}));
+    return engineUtil.createThink(
+      requestSpec,
+      _.get(self.config, 'defaults.think', {})
+    );
   }
 
   if (requestSpec.function) {
     return function(context, callback) {
-      let processFunc = self.config.processor[requestSpec.function];
+      const processFunc = self.config.processor[requestSpec.function];
       if (processFunc) {
-        processFunc(context, ee, function () {
+        processFunc(context, ee, function() {
           return callback(null, context);
         });
       }
-    }
-  }
-
-  if(requestSpec.log) {
-    return function(context, callback) {
-      console.log(template(requestSpec.log, context));
-      return process.nextTick(function() { callback(null, context); });
     };
   }
 
-  let f = function(context, callback) {
+  if (requestSpec.log) {
+    return function(context, callback) {
+      console.log(template(requestSpec.log, context));
+      return process.nextTick(function() {
+        callback(null, context);
+      });
+    };
+  }
+
+  if (requestSpec.connect) {
+    return function(context, callback) {
+      return process.nextTick(function() {
+        callback(null, context);
+      });
+    };
+  }
+
+  const f = function(context, callback) {
     ee.emit('counter', 'engine.websocket.messages_sent', 1);
-    ee.emit('rate', 'engine.websocket.send_rate')
-    let startedAt = process.hrtime();
-    let params = requestSpec.send;
+    ee.emit('rate', 'engine.websocket.send_rate');
+    const params = requestSpec.send;
 
     // Reset onmessage to stop steps interfering with each other
     context.ws.onmessage = undefined;
@@ -92,73 +169,9 @@ WSEngine.prototype.step = function (requestSpec, ee) {
 
     debug('WS send: %s', payload);
 
-    function messageHandler(event) {
-      const { data } = event;
-
-      debug('WS receive: %s', data);
-
-      if (!data) {
-        return callback(new Error('Empty response from WS server'), context)
-      }
-
-      let fauxResponse;
-      try {
-        fauxResponse = {body: JSON.parse(data)};
-      } catch (err) {
-        fauxResponse = {body: event.data}
-      }
-
-      engineUtil.captureOrMatch(
-        params,
-        fauxResponse,
-        context,
-        function captured(err, result) {
-          if (err) {
-            ee.emit('error', err.message || err.code);
-            return callback(err, context);
-          }
-
-          const { captures = {}, matches = {} } = result
-
-          debug('captures and matches:');
-          debug(matches);
-          debug(captures);
-
-          // match and capture are strict by default:
-          const haveFailedMatches = _.some(result.matches, function (v, k) {
-            return !v.success && v.strict !== false;
-          });
-
-          const haveFailedCaptures = _.some(result.captures, function (v, k) {
-            return v.failed;
-          });
-
-          if (haveFailedMatches || haveFailedCaptures) {
-            // TODO: Emit the details of each failed capture/match
-            return callback(new Error('Failed capture or match'), context);
-          }
-
-          _.each(result.matches, function (v, k) {
-            ee.emit('match', v.success, {
-              expected: v.expected,
-              got: v.got,
-              expression: v.expression,
-              strict: v.strict
-            });
-          });
-
-          _.each(result.captures, function (v, k) {
-            _.set(context.vars, k, v.value);
-          });
-
-          return callback(null, context);
-        }
-      )
-    }
-
     // only process response if we're capturing
     if (params.capture) {
-      context.ws.onmessage = messageHandler
+      context.ws.onmessage = getMessageHandler(context, params, ee, callback);
     }
 
     context.ws.send(payload, function(err) {
@@ -170,7 +183,7 @@ WSEngine.prototype.step = function (requestSpec, ee) {
 
       // End step if we're not capturing
       if (!params.capture) {
-          return callback(null, context);
+        return callback(null, context);
       }
     });
   };
@@ -178,85 +191,99 @@ WSEngine.prototype.step = function (requestSpec, ee) {
   return f;
 };
 
-WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
-  let config = this.config;
+function getWsOptions(config) {
+  const options = getWsConfig(config);
+  const subprotocols = _.get(config, 'ws.subprotocols', []);
+  const headers = _.get(config, 'ws.headers', {});
+
+  const subprotocolHeader = _.find(headers, (value, headerName) => {
+    return headerName.toLowerCase() === 'sec-websocket-protocol';
+  });
+
+  if (typeof subprotocolHeader !== 'undefined') {
+    // NOTE: subprotocols defined via config.ws.subprotocols take precedence:
+    subprotocols.push(subprotocolHeader.split(',').map((s) => s.trim()));
+  }
+
+  return { options, subprotocols };
+}
+
+function getWsInstance(config, scenarioSpec, context) {
+  let wsArgs = {
+    ...getWsOptions(config),
+    target: config.target,
+  };
+  const [{ connect }] = scenarioSpec;
+
+  if (connect) {
+    if (connect.function && config.processor[connect.function]) {
+      const processFn = config.processor[connect.function];
+
+      wsArgs = processFn(wsArgs, context);
+    } else {
+      wsArgs.target = template(connect, context);
+    }
+  }
+
+  debug('new WebSocket instance:', wsArgs);
+
+  return new WebSocket(wsArgs.target, wsArgs.subprotocols, wsArgs.options);
+}
+
+WSEngine.prototype.compile = function(tasks, scenarioSpec, ee) {
+  const config = this.config;
 
   return function scenario(initialContext, callback) {
-    function zero(callback) {
-      const options = parseWsOptions(config);
-
-      let subprotocols = _.get(config, 'ws.subprotocols', []);
-      const headers = _.get(config, 'ws.headers', {});
-      const subprotocolHeader = _.find(headers, (value, headerName) => {
-        return headerName.toLowerCase() === 'sec-websocket-protocol';
-      });
-      if (typeof subprotocolHeader !== 'undefined') {
-        // NOTE: subprotocols defined via config.ws.subprotocols take precedence:
-        subprotocols = subprotocols.concat(subprotocolHeader.split(',').map(s => s.trim()));
-      }
-
+    function zero(cb) {
       ee.emit('started');
 
-      debug('Creating new WebSocket', config.target)
-
-      let ws;
-
-      if (config.ws.connect && typeof config.processor[config.ws.connect] === 'function') {
-        const fn = config.processor[config.ws.connect]
-
-        ws = new WebSocket(...Object.values(fn({ target: config.target, subprotocols, options })));
-      } else {
-        ws = new WebSocket(config.target, subprotocols, options);
-      }
+      const ws = getWsInstance(config, scenarioSpec, initialContext);
 
       ws.on('open', function() {
         initialContext.ws = ws;
-        return callback(null, initialContext);
+
+        return cb(null, initialContext);
       });
 
       ws.once('error', function(err) {
         debug(err);
         ee.emit('error', err.message || err.code);
-        return callback(err, {});
+
+        return cb(err, {});
       });
     }
 
     initialContext._successCount = 0;
 
-    let steps = _.flatten([
-      zero,
-      tasks
-    ]);
+    const steps = _.flatten([zero, tasks]);
 
-    async.waterfall(
-      steps,
-      function scenarioWaterfallCb(err, context) {
-        if (err) {
-          debug(err);
-        }
+    async.waterfall(steps, function scenarioWaterfallCb(err, context) {
+      if (err) {
+        debug(err);
+      }
 
-        if (context && context.ws) {
-          context.ws.close();
-        }
+      if (context && context.ws) {
+        context.ws.close();
+      }
 
-        return callback(err, context);
-      });
+      return callback(err, context);
+    });
   };
 };
 
-function parseWsOptions(config) {
+function getWsConfig(config) {
   const tls = config.tls || {};
-  const {proxy, ...options} = (config.ws || {});
+  const { proxy, ...options } = config.ws || {};
 
   if (proxy) {
-    const {url: proxyUrl, ...proxyOptions} = proxy;
+    const { url: proxyUrl, ...proxyOptions } = proxy;
 
     debug('Set proxy: %s, options: %s', proxyUrl, proxyOptions);
 
     const agent = new HttpsProxyAgent({
       ...url.parse(proxyUrl),
-      ...proxyOptions
-    })
+      ...proxyOptions,
+    });
 
     options.agent = agent;
   }


### PR DESCRIPTION
adds support for a new action in a websocket flow that can be used to customise each websocket connection parameters. 

`connect` _must_ be the first step in the flow and it can be a string, a function or an object.

**as a string:**
```yaml
config:
  target: "ws://target:8080"
  variables:
    token:
      "abcde"
scenarios:
  - name: "WS Test"
    engine: ws
    flow:
      - connect: "{{ target }}/?token={{ token }}"
      - send: "hello"
 ```
**as a function:**
```yaml
config:
  target: "ws://target:8080"
  processor: "./functions.js"
  variables:
    token:
      "abcde"
scenarios:
  - name: "WS Test"
    engine: ws
    flow:
      - connect:
          function: "connectHookHandler"
     - send: "hello"
```
the function should have the following signature:
```javascript
function connectHookHandler(params, context, callback) {
  // same as the example above
  params.target = "${params.target}/?token=${context.vars.token}"
  
  callback()
}
```
where:
`params` is an object the properties of which will be passed to the underlying WebSocket constructor. 
`context` is the virtual user context
`callback` the callback that *must* be called for the scenario to continue. If an error is passed to it, the execution fails. 

**as an object:**
`connect` accepts all the parameters of the global `config.ws` plus a `target` property
```yaml
config:
  target: "ws://target:8080"
  variables:
    token:
      "abcde"
scenarios:
  - name: "Scenario 1"
    engine: ws
    flow:
      - connect:
          target: "ws://target:port/?token={{ token }}"
          proxy:
            url: "http://proxy1:3000"
      - send: "hello" 
  - name: "Scenario 2"
    engine: ws
    flow:
      - connect:
          target: "ws://target:port"
          proxy:
            url: "http://proxy2:3001"
      - send: "hello through a different proxy"
```

fixes #663 #1098 