### PR TITLE
feat: handle AWS Lambda timeouts

### DIFF
--- a/lib/launch-platform.js
+++ b/lib/launch-platform.js
@@ -15,6 +15,7 @@ const _ = require('lodash');
 
 const PlatformLocal = require('./platform/local');
 const PlatformLambda = require('./platform/aws-lambda');
+const STATES = require('./platform/worker-states');
 
 async function createLauncher(script, payload, opts, launcherOpts) {
   launcherOpts = launcherOpts || {
@@ -75,12 +76,16 @@ class Launcher {
 
   async initWorkerEvents(workerEvents) {
     workerEvents.on('workerError', (workerId, message) => {
+      this.workers[workerId].state = STATES.stoppedError;
+
       const { id, error, level, aggregatable } = message;
       if (aggregatable) {
         this.workerMessageBuffer.push(message);
       } else {
-        global.artillery.log(`[${id}]: ${error.message}`, level);
+        global.artillery.log(`[${id}]: ${error.message}`);
       }
+
+      this.events.emit('workerError', message);
     });
 
     workerEvents.on('phaseStarted', (workerId, message) => {
@@ -119,38 +124,11 @@ class Launcher {
     });
 
     workerEvents.on('done', async (workerId, message) => {
-      this.workers[workerId].state = 'exited'; // TODO:
+      this.workers[workerId].state = STATES.completed;
 
       this.finalReportsByWorker[workerId] = SSMS.deserializeMetrics(
         message.report
       );
-
-      if (Object.keys(this.finalReportsByWorker).length === this.count) {
-        // Flush messages from workers
-        await this.flushWorkerMessages(0);
-        await this.flushIntermediateMetrics(true);
-
-        // TODO: handle worker death
-
-        const pds = Object.keys(this.finalReportsByWorker).map(
-          (k) => this.finalReportsByWorker[k]
-        );
-
-        const statsByPeriod = Object.values(SSMS.mergeBuckets(pds));
-        const stats = SSMS.pack(statsByPeriod);
-
-        stats.summaries = {};
-        for (const [name, value] of Object.entries(stats.histograms || {})) {
-          const summary = SSMS.summarizeHistogram(value);
-          stats.summaries[name] = summary;
-        }
-
-        // Relay event to workers
-        this.pluginEvents.emit('done', stats);
-        this.pluginEventsLegacy.emit('done', SSMS.legacyReport(stats));
-
-        this.events.emit('done', stats);
-      }
     });
 
     workerEvents.on('log', async (workerId, message) => {
@@ -230,6 +208,40 @@ class Launcher {
         global.artillery.log(result.msg, 'warn');
         // global.artillery.log(result.error, 'warn');
       }
+    }
+  }
+
+  async handleAllWorkersFinished() {
+    const allWorkersDone = Object.keys(this.workers)
+                              .filter((workerId) => {
+                                return this.workers[workerId].state === STATES.completed || this.workers[workerId].state === STATES.stoppedError;
+                              }).length === this.count;
+
+    if (allWorkersDone) {
+      // Flush messages from workers
+      await this.flushWorkerMessages(0);
+      await this.flushIntermediateMetrics(true);
+
+      const pds = Object.keys(this.finalReportsByWorker).map(
+        (k) => this.finalReportsByWorker[k]
+      );
+
+      const statsByPeriod = Object.values(SSMS.mergeBuckets(pds));
+      const stats = SSMS.pack(statsByPeriod);
+
+      stats.summaries = {};
+      for (const [name, value] of Object.entries(stats.histograms || {})) {
+        const summary = SSMS.summarizeHistogram(value);
+        stats.summaries[name] = summary;
+      }
+
+      clearInterval(this.workerExitWatcher);
+
+      // Relay event to workers
+      this.pluginEvents.emit('done', stats);
+      this.pluginEventsLegacy.emit('done', SSMS.legacyReport(stats));
+
+      this.events.emit('done', stats);
     }
   }
 
@@ -323,6 +335,10 @@ class Launcher {
   async run() {
     await this.initPlugins();
 
+    this.workerExitWatcher = setInterval(async () => {
+      await this.handleAllWorkersFinished();
+    }, 5 * 1000);
+
     setInterval(async () => {
       await this.flushWorkerMessages();
     }, 1 * 1000).unref();
@@ -340,15 +356,13 @@ class Launcher {
 
       this.workers[w1.workerId] = {
         id: w1.workerId,
-        script
+        script,
+        state: STATES.initializing,
       };
       debug(`worker init ok: ${w1.workerId}`);
     }
 
     await this.initWorkerEvents(this.platform.events);
-
-    const prepareAll = [];
-    const runAll = [];
 
     for (const [workerId, w] of Object.entries(this.workers)) {
       await this.platform.prepareWorker(workerId, {
@@ -356,6 +370,7 @@ class Launcher {
             payload: this.payload,
             options: this.opts
           });
+        this.workers[workerId].state = STATES.preparing;
     }
     debug('workers prepared');
 
@@ -365,6 +380,7 @@ class Launcher {
     artillery.log('Running scenarios...');
     for (const [workerId, w] of Object.entries(this.workers)) {
       await this.platform.runWorker(workerId, contextVarsString);
+      this.workers[workerId].state = STATES.running;
     }
 
     debug('workers running');

--- a/lib/platform/aws-lambda/index.js
+++ b/lib/platform/aws-lambda/index.js
@@ -197,7 +197,15 @@ class PlatformLambda {
         } else if (body.event === 'phaseStarted' || body.event === 'phaseCompleted') {
           body.id = workerId;
           this.events.emit(body.event, workerId, { phase: body.phase });
+        } else if (body.event === 'workerError') {
+          this.events.emit(body.event, workerId, {
+            id: workerId,
+            error: new Error('A Lambda function has reached its timeout and will be stopped'),
+            level: 'error',
+            aggregatable: false,
+          });
         } else {
+          debug(body);
         }
       }
     });

--- a/lib/platform/aws-lambda/lambda-handler/index.js
+++ b/lib/platform/aws-lambda/lambda-handler/index.js
@@ -2,13 +2,49 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const path = require('path');
+const AWS = require('aws-sdk');
 const { exec } = require('node:child_process');
-const util = require('util');
+const util = require('node:util');
+const { randomUUID } = require('node:crypto');
+
+const TIMEOUT_THRESHOLD_MSEC = 20 * 1000;
 
 async function handler(event, context) {
   const { SQS_QUEUE_URL, SQS_REGION, TEST_RUN_ID, WORKER_ID, ARTILLERY_ARGS, ENV } = event;
   console.log('TEST_RUN_ID: ', TEST_RUN_ID);
+
+  const interval = setInterval(async () => {
+    const timeRemaining = context.getRemainingTimeInMillis();
+
+    if (timeRemaining > TIMEOUT_THRESHOLD_MSEC) {
+      return;
+    }
+
+    const sqs = new AWS.SQS({ region: SQS_REGION });
+    await sqs.sendMessage({
+      QueueUrl: SQS_QUEUE_URL,
+      MessageBody: JSON.stringify({
+        event: 'workerError',
+        reason: 'AWSLambdaTimeout'
+      }),
+      MessageAttributes: {
+        testId: {
+          DataType: 'String',
+          StringValue: TEST_RUN_ID,
+        },
+        workerId: {
+          DataType: 'String',
+          StringValue: WORKER_ID,
+        }
+      },
+      MessageDeduplicationId: randomUUID(),
+      MessageGroupId: TEST_RUN_ID,
+    }).promise();
+
+    clearInterval(interval);
+  }, 5000).unref();
+
+  // TODO: Stop Artillery process - relying on Lambda runtime to shut everything down now
 
   await execArtillery({
     SQS_QUEUE_URL,

--- a/lib/platform/local/artillery-worker-local.js
+++ b/lib/platform/local/artillery-worker-local.js
@@ -6,21 +6,9 @@ const EventEmitter = require('eventemitter3');
 const { Worker } = require('worker_threads');
 const path = require('path');
 
-const awaitOnEE = require('../../util/await-on-ee');
+const STATES = require('../worker-states');
 
-const STATES = {
-  initializing: 1,
-  online: 2,
-  preparing: 3,
-  readyWaiting: 4,
-  running: 5,
-  unknown: 6,
-  stoppedError: 7,
-  completed: 8,
-  stoppedEarly: 9,
-  stoppedFailed: 10,
-  timedout: 11
-};
+const awaitOnEE = require('../../util/await-on-ee');
 
 class ArtilleryWorker {
   constructor(opts) {

--- a/lib/platform/worker-states.js
+++ b/lib/platform/worker-states.js
@@ -1,0 +1,13 @@
+module.exports = {
+  initializing: 1,
+  online: 2,
+  preparing: 3,
+  readyWaiting: 4,
+  running: 5,
+  unknown: 6,
+  stoppedError: 7,
+  completed: 8,
+  stoppedEarly: 9,
+  stoppedFailed: 10,
+  timedout: 11
+};


### PR DESCRIPTION
This change allows the CLI to handle AWS Lambda timeouts gracefully.

A worker Lambda that's about to timeout will send a message to the event bus.The CLI picks up the message and knows not to wait for any more metrics objects from that Lambda.