### PR TITLE
fix flaky test 

### DIFF
--- a/test/scripts/ramp.json
+++ b/test/scripts/ramp.json
@@ -2,7 +2,7 @@
   "config": {
     "target": "http://localhost:3003",
     "phases": [
-      {"duration": 10, "arrivalRate": 1, "rampTo": 10 }
+      {"duration": 2, "arrivalRate": 6, "rampTo": 1 }
     ]
   },
   "scenarios": [

--- a/test/testcases/command-run.bats
+++ b/test/testcases/command-run.bats
@@ -112,7 +112,10 @@
     [[ $status -eq 1 ]]
 }
 
-@test "Ramp up script throughput does not depend on workers" {
+@test "Ramp to script throughput behaves as expected running on multiple workers" {
+    # This would cause older versions of artillery to generate much more traffic than expected
+    # We compare them to the max amount of arrivals we expect from the script
+    # Note: v2.0.0-22 generates 20+ arrivals, almost double
     ./bin/run run -o multiple_workers.json test/scripts/ramp.json
     WORKERS=1 ./bin/run run -o single_worker.json test/scripts/ramp.json
 
@@ -122,12 +125,7 @@
     rm multiple_workers.json
     rm single_worker.json
 
-    expected=55
-    single_diff=$((single_count-expected))
-    single_diff_abs=${single_diff#-}
+    max_expected=11
 
-    multiple_diff=$((multiple_count-expected))
-    multiple_diff_abs=${multiple_diff#-}
-
-    [[ $multiple_diff_abs -le 11 && $single_diff_abs -le 11 ]]
+    [[ $multiple_count -le $max_expected && $single_count -le $max_expected ]]
 }


### PR DESCRIPTION
Update script to reflect a case which caused previous versions to send abnormal traffic (v2.0.0-22 for example)
Check against that particular case so it can run independently of ramp probability

<!-- Closes ART-691 -->
