### PR TITLE
fix: execute arrivalCount phase in one worker

### DIFF
--- a/lib/dist.js
+++ b/lib/dist.js
@@ -42,15 +42,13 @@ function divideWork(script, numWorkers) {
     }
 
     if (phase.arrivalCount) {
-      const counts = distribute(phase.arrivalCount, numWorkers);
-
-      // arrivalCount is executed in the first worker and replaced with
-      // a `pause` phase in the others
-      L.each(counts.slice(1), function (Lc, i) {
+      // arrivalCount is executed in the first worker
+      // and replaced with a `pause` phase in the others
+      for (let i = 1; i < numWorkers; i++) {
         newPhases[i][phaseSpecIndex] = {
           pause: phase.duration
         };
-      });
+      }
 
       return;
     }

--- a/lib/dist.js
+++ b/lib/dist.js
@@ -42,10 +42,16 @@ function divideWork(script, numWorkers) {
     }
 
     if (phase.arrivalCount) {
-      let counts = distribute(phase.arrivalCount, numWorkers);
-      L.each(counts, function (Lc, i) {
-        newPhases[i][phaseSpecIndex].arrivalCount = counts[i];
+      const counts = distribute(phase.arrivalCount, numWorkers);
+
+      // arrivalCount is executed in the first worker and replaced with
+      // a `pause` phase in the others
+      L.each(counts.slice(1), function (Lc, i) {
+        newPhases[i][phaseSpecIndex] = {
+          pause: phase.duration
+        };
       });
+
       return;
     }
 

--- a/test/core/unit/dist.test.js
+++ b/test/core/unit/dist.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const tap = require('tap');
+const divideWork = require('../../../lib/dist');
+
+tap.test('divideWork', (t) => {
+  const numWorkers = 5;
+  const script = {
+    config: {
+      target: 'http://targ.get.url',
+      phases: [{ name: 'arrivalCount', duration: 10, arrivalCount: 5 }]
+    },
+    scenarios: [
+      {
+        flow: [
+          {
+            get: {
+              url: '/'
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  const phases = divideWork(script, numWorkers);
+
+  t.equal(phases.length, numWorkers, 'it divides work for workers');
+  t.equal(
+    phases.filter(
+      (phase) =>
+        phase.config.phases.length === script.config.phases.length &&
+        'arrivalCount' in phase.config.phases[0]
+    ).length,
+    1,
+    'arrivalCount is assigned to just one worker'
+  );
+  t.equal(
+    phases.filter(
+      (phase) =>
+        phase.config.phases.length === script.config.phases.length &&
+        'pause' in phase.config.phases[0]
+    ).length,
+    numWorkers - 1,
+    'arrivalCount is replaced with a pause phase in all but one of the worker scripts'
+  );
+
+  t.end();
+});

--- a/test/core/unit/index.js
+++ b/test/core/unit/index.js
@@ -11,3 +11,4 @@ require('./engine_socketio.test');
 require('./engine_ws.test');
 require('./interpolation.test');
 require('./before_after_hooks.test');
+require('./dist.test');


### PR DESCRIPTION
fixes `arrivalCount` by assigning it to one worker and replacing it with a pause phase for the others.