### PR TITLE
Fix/handle malformed cookiestring response

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -720,10 +720,10 @@ HttpEngine.prototype._handleResponse = function (
     if (rawCookies) {
       context._enableCookieJar = true;
       rawCookies.forEach(function (cookieString) {
-        if (tough.Cookie.parse(cookieString) !== undefined) {
+        try {
           context._jar.setCookieSync(cookieString, url);
-        } else {
-          console.log('Could not parse cookieString from response header, skipping it ' + cookieString);
+        } catch (err) {
+          ee.emit('err', 'Could not parse cookieString from response header, skipping it ' + cookieString);
         }
       });
     }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -720,7 +720,11 @@ HttpEngine.prototype._handleResponse = function (
     if (rawCookies) {
       context._enableCookieJar = true;
       rawCookies.forEach(function (cookieString) {
-        context._jar.setCookieSync(cookieString, url);
+        if (tough.Cookie.parse(cookieString) !== undefined) {
+          context._jar.setCookieSync(cookieString, url);
+        } else {
+          console.log('Could not parse cookieString from response header, skipping it ' + cookieString);
+        }
       });
     }
   }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -724,7 +724,7 @@ HttpEngine.prototype._handleResponse = function (
           context._jar.setCookieSync(cookieString, url);
         } catch (err) {
           debug(`Could not parse cookieString "${cookieString}" from response header, skipping it`);
-          ee.emit('error', 'COOKIE_PARSE_ERROR_INVALID_COOKIE');
+          ee.emit('error', 'cookie_parse_error_invalid_cookie');
         }
       });
     }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -723,7 +723,8 @@ HttpEngine.prototype._handleResponse = function (
         try {
           context._jar.setCookieSync(cookieString, url);
         } catch (err) {
-          ee.emit('error', 'Could not parse cookieString from response header, skipping it ' + cookieString);
+          debug(`Could not parse cookieString "${cookieString}" from response header, skipping it`);
+          ee.emit('error', 'COOKIE_PARSE_ERROR_INVALID_COOKIE');
         }
       });
     }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -723,7 +723,7 @@ HttpEngine.prototype._handleResponse = function (
         try {
           context._jar.setCookieSync(cookieString, url);
         } catch (err) {
-          ee.emit('err', 'Could not parse cookieString from response header, skipping it ' + cookieString);
+          ee.emit('error', 'Could not parse cookieString from response header, skipping it ' + cookieString);
         }
       });
     }

--- a/test/core/scripts/cookies_malformed_response.json
+++ b/test/core/scripts/cookies_malformed_response.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        {"duration": 10, "arrivalRate": 1}
+      ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get": {"url": "/malformed_cookie"}}
+      ]
+    }
+  ]
+}

--- a/test/core/targets/simple.js
+++ b/test/core/targets/simple.js
@@ -211,6 +211,17 @@ function route(server) {
       handler: ok
     }
   ]);
+
+  server.route([
+    {
+      method: 'GET',
+      path: '/malformed_cookie',
+      handler: function (request, h) {
+        return h.response().header('Set-Cookie', '').code(200);
+      }
+    }
+  ]);
+
 }
 
 function ok(req, h) {

--- a/test/core/test_cookies.js
+++ b/test/core/test_cookies.js
@@ -44,8 +44,8 @@ test('cookie jar invalid response', function (t) {
         'There should be some 200s'
       );
       t.ok(
-        report.errors.COOKIE_PARSE_ERROR_INVALID_COOKIE &&
-        report.errors.COOKIE_PARSE_ERROR_INVALID_COOKIE > 0,
+        report.errors.cookie_parse_error_invalid_cookie &&
+        report.errors.cookie_parse_error_invalid_cookie > 0,
         'There shoud be some cookie errors'
       );
       ee.stop().then(() => {

--- a/test/core/test_cookies.js
+++ b/test/core/test_cookies.js
@@ -43,7 +43,6 @@ test('cookie jar invalid response', function (t) {
         report.codes[200] && report.codes[200] > 0,
         'There should be some 200s'
       );
-      t.ok(report.codes[403] === undefined, 'There should be no 403s');
       ee.stop().then(() => {
         t.end();
       });

--- a/test/core/test_cookies.js
+++ b/test/core/test_cookies.js
@@ -8,6 +8,7 @@ const { SSMS } = require('../../core/lib/ssms');
 
 test('cookie jar http', function (t) {
   var script = require('./scripts/cookies.json');
+
   runner(script).then(function (ee) {
     ee.on('done', function (nr) {
       const report = SSMS.legacyReport(nr).report();
@@ -28,6 +29,24 @@ test('cookie jar http', function (t) {
         .catch((err) => {
           t.fail(err);
         });
+    });
+    ee.run();
+  });
+});
+
+test('cookie jar invalid response', function (t) {
+  var script = require('./scripts/cookies_malformed_response.json');
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+      t.ok(
+        report.codes[200] && report.codes[200] > 0,
+        'There should be some 200s'
+      );
+      t.ok(report.codes[403] === undefined, 'There should be no 403s');
+      ee.stop().then(() => {
+        t.end();
+      });
     });
     ee.run();
   });

--- a/test/core/test_cookies.js
+++ b/test/core/test_cookies.js
@@ -43,6 +43,11 @@ test('cookie jar invalid response', function (t) {
         report.codes[200] && report.codes[200] > 0,
         'There should be some 200s'
       );
+      t.ok(
+        report.errors.COOKIE_PARSE_ERROR_INVALID_COOKIE &&
+        report.errors.COOKIE_PARSE_ERROR_INVALID_COOKIE > 0,
+        'There shoud be some cookie errors'
+      );
       ee.stop().then(() => {
         t.end();
       });


### PR DESCRIPTION
See [this comment](https://github.com/artilleryio/artillery/issues/1536#issuecomment-1194431927)

tldr: handles malformed cookies received through a response Set-Cookie header
closes ART-574