### PR TITLE
fix: rampTo behaviour when arrivalRate is less than amount of workers

### DIFF
--- a/core/lib/phases.js
+++ b/core/lib/phases.js
@@ -94,7 +94,7 @@ function createPause(spec, ee) {
 
 function createRamp(spec, ee) {
   const duration = spec.duration || 1;
-  const arrivalRate = spec.arrivalRate || 1;
+  const arrivalRate = spec.arrivalRate || 0;
   const rampTo = spec.rampTo || arrivalRate + 1;
 
   const tick = 1000 / Math.max(arrivalRate, rampTo); // smallest tick

--- a/lib/dist.js
+++ b/lib/dist.js
@@ -30,7 +30,11 @@ function divideWork(script, numWorkers) {
       });
     }
 
-    if (phase.arrivalRate && phase.rampTo) {
+    if (phase.rampTo) {
+      // same behaviour as a single worker. Now we support scripts
+      // with rampTo and no arrivalRate
+      phase.arrivalRate = phase.arrivalRate || 0;
+
       let rates = distribute(phase.arrivalRate, numWorkers);
       let ramps = distribute(phase.rampTo, numWorkers);
       L.each(rates, function (Lr, i) {

--- a/test/core/unit/dist.test.js
+++ b/test/core/unit/dist.test.js
@@ -2,7 +2,6 @@
 
 const tap = require('tap');
 const divideWork = require('../../../lib/dist');
-const isIdlePhase = require('../../../core/lib/is-idle-phase');
 
 
 tap.test('divideWork', (t) => {

--- a/test/core/unit/dist.test.js
+++ b/test/core/unit/dist.test.js
@@ -2,6 +2,8 @@
 
 const tap = require('tap');
 const divideWork = require('../../../lib/dist');
+const isIdlePhase = require('../../../core/lib/is-idle-phase');
+
 
 tap.test('divideWork', (t) => {
   const numWorkers = 5;
@@ -83,5 +85,33 @@ tap.test('set max vusers', (t) => {
   const actualVusers = phases.reduce((partialSum, phase) =>
     partialSum + phase.config.phases[0].maxVusers, 0);
   t.equal(script.config.phases[0].maxVusers, actualVusers);
+  t.end();
+});
+
+tap.test('arrivalRate defaults to zero if not present', (t) => {
+  const numWorkers = 5;
+  const script = {
+    config: {
+      target: 'http://targ.get.url',
+      phases: [{ name: 'rampto', duration: 10, rampTo: 25 }]
+    },
+    scenarios: [
+      {
+        flow: [
+          {
+            get: {
+              url: '/'
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  const phases = divideWork(script, numWorkers);
+  const totalArrivalRate = phases.reduce((partialSum, phase) =>
+    partialSum + phase.config.phases[0].arrivalRate, 0);
+
+  t.equal(totalArrivalRate, 0);
   t.end();
 });

--- a/test/core/unit/phases.test.js
+++ b/test/core/unit/phases.test.js
@@ -68,6 +68,21 @@ test('pause', function (t) {
   phaser.run();
 });
 
+test('rampTo with no arrivalRate defaults to 0', function (t) {
+  const phaseSpec = { rampTo: 5, arrivalRate: 0 };
+
+  t.plan(1);
+  let phaser = createPhaser([phaseSpec]);
+  phaser.on('phaseStarted', function (spec) {
+    t.ok(
+      _.isEqual(spec.arrivalRate, 0),
+      'arrivalRate starts as zero'
+    );
+  t.end();
+  });
+  phaser.run();
+});
+
 test('arrivalCount', function (t) {
   const phaseSpec = {
     duration: 10,
@@ -225,3 +240,4 @@ function testRamp(t, phaseSpec) {
   startedAt = Date.now();
   phaser.run();
 }
+

--- a/test/core/unit/phases.test.js
+++ b/test/core/unit/phases.test.js
@@ -68,7 +68,7 @@ test('pause', function (t) {
   phaser.run();
 });
 
-test('rampTo with no arrivalRate defaults to 0', function (t) {
+test('arrivalRate set to 0 stays at 0', function (t) {
   const phaseSpec = { rampTo: 5, arrivalRate: 0 };
 
   t.plan(1);


### PR DESCRIPTION
See #1589.
Setting an arrival rate lower than the workers being user to run the test, resulted in `rampTo` property being distributed across all workers alongside an incorrect value for `arrivalRate`

This generated an unexpected distribution of requests:
The root cause for this is that having a `rampTo` and no `arrivalRate`, defaulted to `arrivalRate` being 1.
Example:
using `arrivalRate:1; rampTo:25` and running with 7 workers resulted in:

arrival rate distribution for each worker:
```
[
  1, 0, 0, 0, 0, 0, 0
]
```

rampTo distribution for each worker:
```
[
  4, 4, 4, 4, 3, 3, 3
]
```

When this got to the execution logic, arrival rate was being updated to 1 [here](https://github.com/artilleryio/artillery/blob/master/core/lib/phases.js) causing the initial load to be higher than expected, so effective arrival rates were actually:
```
[
  1, 1, 1, 1, 1, 1, 1 // 0s -> 1s
]
```


After the update we remove 1 as default  `arrivalRate`, avoiding the initial spike and still getting the most out of available threads.
Still worth mentioning that for smaller numbers setting `WORKERS=1` may be desired to have a more controlled behavior.