### PR TITLE
fix: redirect chains with capture/afterResponse hooks

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -823,7 +823,7 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
       try {
         context = await promisify(task)(context);
       } catch (taskErr) {
-        ee.emit('error', taskErr);
+        ee.emit('error', taskErr.code || taskErr.message);
         return callback(taskErr, context); // calling back for now for existing client code
       }
     }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -573,7 +573,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                   let processFunc = config.processor[fn];
                   if (!processFunc) {
                     // TODO: DRY - #223
-                    processFunc = function (r, c, e, cb) {
+                    processFunc = function (r, res, c, e, cb) {
                       return cb(null);
                     };
                     console.log(

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -106,7 +106,7 @@ function HttpEngine(script) {
 
   if (
     (script.config.http && script.config.http.extendedMetrics === true) ||
-    global.artillery.runtimeOptions.extendedHTTPMetrics
+    global.artillery?.runtimeOptions.extendedHTTPMetrics
   ) {
     this.extendedHTTPMetrics = true;
   }

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -334,9 +334,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         // Follow all redirects by default unless specified otherwise
         if (typeof requestParams.followRedirect === 'undefined') {
           requestParams.followRedirect = true;
-          requestParams.followAllRedirects = true;
-        } else if (requestParams.followRedirect === false) {
-          requestParams.followAllRedirects = false;
         }
 
         // TODO: Use traverse on the entire flow instead

--- a/test/core/unit/engine_http.test.js
+++ b/test/core/unit/engine_http.test.js
@@ -610,7 +610,17 @@ test('HTTP engine', function (tap) {
       },
       scenarios: [
         {
-          flow: [{ get: { url: '/foo' } }]
+          flow: [
+            {
+              get: {
+                url: '/foo',
+                capture: {
+                  json: '$',
+                  as: 'jsonBody'
+                }
+              }
+            }
+          ]
         }
       ]
     };


### PR DESCRIPTION
This PR improves our handling of redirect chains.

We currently run response processors on every response, so e.g. a `capture` can fail for the first response but succeed for the second response, leading to multiple callbacks to `async.waterfall` being invoked.

This PR changes the logic to only run response processors on the last request in the chain.

It also refactors the code to get rid of `async.waterfall`.