### PR TITLE
feat: add --dotenv flag

### DIFF
--- a/lib/cmds/run.js
+++ b/lib/cmds/run.js
@@ -13,7 +13,7 @@ const p = require('util').promisify;
 const csv = require('csv-parse');
 const debug = require('debug')('commands:run');
 const ip = require('ip');
-
+const dotenv = require('dotenv');
 const _ = require('lodash');
 
 const fs = require('fs');
@@ -39,6 +39,16 @@ class RunCommand extends Command {
 
     // Collect all input files for reading/parsing - via args, --config, or -i
     const inputFiles = argv.concat(flags.input || [], flags.config || []);
+
+    if (flags.dotenv) {
+      const dotEnvPath = path.resolve(process.cwd(), flags.dotenv);
+      try {
+        fs.statSync(dotEnvPath);
+      } catch (err) {
+        console.log(`WARNING: could not read dotenv file: ${flags.dotenv}`);
+      }
+      dotenv.config({ path: dotEnvPath });
+    }
 
     try {
       const script = await prepareTestExecutionPlan(inputFiles, flags);
@@ -253,6 +263,9 @@ RunCommand.flags = {
   solo: flags.boolean({
     char: 's',
     description: 'Create only one virtual user'
+  }),
+  dotenv: flags.string({
+    description: 'Path to a dotenv file to load environment variables from',
   })
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "debug": "^4.3.1",
         "decompress-response": "^6.0.0",
         "deep-for-each": "^3.0.0",
+        "dotenv": "^16.0.1",
         "driftless": "^2.0.3",
         "esprima": "^4.0.0",
         "eventemitter3": "^4.0.4",
@@ -5783,6 +5784,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/driftless": {
@@ -15369,6 +15378,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/tap/node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tap/node_modules/stack-utils": {
       "version": "2.0.5",
       "dev": true,
@@ -22195,6 +22213,11 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "driftless": {
       "version": "2.0.3",
@@ -29342,6 +29365,14 @@
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
           }
         },
         "stack-utils": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "debug": "^4.3.1",
     "decompress-response": "^6.0.0",
     "deep-for-each": "^3.0.0",
+    "dotenv": "^16.0.1",
     "driftless": "^2.0.3",
     "esprima": "^4.0.0",
     "eventemitter3": "^4.0.4",

--- a/test/scripts/with-dotenv/my-vars
+++ b/test/scripts/with-dotenv/my-vars
@@ -1,0 +1,1 @@
+URL=https://www.artillery.io/

--- a/test/scripts/with-dotenv/with-dotenv.yml
+++ b/test/scripts/with-dotenv/with-dotenv.yml
@@ -1,0 +1,6 @@
+config:
+  target: "https://www.wontresolve.none"
+scenarios:
+  - flow:
+      - get:
+          url: "{{ $processEnvironment.URL }}"

--- a/test/testcases/command-run.bats
+++ b/test/testcases/command-run.bats
@@ -61,6 +61,12 @@
   [[ $? -eq 0 ]]
 }
 
+@test "Environment variables can be loaded from dotenv files" {
+  ./bin/run run --dotenv ./test/scripts/with-dotenv/my-vars ./test/scripts/with-dotenv/with-dotenv.yml -o report-with-dotenv.json
+  node -e 'var fs = require("fs"); var j = JSON.parse(fs.readFileSync("report-with-dotenv.json", "utf8"));process.exit(j.aggregate.counters["http.codes.200"] === 1 ? 0 : 1);'
+  [[ $? -eq 0 ]]
+}
+
 @test "Script using a plugin" {
   ARTILLERY_USE_LEGACY_REPORT_FORMAT=1 ARTILLERY_WORKERS=3 ARTILLERY_PLUGIN_PATH="`pwd`/test/plugins/" ./bin/run run -o report.json ./test/scripts/hello_plugin.json
   requestCount1=$(awk '{ sum += $1 } END { print sum }' plugin-data.csv)


### PR DESCRIPTION
Add a `--dotenv` flag which can be used to load environment variables from a `.env` file.