### PR TITLE
feat: add ability to make all rows in a CSV payload available to each VU

### DIFF
--- a/core/lib/readers.js
+++ b/core/lib/readers.js
@@ -33,18 +33,27 @@ function createSequencedReader() {
 
 function createEverythingReader(spec) {
   let parsedData;
+
   return function (data) {
     if (!parsedData) {
       parsedData = [];
-      for (const row of data) {
-        let o = {};
-        for(let i = 0; i < spec.fields.length; i++) {
-          const fieldName = spec.fields[i];
-          o[fieldName] = row[i];
+
+      // Parse the row into an object based on the fields spec
+      if (spec.fields?.length > 0) {
+        for (const row of data) {
+          let o = {};
+            for(let i = 0; i < spec.fields.length; i++) {
+              const fieldName = spec.fields[i];
+              o[fieldName] = row[i];
+            }
+          parsedData.push(o);
         }
-        parsedData.push(o);
+      } else {
+        // Otherwise just return the array of rows
+        parsedData = data;
       }
     }
+
     return parsedData;
   };
 }

--- a/core/lib/readers.js
+++ b/core/lib/readers.js
@@ -8,11 +8,14 @@ const _ = require('lodash');
 
 module.exports = createReader;
 
-function createReader(order) {
+function createReader(order, spec) {
   if (order === 'sequence') {
     return createSequencedReader();
+  } else if (typeof order === 'undefined' && (typeof spec?.name !== 'undefined')) {
+    return createEverythingReader(spec);
+  } else { // random
+    return createRandomReader();
   }
-  return createRandomReader();
 }
 
 function createSequencedReader() {
@@ -25,6 +28,24 @@ function createSequencedReader() {
       i = 0;
     }
     return result;
+  };
+}
+
+function createEverythingReader(spec) {
+  let parsedData;
+  return function (data) {
+    if (!parsedData) {
+      parsedData = [];
+      for (const row of data) {
+        let o = {};
+        for(let i = 0; i < spec.fields.length; i++) {
+          const fieldName = spec.fields[i];
+          o[fieldName] = row[i];
+        }
+        parsedData.push(o);
+      }
+    }
+    return parsedData;
   };
 }
 

--- a/core/lib/readers.js
+++ b/core/lib/readers.js
@@ -11,7 +11,7 @@ module.exports = createReader;
 function createReader(order, spec) {
   if (order === 'sequence') {
     return createSequencedReader();
-  } else if (typeof order === 'undefined' && (typeof spec?.name !== 'undefined')) {
+  } else if (typeof order === 'undefined' && (typeof spec?.name !== 'undefined') && spec?.loadAll === true) {
     return createEverythingReader(spec);
   } else { // random
     return createRandomReader();

--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -101,14 +101,14 @@ function prepareScript(script, payload) {
       runnableScript.config.payload = [
         {
           fields: runnableScript.config.payload.fields,
-          reader: createReader(runnableScript.config.payload.order),
+          reader: createReader(runnableScript.config.payload.order, runnableScript.config.payload),
           data: payload
         }
       ];
     } else {
       runnableScript.config.payload = payload;
       _.each(runnableScript.config.payload, function (el) {
-        el.reader = createReader(el.order);
+        el.reader = createReader(el.order, el);
       });
     }
   } else {
@@ -350,6 +350,10 @@ function datafileVariables(script) {
       _.each(el.fields, function (fieldName, j) {
         result[fieldName] = row[j];
       });
+      if (typeof el.name !== 'undefined') {
+        // Make the entire CSV available
+        result[el.name] = el.reader(el.data);
+      }
     });
   }
   return result;


### PR DESCRIPTION
Setting the "name" property on a CSV payload will make all rows available to the VU, under the variable with that name. The type of the value is an array of objects, where each object has properties corresponding to the "fields" spec of the CSV payload.

Example:

```yaml
config:
  target: https://www.artillery.io
  payload:
    # Load all rows from the CSV file into a "data" variable. Each element of the
    # array will have an "url" and "code" property:
    - path: ./request-response.csv
      name: data
      fields: [url, code]
  plugins:
    expect: {}
scenarios:
  - flow:
    # Loop over each element in the data variable, with loop-over
    # Each element in the "data" array can be accessed via the special
    # $loopElement variable.
    # https://artillery.io/docs/guides/guides/http-reference.html#Looping-through-an-array
    - loop:
        - get:
            url: "{{ $loopElement.url }}"
            followRedirect: false
            expect:
              statusCode: "{{ $loopElement.code }}"
      over: "data"
```