### PR TITLE
feat: allow customization of cookie parsing behavior

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -79,6 +79,14 @@ function HttpEngine(script) {
     this.config.defaults = {};
   }
 
+  if (typeof this.config.http === 'undefined') {
+    this.config.http = {};
+  }
+
+  if(typeof this.config.http.cookieJarOptions === 'undefined') {
+    this.config.http.cookieJarOptions = {};
+  };
+
   // If config.http.pool is set, create & reuse agents for all requests (with
   // max sockets set). That's what we're done here.
   // If config.http.pool is not set, we create new agents for each virtual user.
@@ -710,6 +718,7 @@ HttpEngine.prototype._handleResponse = function (
           context._jar.setCookieSync(cookieString, url);
         } catch (err) {
           debug(`Could not parse cookieString "${cookieString}" from response header, skipping it`);
+          debug(err);
           ee.emit('error', 'cookie_parse_error_invalid_cookie');
         }
       });
@@ -775,8 +784,8 @@ HttpEngine.prototype.setInitialContext = function (initialContext) {
   initialContext._successCount = 0;
 
   initialContext._defaultStrictCapture = this.config.defaults.strictCapture;
+  initialContext._jar = new tough.CookieJar(null, this.config.http.cookieJarOptions);
 
-  initialContext._jar = new tough.CookieJar();
   initialContext._enableCookieJar = false;
   // If a default cookie is set, we will use the jar straightaway:
   if (typeof this.config.defaults.cookie === 'object') {

--- a/test/core/test_cookies.js
+++ b/test/core/test_cookies.js
@@ -56,6 +56,30 @@ test('cookie jar invalid response', function (t) {
   });
 });
 
+test('setting cookie jar parsing options', function (t) {
+  var script = require('./scripts/cookies_malformed_response.json');
+  Object.assign(script.config, { http: { cookieJarOptions: { looseMode: true } }});
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+      t.ok(
+        report.codes[200] && report.codes[200] > 0,
+        'There should be some 200s'
+      );
+
+      t.ok(
+        Object.keys(report.errors).length === 0,
+        'There shoud be no errors'
+      );
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
 test('cookie jar socketio', function (t) {
   var script = require('./scripts/cookies_socketio.json');
   runner(script).then(function (ee) {


### PR DESCRIPTION
config.http.cookieJarOptions may be set to customize the behavior
of the underlying ToughCookie instance.

See available options in ToughCookie docs:

https://github.com/salesforce/tough-cookie#cookiejarstore-options