### PR TITLE
fix(http): prevent multiple callbacks when a capture/match fails

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -221,6 +221,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
   let f = function (context, callback) {
     // Previous request had an error of the kind that should stop current VU
     if (context.error) {
+      ee.emit('error', err.message || err.code);
       return callback(context.error, context);
     }
 
@@ -833,7 +834,6 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
 
     async.waterfall(steps, function scenarioWaterfallCb(err, context) {
       if (err) {
-        ee.emit('error', err.message);
         return callback(err, context);
       } else {
         return callback(null, context);


### PR DESCRIPTION
Fixes #1542 