### PR TITLE
artillery probe improvements

### DIFF
--- a/lib/cmds/probe.js
+++ b/lib/cmds/probe.js
@@ -13,6 +13,7 @@ const highlight = require('cli-highlight').highlight;
 const temp = require('temp').track();
 const mime = require('mime-types');
 const jmespath = require('jmespath');
+const cheerio = require('cheerio');
 const YAML = require('js-yaml');
 
 const telemetry = require('../telemetry').init();
@@ -382,12 +383,15 @@ class ProbeCommand extends Command {
         this.log(`\n${chalk.cyan('Body')} stored in: ${fn}\n`);
       }
 
+      const isJSON = contentType.match(/json/gi);
+      const isXML = contentType.match(/html/gi) || contentType.match(/xml/gi);
+
       if (flags.showBody) {
         let language;
-        if (contentType.match(/json/gi)) {
+        if (isJSON) {
           language = 'json';
         }
-        if (contentType.match(/html/gi)) {
+        if (isXML) {
           language = 'html';
         }
 
@@ -402,29 +406,39 @@ class ProbeCommand extends Command {
         }
       }
 
-      if (flags.jmespath) {
-        if (!contentType.match(/json/g)) {
-          console.error(
-            chalk.yellow('Response Content-Type is not JSON:'),
-            contentType
-          );
-          console.error(chalk.yellow('Trying JMESPath expression anyway'));
-        }
+      if (flags.jmespath || flags.cheerio || flags.q) {
+        if (flags.jmespath || (isJSON && flags.q)) {
+          try {
+            const json = JSON.parse(context.vars.body);
+            const result = jmespath.search(json, flags.jmespath || flags.query);
 
-        try {
-          const json = JSON.parse(context.vars.body);
-          const result = jmespath.search(json, flags.jmespath);
-
-          // If our output is piped we want to print the JSON without highlighting:
-          if (process.stdout.isTTY) {
-            console.log(highlight(JSON.stringify(result, null, 4), { language: 'json' }));
-          } else {
-            console.log(JSON.stringify(result));
+            // If our output is piped we want to print the JSON without highlighting:
+            if (process.stdout.isTTY) {
+              console.log(highlight(JSON.stringify(result, null, 4), { language: 'json' }));
+            } else {
+              console.log(JSON.stringify(result));
+            }
+          } catch (err) {
+            console.error(chalk.red(err.message));
+            process.exit(1);
           }
-
-        } catch (err) {
-          console.error(chalk.red(err.message));
-          process.exit(1);
+        } else if (flags.cheerio || (isXML && flags.query)) {
+          try {
+            const $ = cheerio.load(context.vars.body);
+            const elts = $(flags.cheerio || flags.query).html();
+            // If our output is piped we want to print the without highlighting:
+            if (process.stdout.isTTY) {
+              console.log(highlight(elts, { language: 'html' }));
+            } else {
+              console.log(elts);
+            }
+          } catch (err) {
+            console.error(chalk.red(err.message));
+            process.exit(1);
+          }
+        } else {
+          console.error(chalk.yellow('Content-Type is not JSON or XML/HTML:'), contentType);
+          console.error(chalk.yellow('Unable to run a query'));
         }
       }
 
@@ -575,9 +589,15 @@ ProbeCommand.flags = {
     description: 'Print request headers'
   }),
   jmespath: flags.string({
-    char: 'q',
     description:
       'Run a JMESPath query on a JSON response body (https://docs.art/jmespath)'
+  }),
+  cheerio: flags.string({
+    description: 'Run a Cheerio query on a HTML/XML response body (https://cheerio.js.org)'
+  }),
+  query: flags.string({
+    char: 'q',
+    description: 'Run a JMESPath or Cheerio query on response body depending on content type. This is a shortcut for --jmespath or --cheerio'
   }),
   h1: flags.boolean({
     description: 'Force HTTP/1.1 (Artillery Probe defaults to HTTP/2 if supported by the server)'

--- a/lib/cmds/probe.js
+++ b/lib/cmds/probe.js
@@ -417,7 +417,7 @@ class ProbeCommand extends Command {
 
           // If our output is piped we want to print the JSON without highlighting:
           if (process.stdout.isTTY) {
-            console.log(highlight(JSON.stringify(result), { language: 'json' }));
+            console.log(highlight(JSON.stringify(result, null, 4), { language: 'json' }));
           } else {
             console.log(JSON.stringify(result));
           }

--- a/lib/cmds/probe.js
+++ b/lib/cmds/probe.js
@@ -369,7 +369,7 @@ class ProbeCommand extends Command {
         ).replace(/\|/g, chalk.gray('|'))
       );
 
-      if (!flags.h1) {
+      if (parseInt(context.vars.res.httpVersion, 10) > 1) {
         this.log(chalk.gray('NOTE: DNS, TCP and SSL overhead is not available for HTTP/2 yet due to\na limitation in the underlying HTTP client that artillery probe uses'));
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "artillery-plugin-publish-metrics": "^2.0.0",
         "async": "^1.5.2",
         "chalk": "1.1.3",
-        "cheerio": "^1.0.0-rc.2",
+        "cheerio": "^1.0.0-rc.10",
         "ci-info": "^2.0.0",
         "cli-highlight": "^2.1.11",
         "cli-table3": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "artillery-plugin-publish-metrics": "^2.0.0",
     "async": "^1.5.2",
     "chalk": "1.1.3",
-    "cheerio": "^1.0.0-rc.2",
+    "cheerio": "^1.0.0-rc.10",
     "ci-info": "^2.0.0",
     "cli-highlight": "^2.1.11",
     "cli-table3": "^0.6.0",


### PR DESCRIPTION
* Pretty-print JSON when `-q` is used
* Add support for querying HTML/XML with Cheerio
* `-q` will try to guess whether to run JMESPath or Cheerio. `--jmespath` and `--cheerio` are also supported.