### PR TITLE
feat: remove "histograms" field from JSON report

### DIFF
--- a/lib/cmds/run.js
+++ b/lib/cmds/run.js
@@ -106,6 +106,12 @@ class RunCommand extends Command {
           if (!flags.quiet) {
             console.log('Log file: %s', logfile);
           }
+
+          for (const ix of intermediates) {
+            delete ix.histograms;
+          }
+          delete report.histograms;
+
           fs.writeFileSync(
             logfile,
             JSON.stringify(


### PR DESCRIPTION
The "histograms" field contains data for the raw DDSketch object,
which is unnecessary for intended uses of JSON reports, and can
signficantly inflate the size of generated JSON, especially for
longer tests.

The "summaries" field contains percentile values for time windows
calculated from those histograms.