### PR TITLE
fix(http): fix multiple callbacks on redirects

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -448,7 +448,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           return callback(err, context);
         }
 
-        function requestCallback(err, res, body) {
+        function responseProcessor(err, res, body, done) {
           if (err) {
             return;
           }
@@ -525,7 +525,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                   ee,
                   function (asyncErr) {
                     ee.emit('error', err.message);
-                    return callback(err, context);
+                    return done(err, context);
                   }
                 );
               }
@@ -604,27 +604,24 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                   if (err) {
                     debug(err);
                     ee.emit('error', err.code || err.message);
-                    return callback(err, context);
+                    return done(err, context);
                   }
 
                   if (haveFailedMatches || haveFailedCaptures) {
                     // FIXME: This means only one error in the report even if multiple captures failed for the same request.
-                    return callback(
+                    return done(
                       new Error('Failed capture or match'),
                       context
                     );
                   }
-
-                  return callback(null, context);
+                  return done(null, context);
                 }
               );
             }
           );
         }
 
-        // If we aren't processing the full response, we don't need the
-        // callback:
-        let maybeCallback;
+        let needToProcessResponse = false;
         if (
           typeof requestParams.capture === 'object' ||
           typeof requestParams.match === 'object' ||
@@ -633,7 +630,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             opts.afterResponse.length > 0) ||
           process.env.DEBUG
         ) {
-          maybeCallback = requestCallback;
+          needToProcessResponse = true;
         }
 
         if (!requestParams.url) {
@@ -668,7 +665,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                 res,
                 ee,
                 context,
-                maybeCallback,
+                needToProcessResponse ? responseProcessor : null,
                 callback
               );
             });
@@ -712,7 +709,7 @@ HttpEngine.prototype._handleResponse = function (
   res,
   ee,
   context,
-  maybeCallback,
+  responseProcessor,
   callback
 ) {
   const url = requestParams.url;
@@ -738,7 +735,7 @@ HttpEngine.prototype._handleResponse = function (
     ee.emit('histogram', 'http.tls', res.timings.phases.tls);
   }
   let body = '';
-  if (maybeCallback) {
+  if (responseProcessor) {
     decompressedRes.on('data', (d) => {
       body += d;
     });
@@ -750,21 +747,33 @@ HttpEngine.prototype._handleResponse = function (
     }
 
     context._successCount++;
-    if (!maybeCallback) {
-      // We're done when:
-      // - 3xx response and not following redirects
-      // - not a 3xx response
-      if ((res.statusCode >= 300 && res.statusCode < 400 && !requestParams.followRedirect) ||
-         (res.statusCode < 300 || res.statusCode >= 400)) {
-        callback(null, context);
-      } else {
-        // should not happen, will hang indefinitely
-      }
+
+    if (responseProcessor) {
+      responseProcessor(null, res, body, (processResponseErr) => {
+        if(processResponseErr) {
+          return callback(processResponseErr, context);
+        }
+
+        if (lastRequest(res, requestParams)) {
+          return callback(null, context);
+        }
+      });
     } else {
-      maybeCallback(null, res, body);
+      if(lastRequest(res, requestParams)) {
+        return callback(null, context);
+      }
     }
   });
 };
+
+function lastRequest(res, requestParams) {
+  // We're done when:
+  // - 3xx response and not following redirects
+  // - not a 3xx response
+
+  return ((res.statusCode >= 300 && res.statusCode < 400 && !requestParams.followRedirect) ||
+         (res.statusCode < 300 || res.statusCode >= 400))
+}
 
 HttpEngine.prototype.setInitialContext = function (initialContext) {
   initialContext._successCount = 0;

--- a/test/scripts/with-dotenv/my-vars
+++ b/test/scripts/with-dotenv/my-vars
@@ -1,1 +1,1 @@
-URL=https://www.artillery.io/
+URL=https://www.artillery.io/docs


### PR DESCRIPTION
This PR is a follow up to https://github.com/artilleryio/artillery/commit/9791e3aace66bd58416a6e6ee509f8192240ad9d.

- Refactor the code that processes responses to **not** callback to `async`
- Account for the case when we have a redirect with a request that does not require a response processor

