### PR TITLE
fix: update 'commons' dependency to '@artilleryio/int-commons'

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "main": "./index.js",
   "dependencies": {
+    "@artilleryio/int-commons": "latest",
     "@artilleryio/sketches-js": "^1.0.4",
     "@hapi/basic": "^6.0.0",
     "agentkeepalive": "^4.1.0",
@@ -10,7 +11,6 @@
     "async": "^2.6.4",
     "chalk": "^2.4.2",
     "cheerio": "^1.0.0-rc.10",
-    "commons": "*",
     "cookie-parser": "^1.4.3",
     "csv-parse": "^4.16.3",
     "debug": "^4.3.1",


### PR DESCRIPTION
To be honest I'm not 100% sure this is the right change, but when installing artillary globally (in my CI), it errors out with 
```
error Couldn't find any versions for "commons" that matches "*"
```

I cannot imagine that you really wanted to load [this library](https://www.npmjs.com/package/commons), but rather reference your own.  