### PR TITLE
feat: allow solo capture step with ws engine

### DIFF
--- a/test/core/index.js
+++ b/test/core/index.js
@@ -14,6 +14,7 @@ require('./test_basic_auth');
 require('./test_cookies');
 require('./test_concurrent_requests');
 require('./http');
+require('./test_ws_match_wait');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/core/test_ws_match_wait.js
+++ b/test/core/test_ws_match_wait.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const { test } = require('tap');
+const runner = require('../../core').runner;
+const http = require('http');
+const WebSocket = require('ws');
+const { SSMS } = require('../../core/lib/ssms');
+
+test('should match a websocket response without capture', (t) => {
+  const server = http.createServer();
+  const wss = new WebSocket.Server({ server: server });
+  const targetServer = server.listen(0);
+
+  wss.on('connection', function (ws) {
+    ws.on('message', function () {
+      ws.send(JSON.stringify({ foo: 'bar' }));
+    });
+  });
+
+  const script = {
+    config: {
+      target: `ws://127.0.0.1:${targetServer.address().port}`,
+      phases: [{ duration: 1, arrivalCount: 1 }]
+    },
+    scenarios: [
+      {
+        engine: 'ws',
+        flow: [
+          {
+            send: {
+              payload: 'hello',
+              match: { json: '$.foo', value: 'bar' }
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', (nr) => {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.ok(
+        Object.keys(report.errors).length === 0,
+        'There should be no errors'
+      );
+
+      ee.stop().then(() => {
+        targetServer.close(t.end);
+      });
+    });
+
+    ee.run();
+  });
+});
+
+test('should wait for a websocket response without send', (t) => {
+  const server = http.createServer();
+  const wss = new WebSocket.Server({ server: server });
+  const targetServer = server.listen(0);
+
+  wss.on('connection', function (ws) {
+    ws.on('message', function () {
+      ws.send(JSON.stringify({ foo: 'bar' }));
+      setTimeout(() => ws.send(JSON.stringify({ bar: 'baz' }), 100));
+    });
+  });
+
+  const script = {
+    config: {
+      target: `ws://127.0.0.1:${targetServer.address().port}`,
+      phases: [{ duration: 1, arrivalCount: 1 }]
+    },
+    scenarios: [
+      {
+        engine: 'ws',
+        flow: [
+          {
+            send: {
+              payload: 'hello',
+              match: { json: '$.foo', value: 'bar' }
+            },
+            wait: {
+              match: { json: '$.bar', value: 'baz' }
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', (nr) => {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.ok(Object.keys(report.errors).length === 0, 'The wait should match');
+
+      ee.stop().then(() => {
+        targetServer.close(t.end);
+      });
+    });
+
+    ee.run();
+  });
+});
+
+test('should wait for multiple websocket responses in a loop', (t) => {
+  const server = http.createServer();
+  const wss = new WebSocket.Server({ server: server });
+  const targetServer = server.listen(0);
+
+  wss.on('connection', function (ws) {
+    ws.on('message', function () {
+      ws.send(JSON.stringify({ foo: 'bar' }));
+      for (let i = 0; i < 5; i++) {
+        setTimeout(() => ws.send(JSON.stringify({ bar: 'baz' }), i * 100));
+      }
+    });
+  });
+
+  const script = {
+    config: {
+      target: `ws://127.0.0.1:${targetServer.address().port}`,
+      phases: [{ duration: 1, arrivalCount: 1 }]
+    },
+    scenarios: [
+      {
+        engine: 'ws',
+        flow: [
+          { send: 'hello' },
+          {
+            loop: [{ wait: { match: { json: '$.bar', value: 'baz' } } }],
+            count: 5
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', (nr) => {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.ok(Object.keys(report.errors).length === 0, 'All waits should match');
+      ee.stop().then(() => {
+        targetServer.close(t.end);
+      });
+    });
+
+    ee.run();
+  });
+});


### PR DESCRIPTION
It does not seem possible to `capture` a message from the server except as a response to a send.  This PR makes an alias of the `send` step called `wait` purely for readability purposes and also checks for a `payload` before sending anything, allowing a solo `capture` step to be defined.

The current ws engine also has an undocumented `match` feature, but you cannot use it without at least an empty capture.  This PR checks for either `capture` or `match` being defined rather than just `capture`.

e.g.

```
    flow:
      - send:
          payload:
            type: handshake
          capture:
            json: "$.user_id"
            as: "user_id"
      - think: 2
      - send:
          payload:
            type: text
            text: "unittest-20220420"
          match:
            json: "$.type"
            value: typing
      - wait:
          match: 
            json: "$.text"
            value: what is your name?
      - think: 2
      - send:
          payload:
            type: text
            text: "{{ naughtyString }}"
          match:
            json: "$.type"
            value: typing
      - wait:
          match: 
            json: "$.text"
            value: please enter yes
```