### PR TITLE
fix(console-reporter): count elapsed time from first recorded metric

### DIFF
--- a/lib/console-reporter.js
+++ b/lib/console-reporter.js
@@ -35,7 +35,7 @@ function ConsoleReporter(opts) {
   this.spinner.start();
 
   this.reportScenarioLatency = !!opts.reportScenarioLatency;
-  this.startTime = Date.now();
+  this.startTime = null;
 
   let self = this;
 
@@ -105,6 +105,10 @@ ConsoleReporter.prototype.phaseCompleted = function phaseCompleted(phase) {
 ConsoleReporter.prototype.stats = function stats(data) {
   if (this.quiet) {
     return this;
+  }
+
+  if (!this.startTime) {
+    this.startTime = data.firstMetricAt || Date.now();
   }
 
   // NOTE: histograms property is available and contains raw


### PR DESCRIPTION
This fixes the issue where Artillery reports an elapsed time that's longer than the actual running time of all VUs in the test.

This is particularly noticeable for short tests (say under 30s) running on AWS Lambda with a large number of workers. The time it takes to spin everything up for the test can be considerably longer than the running time of VUs, making the reported elapsed time particularly surprising.