### PR TITLE
style: add code formatting & linting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "plugin:prettier/recommended"
+  ],
   "env": {
     "node": true,
     "es6": true
@@ -7,7 +10,8 @@
     "expect": true
   },
   "parserOptions": {
-    "ecmaVersion": 9
+    "ecmaVersion": 2018,
+    "sourceType": "module" // Allows for the use of imports
   },
   "rules": {
     // Ignore Rules

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "util.js",
     ".artilleryrc"
   ],
+  "prettier": {
+    "semi": true,
+    "singleQuote": true,
+    "useTabs": false
+  },
   "oclif": {
     "commands": "./lib/cmds",
     "bin": "artillery",
@@ -33,6 +38,8 @@
   "scripts": {
     "test": "export ARTILLERY_DISABLE_TELEMETRY=true && tap --timeout=120 --no-coverage test/unit/*test*.js && bash test/runner.sh && bash test/core/run.sh && bash test/lib/run.sh",
     "is_linted": "find . -name '*.js' | grep -v node_modules | xargs eslint",
+    "lint": "eslint --ext \".js,.ts,.tsx\" --ignore-path .gitignore .",
+    "lint-fix": "npm run lint -- --fix",
     "commitlint-last-commit": "commitlint --from $(git show HEAD~1 | grep commit | awk '{print $2}')"
   },
   "tap": {
@@ -116,13 +123,15 @@
     "@hapi/hapi": "^20.1.3",
     "@oclif/dev-cli": "^1.22.2",
     "cookie-parser": "^1.4.3",
-    "eslint": "^5.14.1",
+    "eslint": "^8.6.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "execa": "^0.10.0",
     "express": "^4.16.3",
     "get-bin-path": "^5.1.0",
     "husky": "^4.2.5",
     "nock": "^11.8.2",
-    "prettier": "^1.5.2",
+    "prettier": "^2.5.1",
     "proxy": "^1.0.2",
     "rewiremock": "^3.14.3",
     "sinon": "^4.5.0",


### PR DESCRIPTION
- Add Prettier + config
- Add npm scripts to lint + check style

Prettier/eslint are configured to stay close to current code style.

Will apply style/lint fixes in a separate PR.