### PR TITLE
fix: wildcard added to catch socket events

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -8,6 +8,7 @@ const async = require('async');
 const _ = require('lodash');
 
 const io = require('socket.io-client');
+const wildcardPatch = require('socketio-wildcard')(io.Manager);
 
 const deepEqual = require('fast-deep-equal');
 const debug = require('debug')('socketio');
@@ -301,6 +302,7 @@ SocketIoEngine.prototype.loadContextSocket = function (namespace, context, cb) {
 
     const socket = io(target, options);
     context.sockets[namespace] = socket;
+    wildcardPatch(socket);
 
     socket.onAny(() => {
       context.__receivedMessageCount++;


### PR DESCRIPTION
Support of this package https://www.npmjs.com/package/socketio-wildcard given only for socket V1 and V2 but it's also working for socket V3 and V4. Without this package we can't catch event with socket.on('*', callback).
Tested this on my machine.