### PR TITLE
Package publishing with GitHub Actions

### DIFF
--- a/.github/workflows/npm-publish-artillery.yml
+++ b/.github/workflows/npm-publish-artillery.yml
@@ -1,0 +1,24 @@
+name: Publish Artillery CLI to npm
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/artillery/package.json
+jobs:
+  build:
+    if: "contains(github.event.head_commit.message, 'ci: release v')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@artilleryio'
+      - run: npm -w artillery publish --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Existing CircleCI-based workflow won't work with the new monorepo
structure anymore, as it relies on pushing a tag, and is not
monorepo-aware.

This action will run when all of the following conditions are met:

1. Branch is "main"
2. Commit message starts with: "ci: release v", e.g.: "ci: release v1.2.3"
3. The commit modifies packages/artillery/package.json