### PR TITLE
Issue 1522 expect plugin feature

### DIFF
--- a/packages/artillery-plugin-expect/lib/expectations.js
+++ b/packages/artillery-plugin-expect/lib/expectations.js
@@ -11,6 +11,7 @@ const _ = require('lodash');
 module.exports = {
   contentType: expectContentType,
   statusCode: expectStatusCode,
+  notStatusCode: expectNotStatusCode,
   hasHeader: expectHasHeader,
   headerEquals: expectHeaderEquals,
   hasProperty: expectHasProperty,
@@ -187,6 +188,27 @@ function expectStatusCode(expectation, body, req, res, userContext) {
     result.ok = expectedStatusCode.filter(x => Number(res.statusCode) === Number(x)).length > 0;
   } else {
     result.ok = Number(res.statusCode) === Number(expectedStatusCode);
+  }
+
+  result.got = res.statusCode;
+  return result;
+}
+
+function expectNotStatusCode(expectation, body, req, res, userContext) {
+  debug('check notStatusCode');
+
+  const expectedNotStatusCode = template(expectation.notStatusCode, userContext);
+
+  let result = {
+    ok: false,
+    expected: `Status code different than ${expectedNotStatusCode}`,
+    type: 'notStatusCode',
+  };
+
+  if (Array.isArray(expectedNotStatusCode)) {
+    result.ok = !expectedNotStatusCode.filter((x) => Number(res.statusCode) === Number(x)).length;
+  } else {
+    result.ok = Number(res.statusCode) !== Number(expectedNotStatusCode);
   }
 
   result.got = res.statusCode;

--- a/packages/artillery-plugin-expect/test/index.js
+++ b/packages/artillery-plugin-expect/test/index.js
@@ -64,6 +64,42 @@ test('Expectation: statusCode', async (t) => {
   });
 });
 
+test("Expectation: notStatusCode", async (t) => {
+  const expectations = require("../lib/expectations");
+
+  const data = [
+    // expectation - value received - user context - expected result
+    ['{{ expectedNotStatusCode }}', 200, { vars: { expectedNotStatusCode: 404 } }, true],
+    [301, 200, { vars: {} }, true],
+    ['400', 301, { vars: {} }, true],
+    [404, '200', { vars: {} }, true],
+    ['401', '200', { vars: {} }, true],
+    [[404, 200, 300], 310, { vars: {} }, true],
+    [['404', '200', '300'], '310', { vars: {} }, true],
+    [['404', '200', '300'], 310, { vars: {} }, true],
+    
+    [('{{ expectedNotStatusCode }}', 200, { vars: { expectedNotStatus: 200 } }, false)],
+    ['{{ expectedNotStatusCode }}', '200', { vars: {} }, false],
+    [200, '200', { vars: {} }, false],
+    ['200', 200, { vars: {} }, false],
+    [[404, 202, 310], 404, { vars: {} }, false],
+    [['404', '200', '300'], '300', { vars: {} }, false],
+    [['404', '200', '310'], 310, { vars: {} }, false],
+  ];
+
+  data.forEach((e) => {
+    const result = expectations.notStatusCode(
+      { notStatusCode: e[0] }, // expectation
+      {}, // body
+      {}, // req
+      { statusCode: e[1] }, // res
+      e[2] // userContext
+    );
+
+    t.true(result.ok === e[3]);
+  });
+});
+
 test('Expectation: validRegex', async (t) => {
   const expectations = require('../lib/expectations');
 


### PR DESCRIPTION
## What
I've added an additional expectation case/keyword for expect plugin named `notStatusCode`. It checks if response status code is different than the one/s specified.
This was done to address the #1522 in the issue tracker.

## Why
In some cases users want to test that the returned status code is different than certain status code/s, rather than equal to one.

## How
It was done by creating a new `expectNotStatusCode` function in the file where other expectations are created, and exporting it with them. It follows the same 'template' as other expectation functions - returns the `result` JS object that has `expectation`, `ok`, `expected` and `got` properties. 

Since this function is very similar to `expectStatusCode` one, the code is repetitive and could be extracted into a separate function that would be used by both `expectStatusCode` and `expectNotStatusCode` (as was done with `expectHasProperty` and `expextNotHasProperty` [here](https://github.com/artilleryio/artillery/blob/28975a7b41672189821507975719e4319ca45aab/packages/artillery-plugin-expect/lib/expectations.js#L196) ). 
However because these two functions are fairly short and readable, and the extracted function would only be used by them, I've opted not to do this as I believe it might be more readable as is. I do have the other version made and ready to commit though, if that would be the preferred solution. 

## Testing
I have written a test as well but unfortunately could not check if it is passing because, at this moment, the tests are failing as is (without any changes from my side) when I run them. I have however tested the new expectation manually and I believe it  is behaving as it should. 
The test itself could use a look.

Both the test and the function are positioned right under their `statusCode` counterparts for easy comparison.
