### PR TITLE
fix(lamda): replace hardcoded memorySize with actual parameter

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -652,7 +652,7 @@ class PlatformLambda {
       FunctionName: functionName,
       Description: 'Artillery.io test',
       Handler: 'index.handler',
-      MemorySize: 4096,
+      MemorySize: this.memorySize,
       PackageType: 'Zip',
       Runtime: 'nodejs16.x',
       Architectures: [this.architecture],


### PR DESCRIPTION
Lambda:
Now follows `memory-size` obtained from user (still defaults to 4096 if no option present).

```
artillery run
 --platform aws:lambda 
 ...
 --platform-opt memory-size=2048 hello.yaml
```
Results in the following lambda properties:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/102969687/207699677-2ead9619-a6d1-4a7e-8392-aca7a0f6d9f3.png">

