### PR TITLE
fix: processor and plugins with 'before' hook 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   run_tests:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:lts
 
     working_directory: ~/repo
 
@@ -35,7 +35,7 @@ jobs:
   npm_publish:
     working_directory: ~/repo
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:lts
     steps:
       - checkout
       - run:

--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -39,7 +39,8 @@ module.exports = {
   },
   runnerFuncs: {
     handleScriptHook,
-    prepareScript
+    prepareScript,
+    loadProcessor
   }
 };
 
@@ -83,6 +84,20 @@ function loadEngines(
   );
 
   return { loadedEngines, warnings };
+}
+
+function loadProcessor(script, options) {
+  if (script.config.processor) {
+    const absoluteScriptPath = path.resolve(process.cwd(), options.scriptPath);
+    const processorPath = path.resolve(
+      path.dirname(absoluteScriptPath),
+      script.config.processor
+    );
+    const processor = require(processorPath);
+    script.config.processor = processor;
+  }
+
+  return script;
 }
 
 function prepareScript(script, payload) {

--- a/lib/launch-local.js
+++ b/lib/launch-local.js
@@ -16,7 +16,7 @@ const p = require('util').promisify;
 const _ = require('lodash');
 
 const core = require('./dispatcher');
-const { handleScriptHook, prepareScript } = core.runnerFuncs;
+const { handleScriptHook, prepareScript, loadProcessor } = core.runnerFuncs;
 
 async function createLauncher(script, payload, opts) {
   return new Launcher(script, payload, opts);
@@ -198,7 +198,7 @@ class Launcher {
       return {};
     }
 
-    const runnableScript = prepareScript(this.script, _.cloneDeep(this.payload), this.opts);
+    const runnableScript = loadProcessor(prepareScript(this.script, _.cloneDeep(this.payload)), this.opts);
     const contextVars = await handleScriptHook(
       hook,
       runnableScript,

--- a/lib/launch-local.js
+++ b/lib/launch-local.js
@@ -13,6 +13,7 @@ const debug = require('debug')('core');
 
 const os = require('os');
 const p = require('util').promisify;
+const _ = require('lodash');
 
 const core = require('./dispatcher');
 const { handleScriptHook, prepareScript } = core.runnerFuncs;
@@ -197,7 +198,7 @@ class Launcher {
       return {};
     }
 
-    const runnableScript = prepareScript(this.script, this.payload);
+    const runnableScript = prepareScript(this.script, _.cloneDeep(this.payload), this.opts);
     const contextVars = await handleScriptHook(
       hook,
       runnableScript,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -27,6 +27,7 @@ const { loadPlugins, loadPluginsConfig } = require('./load-plugins');
 
 const EventEmitter = require('eventemitter3');
 const p = require('util').promisify;
+const { loadProcessor } = core.runnerFuncs;
 
 process.env.LOCAL_WORKER_ID = threadId;
 
@@ -99,19 +100,8 @@ async function cleanup() {
 }
 
 async function prepare(opts) {
-  const { script, payload, options } = opts;
-  let absoluteScriptPath = path.resolve(process.cwd(), options.scriptPath);
-  options.absoluteScriptPath = absoluteScriptPath;
-
-  // load processor if needed:
-  if (script.config.processor) {
-    let processorPath = path.resolve(
-      path.dirname(absoluteScriptPath),
-      script.config.processor
-    );
-    let processor = require(processorPath);
-    script.config.processor = processor;
-  }
+  const { script: _script, payload, options } = opts;
+  const script = loadProcessor(_script, options);
 
   //
   // load plugins

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "scripts": {
-    "test": "export ARTILLERY_DISABLE_TELEMETRY=true && tap --timeout=120 --no-coverage test/unit/*test*.js && bash test/runner.sh && bash test/core/run.sh && bash test/lib/run.sh",
+    "test": "export ARTILLERY_DISABLE_TELEMETRY=true && tap --timeout=120 --no-coverage test/unit/*test*.js && bash test/runner.sh && bash test/core/run.sh && bash test/lib/run.sh && node test/testcases/plugins/*.test.js",
     "is_linted": "find . -name '*.js' | grep -v node_modules | xargs eslint",
     "lint": "eslint --ext \".js,.ts,.tsx\" --ignore-path .gitignore .",
     "lint-fix": "npm run lint -- --fix",

--- a/test/core/plugins/artillery-plugin-httphooks/index.js
+++ b/test/core/plugins/artillery-plugin-httphooks/index.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+function httpHooks(script) {
+  if (typeof process.env.LOCAL_WORKER_ID === 'undefined') {
+    return;
+  }
+
+  script.scenarios.forEach(function (scenario) {
+    scenario.afterResponse = [].concat(scenario.afterResponse || []);
+    scenario.afterResponse.push('afterResponseFn');
+  });
+
+  script.config.processor.afterResponseFn = afterResponseFn;
+  return this;
+}
+
+function afterResponseFn(req, res, userContext, events, done) {
+  console.log('afterResponse hook');
+
+  done();
+}
+
+module.exports.Plugin = httpHooks;

--- a/test/core/plugins/artillery-plugin-httphooks/package.json
+++ b/test/core/plugins/artillery-plugin-httphooks/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "artillery-plugin-httphooks",
+  "version": "1.0.0",
+  "description": "A plugin that attach functions to http hooks",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MPL-2.0"
+}

--- a/test/testcases/plugins/plugins-processor.test.js
+++ b/test/testcases/plugins/plugins-processor.test.js
@@ -1,0 +1,50 @@
+const { test } = require('tap');
+const http = require('http');
+const { $ } = require('zx');
+const path = require('path');
+
+const A9 = process.env.A9 || path.join(__dirname, '../../../bin/artillery');
+
+function createServer() {
+  return http.createServer((req, res) => {
+    switch (req.method) {
+      case 'POST':
+        return res.writeHead(201).end();
+      case 'GET':
+        return res.writeHead(204).end();
+      default:
+        return res.writeHead(405).end();
+    }
+  });
+}
+
+(async function () {
+  const server = createServer().listen(0);
+
+  const overrides = JSON.stringify({
+    config: {
+      phases: [{ duration: 2, arrivalRate: 2 }],
+      target: `http://localhost:${server.address().port}`,
+      processor: path.join(__dirname, '/processor.js'),
+      plugins: {
+        httphooks: {}
+      }
+    }
+  });
+
+  await $`${A9} -V`;
+
+  test('plugins can attach functions to processor object', async (t) => {
+    const output = await $`ARTILLERY_PLUGIN_PATH=${path.join(
+      __dirname,
+      '../../core/plugins'
+    )} ${A9} run --quiet --overrides ${overrides} ${path.join(
+      __dirname,
+      '/script.json'
+    )}`;
+
+    t.match(output, /afterResponse hook/, 'plugin output');
+
+    server.close(t.end);
+  });
+})();

--- a/test/testcases/plugins/processor.js
+++ b/test/testcases/plugins/processor.js
@@ -1,0 +1,5 @@
+function processorFn() {
+  return true;
+}
+
+module.exports = { processorFn };

--- a/test/testcases/plugins/script.json
+++ b/test/testcases/plugins/script.json
@@ -1,0 +1,26 @@
+{
+  "config": {},
+  "before": {
+    "flow": [
+      {
+        "post": {
+          "url": "/"
+        }
+      }
+    ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "get": {
+            "url": "/",
+            "expect": {
+              "statusCode": 204
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
fixes a regression bug introduced in `2.0.0-8` and reverted in `2.0.0-9` where plugins could not attach functions to the test script if `processor` and `before` were both present