### PR TITLE
fix: test with no explicit phases do not create final report in distributed mode

### DIFF
--- a/core/lib/is-idle-phase.js
+++ b/core/lib/is-idle-phase.js
@@ -6,7 +6,8 @@ function isIdlePhase(phase) {
   return (
     (phase.arrivalRate === 0 && !phase.rampTo) ||
     phase.arrivalCount === 0 ||
-    phase.maxVusers === 0
+    phase.maxVusers === 0 ||
+    phase.pause > 0
   );
 }
 

--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -200,14 +200,11 @@ function run(script, ee, options, runState, contextVars) {
   });
   phaser.on('phaseStarted', function (spec) {
     ee.emit('phaseStarted', spec);
-    // if (isIdlePhase(spec)) {
-    //   ee.emit('stats', SSMS.empty());
-    // }
+    if (spec.pause > 0) {
+      ee.emit('stats', SSMS.empty());
+    }
   });
   phaser.on('phaseCompleted', function (spec) {
-    // if (isIdlePhase(spec)) {
-    //   ee.emit('stats', SSMS.empty());
-    // }
     ee.emit('phaseCompleted', spec);
   });
   phaser.on('done', function () {

--- a/core/lib/runner.js
+++ b/core/lib/runner.js
@@ -200,12 +200,15 @@ function run(script, ee, options, runState, contextVars) {
   });
   phaser.on('phaseStarted', function (spec) {
     ee.emit('phaseStarted', spec);
-    if (spec.pause > 0) {
+    if (isIdlePhase(spec)) {
       ee.emit('stats', SSMS.empty());
     }
   });
   phaser.on('phaseCompleted', function (spec) {
     ee.emit('phaseCompleted', spec);
+    if (isIdlePhase(spec)) {
+      ee.emit('stats', SSMS.empty());
+    }
   });
   phaser.on('done', function () {
     debug('All phases launched');


### PR DESCRIPTION
Stat aggregation waits for all workers to emit the `stats`, but sleeping workers did not.
If this happened in the last phase of the test, there was a race condition where one possible scenario was the test ending before final report was printed.

Added emit to sleeping worker phases, refactored `isIdlePhase` so that sleeping workers are not taken into account as needed workers to build report.
  - Short tests are going to emit the final report properly as we get rid of the race condition where report aggregation and app shutdown are competing
  - Short tests are going to finish sooner (3-4s in my machine but its tied to number of workers)
Closes ART-642