### PR TITLE
feat: track usage of built-in & community engines

### DIFF
--- a/lib/cmds/run.js
+++ b/lib/cmds/run.js
@@ -356,6 +356,35 @@ async function sendTelemetry(script, flags) {
     properties.hostnameHash = hash(os.hostname());
     properties.usernameHash = hash(os.userInfo().username);
 
+    if (script.config?.engines) {
+      properties.loadsEngines = true;
+    }
+
+    properties.enginesUsed = [];
+    const OSS_ENGINES = [
+      'http',
+      'socketio',
+      'ws',
+
+      'playwright',
+      'kinesis',
+      'socketio-v3',
+      'rediscluster',
+      'kafka',
+      'tcp',
+      'grpc',
+      'meteor',
+      'graphql-ws',
+      'ldap',
+      'lambda',
+    ];
+
+    for(const scenario of (script.scenarios || [])) {
+      if(OSS_ENGINES.indexOf(scenario.engine || 'http') > -1) {
+        properties.enginesUsed.push(scenario.engine || 'http');
+      }
+    }
+
     // Official plugins:
     if (script.config.plugins) {
       properties.plugins = true;
@@ -364,6 +393,7 @@ async function sendTelemetry(script, flags) {
         'expect',
         'publish-metrics',
         'metrics-by-endpoint',
+        'ensure',
         'hls',
         'fuzzer',
         'ensure'


### PR DESCRIPTION
Add tracking for:

* whether third-party engines are used
* if so, which open-source / community engines are used
* whether the ensure plugin is used