### PR TITLE
fix: keep original load phase name when replacing arrivalCounts with pauses

### DIFF
--- a/lib/dist.js
+++ b/lib/dist.js
@@ -46,6 +46,7 @@ function divideWork(script, numWorkers) {
       // and replaced with a `pause` phase in the others
       for (let i = 1; i < numWorkers; i++) {
         newPhases[i][phaseSpecIndex] = {
+          name: phase.name,
           pause: phase.duration
         };
       }

--- a/test/core/unit/dist.test.js
+++ b/test/core/unit/dist.test.js
@@ -45,5 +45,16 @@ tap.test('divideWork', (t) => {
     'arrivalCount is replaced with a pause phase in all but one of the worker scripts'
   );
 
+  t.ok(
+    phases
+      .slice(1)
+      .every(
+        (phase) =>
+          'pause' in phase.config.phases[0] &&
+          phase.config.phases[0].name === script.config.phases[0].name
+      ),
+    'pause phases created to replace arrivalCounts keep the same name as the original arrivalCount phase'
+  );
+
   t.end();
 });


### PR DESCRIPTION
fixes #1313 