### PR TITLE
refactor(ramp): deterministic version

### DIFF
--- a/packages/artillery/lib/dist.js
+++ b/packages/artillery/lib/dist.js
@@ -28,8 +28,8 @@ function divideWork(script, numWorkers) {
       // with rampTo and no arrivalRate
       phase.arrivalRate = phase.arrivalRate || 0;
 
-      let rates = distribute(phase.arrivalRate, numWorkers);
-      let ramps = distribute(phase.rampTo, numWorkers);
+      let rates = distributeEven(phase.arrivalRate, numWorkers);
+      let ramps = distributeEven(phase.rampTo, numWorkers);
       let activeWorkers = Math.max(rates.filter(r => r > 0).length, ramps.filter(r => r > 0).length);
       let maxVusers = phase.maxVusers ? distribute(phase.maxVusers, activeWorkers) : false;
       L.each(rates, function (Lr, i) {
@@ -108,12 +108,32 @@ function divideWork(script, numWorkers) {
     }
   }
 
+  let activeWorkers = 1;
+  result.forEach(r => {
+    r.config.phases.forEach(p => {
+      p.totalWorkers = result.length;
+    p.worker = activeWorkers;
+    }),
+    activeWorkers++;
+  });
+
   return result;
 }
 
 /**
  * Given M "things", distribute them between N peers as equally as possible
  */
+function distributeEven(m, n){
+  m = Number(m);
+  n = Number(n);
+  let result = [];
+  for (let i = 0; i < n; i++) {
+    result.push(m/n);
+  }
+
+  return result;
+}
+
 function distribute(m, n) {
   m = Number(m);
   n = Number(n);

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -251,7 +251,7 @@ tap.test(
   async (t) => {
     // This would cause older versions of artillery to generate much more traffic than expected
     // We compare them to the max amount of arrivals we expect from the script # Note: v2.0.0-22 generates 20+ arrivals, almost double
-    const arrivalUpperBound = 11;
+    const totalRequests = 7;
 
     const reportMultipleFile = 'multiple_workers.json';
     const reportMultipleFilePath = await getRootPath(reportMultipleFile);
@@ -281,8 +281,8 @@ tap.test(
         deleteFile(reportSingleFilePath) &&
         exitCodeMultiple === 0 &&
         exitCodeSingle === 0 &&
-        multipleCount <= arrivalUpperBound &&
-        singleCount <= arrivalUpperBound
+        multipleCount === totalRequests &&
+        singleCount === totalRequests
     );
   }
 );

--- a/packages/core/lib/phases.js
+++ b/packages/core/lib/phases.js
@@ -94,7 +94,6 @@ function createPause(spec, ee) {
 }
 
 function createRamp(spec, ee) {
-  const FRACTIONAL_CORRECTION = 1.1;
   const duration = spec.duration || 1;
   const arrivalRate = spec.arrivalRate;
   const rampTo = spec.rampTo;
@@ -123,9 +122,8 @@ function createRamp(spec, ee) {
       periodArrivals[i] = Math.floor(rawPeriodArrivals);
 
       // Think of fractionalPart * workers as the amount of arrivals that could not be
-      // shared evenly across all workers. Multiplier is used to adress fraction precision
-      // i.e: (X.3333333333 % 1) * 3 < 1
-      if ((rawPeriodArrivals % 1) * totalWorkers * FRACTIONAL_CORRECTION >= worker) {
+      // shared evenly across all workers.
+      if (Math.round((rawPeriodArrivals % 1) * totalWorkers) >= worker) {
         periodArrivals[i] = periodArrivals[i] + 1;
       }
 


### PR DESCRIPTION
Refactor rampTo logic to be deterministic. This means: no more probability is used.

Total requests are now equal to: duration * (rampto+arrivalRate)/2
Arrivals for each second of a phase are calculated beforehand and ticks adjusted to reach desired throughput.

Arrivals are distributed evenly across all workers.

Explanation: given a second where 4 workers generate 5 arrivals:
 - Each worker:
   -   gets 1.25 'arrivals' for that period
   -   sets the current arrival as 1 (as .XX arrivals are not a thing)
   -   based on the pending 0.25 each worker determines if it needs to add an extra arrival:
         rest >= 0.25 -> worker1 bumps rate by one
         rest >= 0.50 -> worker2 bumps rate by one
         rest >= 0.75 -> worker3 bumps rate by one
So every 'extra' arrival results in a worker taking 'ownership' of it. Again, the minimum step being +/- 1 arrival from one period (1s) to the next. In this case only the first worker bumps its arrivalRate to 2. So we end up with 5 arrivals distributed like: 2 + 1 + 1 +1


Examples:
1to2 in 200 s:
old (random bumps to 2): 
<img width="325" alt="image" src="https://user-images.githubusercontent.com/102969687/208499626-2c00eb68-2836-482d-aaaa-8575b9310d3a.png">
new:
![image](https://user-images.githubusercontent.com/102969687/208499398-d784075c-9266-4584-91d8-ea68d68a7af6.png)

total requests example: 
![image](https://user-images.githubusercontent.com/102969687/208499745-5c772ae0-e595-44cc-b4fb-2d9dd2a2bdb6.png)

Small increments:
![image](https://user-images.githubusercontent.com/102969687/208500207-fe165b32-b97f-4011-9fe0-60b6a91245c1.png)
(Edge cases are shorter in duration due to rounding)
