### PR TITLE
feat: support poisson arrival mode when using arrivalCount

### DIFF
--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -165,8 +165,9 @@ function createArrivalCount(spec, ee) {
     const duration = spec.duration * 1000;
 
     if(spec.arrivalCount > 0) {
+      debug('creating a %s process for arrivalCount', spec.mode);
       const interval = duration / spec.arrivalCount;
-      const p = arrivals.uniform.process(interval, duration);
+      const p = arrivals[spec.mode].process(interval, duration);
       p.on('arrival', function() {
         ee.emit('arrival', spec);
       });


### PR DESCRIPTION
It seems like this should work just fine. I haven't added a test because I didn't see any other test using the poisson mode. Happy to do so.