### PR TITLE
feat: use a pool of SQS consumers

### DIFF
--- a/lib/platform/aws-lambda/index.js
+++ b/lib/platform/aws-lambda/index.js
@@ -20,7 +20,7 @@ const AWS = require('aws-sdk');
 
 const https = require('https');
 
-const { Consumer } = require('sqs-consumer');
+const { QueueConsumer } = require('../../queue-consumer');
 
 const { createBOM } = require('../../create-bom/create-bom');
 
@@ -210,83 +210,99 @@ class PlatformLambda {
 
     const self = this;
 
-    const consumer = Consumer.create({
-      queueUrl: process.env.SQS_QUEUE_URL || this.sqsQueueUrl,
-      region: this.region,
-      waitTimeSeconds: 10,
-      messageAttributeNames: ['testId', 'workerId'],
-      visibilityTimeout: 60,
-      batchSize: 10,
-      sqs: new AWS.SQS({
-        httpOptions: {
-          agent: new https.Agent({
-            keepAlive: true
-          })
-        },
-        region: this.region
-      }),
-      handleMessage: async (message) => {
-        let body = null;
-        try {
-          body = JSON.parse(message.Body);
-        } catch (err) {
-          console.error(err);
-          console.log(message.Body);
-        }
+    const consumer = new QueueConsumer();
+    consumer.create(
+      {
+        poolSize: Math.min(self.platformOpts.count, 100)
+      },
+      {
+        queueUrl: process.env.SQS_QUEUE_URL || this.sqsQueueUrl,
+        region: this.region,
+        waitTimeSeconds: 10,
+        messageAttributeNames: ['testId', 'workerId'],
+        visibilityTimeout: 60,
+        batchSize: 10,
+        sqs: new AWS.SQS({
+          httpOptions: {
+            agent: new https.Agent({
+              keepAlive: true
+            })
+          },
+          region: this.region
+        }),
+        handleMessage: async (message) => {
+          let body = null;
+          try {
+            body = JSON.parse(message.Body);
+          } catch (err) {
+            console.error(err);
+            console.log(message.Body);
+          }
 
-        //
-        // Ignore any messages that are invalid or not tagged properly.
-        //
+          //
+          // Ignore any messages that are invalid or not tagged properly.
+          //
 
-        if(process.env.LOG_SQS_MESSAGES) {
-          console.log(message);
-        }
+          if (process.env.LOG_SQS_MESSAGES) {
+            console.log(message);
+          }
 
-        if (!body) {
-          throw new Error('SQS message with empty body');
-        }
+          if (!body) {
+            throw new Error('SQS message with empty body');
+          }
 
-        const attrs = message.MessageAttributes;
-        if (!attrs || !attrs.testId || !attrs.workerId) {
-          throw new Error('SQS message with no testId or workerId');
-        }
+          const attrs = message.MessageAttributes;
+          if (!attrs || !attrs.testId || !attrs.workerId) {
+            throw new Error('SQS message with no testId or workerId');
+          }
 
-        if (self.testRunId !== attrs.testId.StringValue) {
-          throw new Error('SQS message for an unknown testId');
-        }
+          if (self.testRunId !== attrs.testId.StringValue) {
+            throw new Error('SQS message for an unknown testId');
+          }
 
-        const workerId = attrs.workerId.StringValue;
+          const workerId = attrs.workerId.StringValue;
 
-        if (body.event === 'workerStats') {
-          this.events.emit('stats', workerId, body); // event consumer accesses body.stats
-        } else if (body.event === 'artillery.log') {
-          console.log(body.log);
-        } else if (body.event === 'done') {
-          // 'done' handler in Launcher exects the message argument to have an "id" and "report" fields
-          body.id = workerId;
-          body.report = body.stats; // Launcher expects "report", SQS reporter sends "stats"
-          this.events.emit('done', workerId, body);
-        } else if (body.event === 'phaseStarted' || body.event === 'phaseCompleted') {
-          body.id = workerId;
-          this.events.emit(body.event, workerId, { phase: body.phase });
-        } else if (body.event === 'workerError') {
-          this.events.emit(body.event, workerId, {
-            id: workerId,
-            error: new Error(`A Lambda function has exited with an error. Reason: ${body.reason}`),
-            level: 'error',
-            aggregatable: false,
-            logs: body.logs,
-          });
-        } else {
-          debug(body);
+          if (body.event === 'workerStats') {
+            this.events.emit('stats', workerId, body); // event consumer accesses body.stats
+          } else if (body.event === 'artillery.log') {
+            console.log(body.log);
+          } else if (body.event === 'done') {
+            // 'done' handler in Launcher exects the message argument to have an "id" and "report" fields
+            body.id = workerId;
+            body.report = body.stats; // Launcher expects "report", SQS reporter sends "stats"
+            this.events.emit('done', workerId, body);
+          } else if (
+            body.event === 'phaseStarted' ||
+            body.event === 'phaseCompleted'
+          ) {
+            body.id = workerId;
+            this.events.emit(body.event, workerId, { phase: body.phase });
+          } else if (body.event === 'workerError') {
+            this.events.emit(body.event, workerId, {
+              id: workerId,
+              error: new Error(
+                `A Lambda function has exited with an error. Reason: ${body.reason}`
+              ),
+              level: 'error',
+              aggregatable: false,
+              logs: body.logs
+            });
+          } else {
+            debug(body);
+          }
         }
       }
-    });
+    );
 
     let queueEmpty = 0;
 
-    consumer.on('error', (err) => { artillery.log(err) });
-    consumer.on('empty', (err) => { debug('queueEmpty:', queueEmpty); queueEmpty++; });
+    consumer.on('error', (err) => {
+      artillery.log(err);
+    });
+    consumer.on('empty', (err) => {
+      debug('queueEmpty:', queueEmpty);
+      queueEmpty++;
+    });
 
     consumer.start();
 

--- a/lib/queue-consumer/index.js
+++ b/lib/queue-consumer/index.js
@@ -1,0 +1,57 @@
+const { EventEmitter } = require('eventemitter3');
+const debug = require('debug')('queue-consumer');
+const { Consumer } = require('sqs-consumer');
+
+class QueueConsumer extends EventEmitter {
+  create(opts = { poolSize: 30 }, queueConsumerOpts) {
+    this.events = new EventEmitter();
+
+    this.consumers = [];
+
+    for (let i = 0; i < opts.poolSize; i++) {
+      const sqsConsumer = Consumer.create(queueConsumerOpts);
+
+      sqsConsumer.on('error', (err) => {
+        // TODO: Ignore "SQSError: SQS delete message failed:" errors
+
+        if (err.message && err.message.match(/ReceiptHandle.+expired/i)) {
+          debug(err.name, err.message);
+        } else {
+          sqsConsumer.stop();
+          this.emit('error', err);
+        }
+      });
+
+      let empty = 0;
+      sqsConsumer.on('empty', () => {
+        empty++;
+        if (empty > 10) {
+          this.emit('messageReceiveTimeout'); // TODO:
+        }
+      });
+
+      this.consumers.push(sqsConsumer);
+    }
+
+    return this;
+  }
+
+  constructor(opts) {
+    super();
+    return this;
+  }
+
+  start() {
+    for (const consumer of this.consumers) {
+      consumer.start();
+    }
+  }
+
+  stop() {
+    for (const consumer of this.consumers) {
+      consumer.stop();
+    }
+  }
+}
+
+module.exports = { QueueConsumer };


### PR DESCRIPTION
Create a pool of SQS consumers instead of just one. This leads to a speed up when processing messages in load tests with many (50+) workers.