### PR TITLE
fix: improve error handling in Lambda workers

### DIFF
--- a/lib/platform/aws-lambda/index.js
+++ b/lib/platform/aws-lambda/index.js
@@ -200,7 +200,7 @@ class PlatformLambda {
         } else if (body.event === 'workerError') {
           this.events.emit(body.event, workerId, {
             id: workerId,
-            error: new Error('A Lambda function has reached its timeout and will be stopped'),
+            error: new Error(`A Lambda function has exited with an error. Reason: ${body.reason}`),
             level: 'error',
             aggregatable: false,
           });

--- a/lib/platform/aws-lambda/lambda-handler/index.js
+++ b/lib/platform/aws-lambda/lambda-handler/index.js
@@ -3,15 +3,50 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const AWS = require('aws-sdk');
-const { exec } = require('node:child_process');
+const { spawn } = require('node:child_process');
 const util = require('node:util');
 const { randomUUID } = require('node:crypto');
 
 const TIMEOUT_THRESHOLD_MSEC = 20 * 1000;
 
+class MQ {
+  constructor({ region, queueUrl, attrs } = opts) {
+    this.sqs = new AWS.SQS({ region });
+    this.queueUrl = queueUrl;
+    this.attrs = attrs;
+  }
+
+  async send(body) {
+    const messageAttributes = Object.keys(this.attrs).reduce((acc, key) => {
+      acc[key] = {
+        DataType: 'String',
+        StringValue: this.attrs[key],
+      };
+      return acc;
+    }, {});
+
+    return this.sqs.sendMessage({
+      QueueUrl: this.queueUrl,
+      MessageBody: JSON.stringify(body),
+      MessageAttributes: messageAttributes,
+      MessageDeduplicationId: randomUUID(),
+      MessageGroupId: this.attrs.testId,
+    }).promise();
+  }
+}
+
 async function handler(event, context) {
   const { SQS_QUEUE_URL, SQS_REGION, TEST_RUN_ID, WORKER_ID, ARTILLERY_ARGS, ENV } = event;
   console.log('TEST_RUN_ID: ', TEST_RUN_ID);
+
+  const mq = new MQ({
+    region: SQS_REGION,
+    queueUrl: SQS_QUEUE_URL,
+    attrs: {
+      testId: TEST_RUN_ID,
+      workerId: WORKER_ID,
+    }
+  });
 
   const interval = setInterval(async () => {
     const timeRemaining = context.getRemainingTimeInMillis();
@@ -20,40 +55,33 @@ async function handler(event, context) {
       return;
     }
 
-    const sqs = new AWS.SQS({ region: SQS_REGION });
-    await sqs.sendMessage({
-      QueueUrl: SQS_QUEUE_URL,
-      MessageBody: JSON.stringify({
-        event: 'workerError',
-        reason: 'AWSLambdaTimeout'
-      }),
-      MessageAttributes: {
-        testId: {
-          DataType: 'String',
-          StringValue: TEST_RUN_ID,
-        },
-        workerId: {
-          DataType: 'String',
-          StringValue: WORKER_ID,
-        }
-      },
-      MessageDeduplicationId: randomUUID(),
-      MessageGroupId: TEST_RUN_ID,
-    }).promise();
+    await mq.send({
+      event: 'workerError',
+      reason: 'AWSLambdaTimeout'
+    });
 
     clearInterval(interval);
   }, 5000).unref();
 
   // TODO: Stop Artillery process - relying on Lambda runtime to shut everything down now
 
-  await execArtillery({
-    SQS_QUEUE_URL,
-    SQS_REGION,
-    TEST_RUN_ID,
-    WORKER_ID,
-    ARTILLERY_ARGS,
-    ENV
-  });
+  try {
+    await execArtillery({
+      SQS_QUEUE_URL,
+      SQS_REGION,
+      TEST_RUN_ID,
+      WORKER_ID,
+      ARTILLERY_ARGS,
+      ENV
+    });
+  } catch (err) {
+    console.error(err);
+
+    await mq.send({
+      event: 'workerError',
+      reason: 'StartupFailure'
+    });
+  }
 }
 
 async function execArtillery(options) {;
@@ -66,27 +94,20 @@ async function execArtillery(options) {;
     ENV,
   } = options;
 
-  try {
-    const env = Object.assign({}, process.env, {
-      ARTILLERY_PLUGINS: `{"sqs-reporter":{"region": "${SQS_REGION}"}}`,
-      SQS_TAGS: `[{"key":"testId","value":"${TEST_RUN_ID}"},{"key":"workerId","value":"${WORKER_ID}"}]`,
-      SQS_QUEUE_URL: SQS_QUEUE_URL,
-      SQS_REGION: SQS_REGION,
-      ARTILLERY_DISABLE_ENSURE: 'true',
-      ARTILLERY_DISABLE_TELEMETRY: 'true',
-      // SHIP_LOGS: 'true',
-    }, ENV);
+  const env = Object.assign({}, process.env, {
+    ARTILLERY_PLUGINS: `{"sqs-reporter":{"region": "${SQS_REGION}"}}`,
+    SQS_TAGS: `[{"key":"testId","value":"${TEST_RUN_ID}"},{"key":"workerId","value":"${WORKER_ID}"}]`,
+    SQS_QUEUE_URL: SQS_QUEUE_URL,
+    SQS_REGION: SQS_REGION,
+    ARTILLERY_DISABLE_ENSURE: 'true',
+    ARTILLERY_DISABLE_TELEMETRY: 'true',
+    // SHIP_LOGS: 'true',
+  }, ENV);
 
-    const { stdout, stderr } = await runProcess('/var/lang/bin/node ./node_modules/.bin/artillery', ARTILLERY_ARGS, {
-      env
-    });
-
-    console.log(stdout);
-    console.log(stderr);
-  } catch (err) {
-    console.log('exec error');
-    console.log(err);
-  }
+  await runProcess('/var/lang/bin/node', ['./node_modules/.bin/artillery'].concat(ARTILLERY_ARGS), {
+    env,
+    log: true,
+  });
 }
 
 const sleep = async function(n) {
@@ -97,12 +118,35 @@ const sleep = async function(n) {
   });
 }
 
-// TODO: Replace exec with spawn()
-async function runProcess(name, args, opts) {
-  const execp = util.promisify(exec);
+async function runProcess(name, args, {env, log } = opts) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(name, args, { env });
+    let stdout = '';
+    let stderr = '';
 
-  const { stdout, stderr } = await execp(`${name} ${args.join(' ')}`, { env: opts.env });
-  return { stdout, stderr };
+    proc.stdout.on('data', (data) => {
+      if (log) {
+        console.log(data.toString());
+      }
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      if (log) {
+        console.error(data.toString());
+      }
+
+      stderr += data.toString();
+    });
+
+    proc.once('close', (code) => {
+      resolve({stdout, stderr, code});
+    });
+
+    proc.on('error', (err) => {
+      reject(err);
+    });
+  });
 }
 
 exports.handler = handler;


### PR DESCRIPTION
- Send back a message when the Artillery process can't be started
- Replace `exec` with `spawn` and print Artillery's output as it becomes available to make debugging easier