### PR TITLE
fix(http): handle response decompression properly

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -713,10 +713,10 @@ HttpEngine.prototype._handleResponse = function (
   callback
 ) {
   const url = requestParams.url;
-  const decompressedRes = decompressResponse(res);
-  let code = decompressedRes.statusCode;
+  res = decompressResponse(res);
+  let code = res.statusCode;
   if (!context._enableCookieJar) {
-    const rawCookies = decompressedRes.headers['set-cookie'];
+    const rawCookies = res.headers['set-cookie'];
     if (rawCookies) {
       context._enableCookieJar = true;
       rawCookies.forEach(function (cookieString) {
@@ -736,7 +736,7 @@ HttpEngine.prototype._handleResponse = function (
   }
   let body = '';
   if (responseProcessor) {
-    decompressedRes.on('data', (d) => {
+    res.on('data', (d) => {
       body += d;
     });
   }


### PR DESCRIPTION
Almost the same thing as https://github.com/artilleryio/artillery/pull/999

Since we are using `decompressResponse` and `on('data')` is added to it, `on('end')` should also be executed on the decompressResponse... but it is being executed on raw response causing a race condition, so when response end happens, response data didn't happen yet, and we end up with empty body string.

This PR makes the handle response use decompressResponse for everything instead of mixing raw response object and the decompress response object.

Fixes https://github.com/artilleryio/artillery/issues/1562