### PR TITLE
dep: downgrade async from 2.6.4 to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "artillery-plugin-expect": "^2.0.1",
         "artillery-plugin-metrics-by-endpoint": "^1.0.2",
         "artillery-plugin-publish-metrics": "^2.0.0",
-        "async": "^2.6.4",
+        "async": "^1.5.2",
         "chalk": "1.1.3",
         "cheerio": "^1.0.0-rc.2",
         "ci-info": "^2.0.0",
@@ -3340,6 +3340,14 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/artillery-plugin-publish-metrics/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/artillery-plugin-publish-metrics/node_modules/semver": {
       "version": "7.3.7",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -3432,12 +3440,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "node_modules/async-hook-domain": {
       "version": "2.0.4",
@@ -20432,6 +20437,14 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -20518,12 +20531,9 @@
       }
     },
     "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-hook-domain": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "artillery-plugin-expect": "^2.0.1",
     "artillery-plugin-metrics-by-endpoint": "^1.0.2",
     "artillery-plugin-publish-metrics": "^2.0.0",
-    "async": "^2.6.4",
+    "async": "^1.5.2",
     "chalk": "1.1.3",
     "cheerio": "^1.0.0-rc.2",
     "ci-info": "^2.0.0",


### PR DESCRIPTION
The upgrade broke a test [1]. Reverting until we can look into the
underlying issue and fix it properly.

This reverts the change in e51e3a5369f8632480dae4a39a993adb34cd5748.

1. E.g.: https://app.circleci.com/pipelines/github/artilleryio/artillery/526/workflows/8e7b73cc-f0e3-4438-b6fe-5fe0cf4cc292/jobs/1062?invite=true#step-109-48