### PR TITLE
feat: allow looping over object paths

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -80,7 +80,7 @@ function createLoopWithCount(count, steps, opts) {
         overValues = opts.overValues;
         loopValue = overValues[i];
       } else if (opts.overValues && typeof opts.overValues === 'string') {
-        overValues = context.vars[opts.overValues];
+        overValues = L.get(context.vars, opts.overValues);
         if (L.isArray(overValues)) {
           loopValue = overValues[i];
         } else {

--- a/test/core/scripts/loop_nested_range.json
+++ b/test/core/scripts/loop_nested_range.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+      "target": "http://localhost:3003",
+      "phases": [
+        {"duration": 10, "arrivalRate": 1}
+      ],
+      "statsInterval": 1,
+      "variables": {
+          "outer": {
+              "items": [9, 10, 11]
+          }
+      }
+    },
+    "scenarios": [
+      {
+        "flow": [
+          {
+            "loop": [
+              {"get": {"url": "/"}},
+              {"get": {"url": "/loop/{{ $loopElement }}"}}
+            ],
+            "over": "outer.items"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/test/core/test_loop.js
+++ b/test/core/test_loop.js
@@ -58,3 +58,33 @@ test('loop with range', (t) => {
     ee.run();
   });
 });
+
+test('loop with nested range', (t) => {
+  const script = require('./scripts/loop_nested_range.json');
+
+  runner(script).then(function(ee) {
+    ee.on('done', (nr) => {
+      const report = SSMS.legacyReport(nr).report();
+
+      let scenarios = report.scenariosCompleted;
+      let requests = report.requestsCompleted;
+      let expected = scenarios * 3 * 2;
+      let code200 = report.codes[200];
+      let code404 = report.codes[404];
+
+      t.assert(
+        requests === expected,
+        'Should have ' + expected + ' requests for each completed scenario');
+      t.assert(code200 > 0,
+               'There should be a non-zero number of 200s');
+
+      // If $loopCount breaks, we'll see 404s here.
+      t.assert(!code404,
+               'There should be no 404s');
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});


### PR DESCRIPTION
Original issue link: #683

This allows complex response objects to be used directly as loop over targets without the need to restructure them or otherwise duplicate values as top level context.vars properties. My use case merges data from multiple scenario steps to be used in a later loop, and allowing this greatly simplifies the logic.