### PR TITLE
fix: check for rampTo when starting arrivalRate is 0 for a worker

### DIFF
--- a/core/lib/is-idle-phase.js
+++ b/core/lib/is-idle-phase.js
@@ -4,7 +4,9 @@
 
 function isIdlePhase(phase) {
   return (
-    phase.arrivalRate === 0 || phase.arrivalCount === 0 || phase.maxVusers === 0
+    (phase.arrivalRate === 0 && !phase.rampTo) ||
+    phase.arrivalCount === 0 ||
+    phase.maxVusers === 0
   );
 }
 


### PR DESCRIPTION
When the `arrivalRate` is set to a value lower than the number of workers, the distribution logic will create workers with `arrivalRate: 0`.  Because the default isIdlePhase logic only checks for `arrivalRate === 0` to cull workers, if a `rampTo` is defined and set to a value greater than the number of workers, any workers that have a starting `arrivalRate: 0`, but a `rampTo > 0` will get culled, along with their distributed load.

This is most noticeable with `arrivalRate: 1` as all workers except the initial one will be culled, resulting in just one worker, with a distributed value (1/workers) for `rampTo`

This simple fix checks that no `rampTo` is defined if `arrivalRate === 0`