### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,
+along with any information you feel relevant to replicating it.
+-->
+
+Version info: <!-- artillery -v output -->
+```
+<version>
+```
+
+Running this command: 
+```
+<command>
+```
+
+I expected to see this happen:
+
+*explanation*
+
+Instead, this happened:
+
+*explanation*
+
+Files being used:
+```
+<relevant yaml/js/csv go here>
+```


### PR DESCRIPTION
Add template for bug reports. Based on github's default template and [rust](https://github.com/rust-lang/rust/edit/master/.github/ISSUE_TEMPLATE/bug_report.md)'s 
Closes ART-348