### PR TITLE
test(lambda): fix test check

### DIFF
--- a/packages/artillery/test/cli/run-lambda.test.js
+++ b/packages/artillery/test/cli/run-lambda.test.js
@@ -35,6 +35,6 @@ tap.test('Run a test on AWS Lambda', async (t) => {
   ]);
 
   t.ok(
-    stdout.indexOf('Summary report') > 0 && stdout.indexOf('http.codes.200' > 0)
+    stdout.indexOf('Summary report') > 0 && stdout.indexOf('http.codes.200') > 0
   );
 });


### PR DESCRIPTION
fix typo on lambda test
- lambda runs are throwing an error but it wasn't getting caught in CI
  - `A Lambda function has exited with an error. Reason: ArtilleryError` (but was still printing the summary)
- source: `an update to int-core on main hasn't been published to npm`
When that is fixed this should run properly 