### PR TITLE
fix: removed deprecated package oclif/dev-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3606,202 +3606,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@oclif/dev-cli": {
-      "version": "1.22.2",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/command": "^1.5.13",
-        "@oclif/config": "^1.12.12",
-        "@oclif/errors": "^1.2.2",
-        "@oclif/plugin-help": "^2.1.6",
-        "cli-ux": "^5.2.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "github-slugger": "^1.2.1",
-        "lodash": "^4.17.11",
-        "normalize-package-data": "^2.5.0",
-        "qqjs": "^0.3.10",
-        "tslib": "^1.9.3"
-      },
-      "bin": {
-        "oclif-dev": "bin/run"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/@oclif/plugin-help": {
-      "version": "2.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/command": "^1.5.13",
-        "chalk": "^2.4.1",
-        "indent-string": "^4.0.0",
-        "lodash.template": "^4.4.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0",
-        "widest-line": "^2.0.1",
-        "wrap-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@oclif/dev-cli/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "license": "ISC"
-    },
-    "node_modules/@oclif/dev-cli/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/string-width": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
-    "node_modules/@oclif/dev-cli/node_modules/widest-line": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/widest-line/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/widest-line/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/wrap-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@oclif/dev-cli/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@oclif/errors": {
       "version": "1.3.5",
       "license": "MIT",
@@ -4419,13 +4223,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@oclif/screen": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@oclif/test": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.21.tgz",
@@ -4755,14 +4552,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/gradient-string": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/gradient-string/-/gradient-string-1.1.2.tgz",
@@ -4820,6 +4609,7 @@
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -5395,6 +5185,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/array.prototype.every": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.every/-/array.prototype.every-1.1.4.tgz",
+      "integrity": "sha512-Aui35iRZk1HHLRAyF7QP0KAnOnduaQ6fo6k1NVWfRc0xTs2AZ70ytlXvOmkC6Di4JmUs2Wv3DYzGtCQFSk5uGg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arrgv": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
@@ -5426,6 +5234,10 @@
     },
     "node_modules/artillery": {
       "resolved": "packages/artillery",
+      "link": true
+    },
+    "node_modules/artillery-engine-posthog": {
+      "resolved": "packages/artillery-engine-posthog",
       "link": true
     },
     "node_modules/artillery-plugin-ensure": {
@@ -6766,10 +6578,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "license": "ISC"
-    },
     "node_modules/chunkd": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
@@ -7070,117 +6878,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux": {
-      "version": "5.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/command": "^1.8.15",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.4.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/cli-ux/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/supports-color": {
-      "version": "8.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/cli-width": {
@@ -8088,6 +7785,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
@@ -8128,6 +7859,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/degenerator": {
@@ -8223,13 +7979,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dezalgo": {
@@ -8371,6 +8120,18 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "ignored": "bin/ignored"
       }
     },
     "node_modules/driftless": {
@@ -8633,6 +8394,110 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es6-error": {
@@ -9762,6 +9627,7 @@
     },
     "node_modules/execa": {
       "version": "0.10.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^6.0.0",
@@ -9778,6 +9644,7 @@
     },
     "node_modules/execa/node_modules/cross-spawn": {
       "version": "6.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
@@ -9792,6 +9659,7 @@
     },
     "node_modules/execa/node_modules/path-key": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9799,6 +9667,7 @@
     },
     "node_modules/execa/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -9806,6 +9675,7 @@
     },
     "node_modules/execa/node_modules/shebang-command": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -9816,6 +9686,7 @@
     },
     "node_modules/execa/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9823,6 +9694,7 @@
     },
     "node_modules/execa/node_modules/which": {
       "version": "1.3.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9929,13 +9801,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/extract-stack": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/extsprintf": {
@@ -10474,10 +10339,37 @@
       "version": "2.0.1",
       "license": "ISC"
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gauge": {
       "version": "3.0.2",
@@ -10563,9 +10455,26 @@
     },
     "node_modules/get-stream": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-uri": {
@@ -10624,6 +10533,7 @@
     },
     "node_modules/github-slugger": {
       "version": "1.5.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/github-username": {
@@ -10704,6 +10614,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/globby": {
@@ -10899,11 +10824,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-dynamic-import": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.0.1.tgz",
+      "integrity": "sha512-X3fbtsZmwb6W7fJGR9o7x65fZoodygCrZ3TVycvghP62yYQfS0t4RS0Qcz+j5tQYUKeSWS09tHkWW6WhFV3XhQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -11564,6 +11535,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "dev": true,
@@ -11606,9 +11591,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "license": "MIT"
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -11618,6 +11629,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-builtin-module": {
@@ -11659,9 +11686,25 @@
     },
     "node_modules/is-core-module": {
       "version": "2.9.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11776,6 +11819,27 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-npm": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -11793,6 +11857,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -11823,6 +11902,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11841,6 +11921,22 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-retry-allowed": {
       "version": "1.2.0",
@@ -11861,11 +11957,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-text-path": {
@@ -11916,6 +12064,40 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "dev": true
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -12237,6 +12419,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -12477,27 +12660,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/load-json-file": {
-      "version": "6.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^5.0.0",
-        "strip-bom": "^4.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.6.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/load-yaml-file": {
       "version": "0.2.0",
@@ -12548,6 +12712,7 @@
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -12587,6 +12752,7 @@
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
@@ -12595,6 +12761,7 @@
     },
     "node_modules/lodash.templatesettings": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
@@ -13105,8 +13272,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "license": "MIT"
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -13257,10 +13428,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "license": "MIT"
     },
     "node_modules/mkdirp-infer-owner": {
       "version": "2.0.0",
@@ -14372,6 +14539,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^2.0.0"
@@ -14382,6 +14550,7 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14479,11 +14648,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/object-treeify": {
       "version": "1.1.33",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/oclif": {
@@ -14769,6 +14981,7 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15202,6 +15415,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -15341,6 +15555,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -16036,97 +16251,6 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/qqjs": {
-      "version": "0.3.11",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "debug": "^4.1.1",
-        "execa": "^0.10.0",
-        "fs-extra": "^6.0.1",
-        "get-stream": "^5.1.0",
-        "glob": "^7.1.2",
-        "globby": "^10.0.1",
-        "http-call": "^5.1.2",
-        "load-json-file": "^6.2.0",
-        "pkg-dir": "^4.2.0",
-        "tar-fs": "^2.0.0",
-        "tmp": "^0.1.0",
-        "write-json-file": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/qqjs/node_modules/fs-extra": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
-    "node_modules/qqjs/node_modules/get-stream": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/qqjs/node_modules/globby": {
-      "version": "10.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.0.3",
-        "glob": "^7.1.3",
-        "ignore": "^5.1.1",
-        "merge2": "^1.2.3",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qqjs/node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/qqjs/node_modules/rimraf": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/qqjs/node_modules/tmp": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -16452,6 +16576,23 @@
         "regexp-tree": "bin/regexp-tree"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "dev": true,
@@ -16600,6 +16741,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.8.1",
@@ -16663,6 +16805,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
       }
     },
     "node_modules/retry": {
@@ -16783,6 +16934,20 @@
       "dev": true,
       "dependencies": {
         "regexp-tree": "~0.1.1"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safer-buffer": {
@@ -17235,6 +17400,7 @@
     },
     "node_modules/sort-keys": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^2.0.0"
@@ -17285,6 +17451,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -17293,10 +17460,12 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -17305,6 +17474,7 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.11",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split": {
@@ -17427,6 +17597,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "dev": true,
@@ -17473,6 +17655,51 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -17538,6 +17765,7 @@
     },
     "node_modules/strip-eof": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17701,6 +17929,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19653,6 +19882,78 @@
         "node": ">=8"
       }
     },
+    "node_modules/tape": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.3.tgz",
+      "integrity": "sha512-cUDDGSbyoSIpdUAqbqLI/r7i/S4BHuCB9M5j7E/LrLs/x/i4zeAJ798aqo+FGo+kr9seBZwr8AkZW6rjceyAMQ==",
+      "dev": true,
+      "dependencies": {
+        "array.prototype.every": "^1.1.4",
+        "call-bind": "^1.0.2",
+        "deep-equal": "^2.2.0",
+        "defined": "^1.0.1",
+        "dotignore": "^0.1.2",
+        "for-each": "^0.3.3",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.2.3",
+        "has": "^1.0.3",
+        "has-dynamic-import": "^2.0.1",
+        "inherits": "^2.0.4",
+        "is-regex": "^1.1.4",
+        "minimist": "^1.2.7",
+        "object-inspect": "^1.12.3",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "resolve": "^2.0.0-next.4",
+        "resumer": "^0.0.0",
+        "string.prototype.trim": "^1.2.7",
+        "through": "^2.3.8"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tape/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tape/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -19668,16 +19969,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
       }
     },
     "node_modules/tar-stream": {
@@ -20266,6 +20557,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "license": "MIT",
@@ -20283,6 +20588,21 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unicode-length": {
@@ -20566,6 +20886,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -20715,6 +21036,37 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.0",
       "license": "ISC"
@@ -20857,24 +21209,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/write-json-file": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "detect-indent": "^6.0.0",
-        "graceful-fs": "^4.1.15",
-        "is-plain-obj": "^2.0.0",
-        "make-dir": "^3.0.0",
-        "sort-keys": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ws": {
@@ -21833,7 +22167,7 @@
       }
     },
     "packages/artillery": {
-      "version": "2.0.0-28",
+      "version": "2.0.0-29",
       "license": "MPL-2.0",
       "dependencies": {
         "@artilleryio/int-commons": "latest",
@@ -21841,7 +22175,6 @@
         "@aws-sdk/credential-providers": "^3.127.0",
         "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.18.3",
-        "@oclif/dev-cli": "^1.22.2",
         "@oclif/plugin-help": "^3.3.1",
         "@oclif/plugin-not-found": "^2.3.1",
         "archiver": "^5.3.1",
@@ -21893,6 +22226,23 @@
       "engines": {
         "node": ">= 16.15.0"
       }
+    },
+    "packages/artillery-engine-posthog": {
+      "version": "0.0.1",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "async": "^3.2.4",
+        "debug": "^4.3.4",
+        "posthog-node": "^2.2.3"
+      },
+      "devDependencies": {
+        "tape": "^5.6.1"
+      }
+    },
+    "packages/artillery-engine-posthog/node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
     },
     "packages/artillery-plugin-expect": {
       "version": "2.1.0",
@@ -22826,6 +23176,7 @@
       "name": "@artilleryio/int-core",
       "version": "2.0.2",
       "dependencies": {
+        "@artilleryio/int-commons": "latest",
         "@artilleryio/sketches-js": "^1.0.4",
         "@hapi/basic": "^6.0.0",
         "agentkeepalive": "^4.1.0",
@@ -22833,7 +23184,6 @@
         "async": "^2.6.4",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.10",
-        "commons": "*",
         "cookie-parser": "^1.4.3",
         "csv-parse": "^4.16.3",
         "debug": "^4.3.1",
@@ -22865,6 +23215,20 @@
         "@hapi/hapi": "^20.1.3",
         "rewiremock": "^3.14.3",
         "sinon": "^4.5.0"
+      }
+    },
+    "packages/core/node_modules/@artilleryio/int-commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@artilleryio/int-commons/-/int-commons-2.0.0.tgz",
+      "integrity": "sha512-GmTLcdHoYTObhv9pQlisLtam08y0V09cIcUAT6FDX1lyFSTqiU/uEPtAmeEQdOBOF6yqWMnwZkc351mM1FlE8A==",
+      "dependencies": {
+        "async": "^2.6.4",
+        "cheerio": "^1.0.0-rc.10",
+        "debug": "^4.3.1",
+        "deep-for-each": "^3.0.0",
+        "espree": "^9.4.1",
+        "jsonpath-plus": "^7.2.0",
+        "lodash": "^4.17.19"
       }
     },
     "packages/core/node_modules/nock": {
@@ -23242,6 +23606,7 @@
     "@artilleryio/int-core": {
       "version": "file:packages/core",
       "requires": {
+        "@artilleryio/int-commons": "latest",
         "@artilleryio/sketches-js": "^1.0.4",
         "@hapi/basic": "^6.0.0",
         "@hapi/hapi": "^20.1.3",
@@ -23250,7 +23615,6 @@
         "async": "^2.6.4",
         "chalk": "^2.4.2",
         "cheerio": "^1.0.0-rc.10",
-        "commons": "*",
         "cookie-parser": "^1.4.3",
         "csv-parse": "^4.16.3",
         "debug": "^4.3.1",
@@ -23281,6 +23645,20 @@
         "ws": "^7.5.7"
       },
       "dependencies": {
+        "@artilleryio/int-commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@artilleryio/int-commons/-/int-commons-2.0.0.tgz",
+          "integrity": "sha512-GmTLcdHoYTObhv9pQlisLtam08y0V09cIcUAT6FDX1lyFSTqiU/uEPtAmeEQdOBOF6yqWMnwZkc351mM1FlE8A==",
+          "requires": {
+            "async": "^2.6.4",
+            "cheerio": "^1.0.0-rc.10",
+            "debug": "^4.3.1",
+            "deep-for-each": "^3.0.0",
+            "espree": "^9.4.1",
+            "jsonpath-plus": "^7.2.0",
+            "lodash": "^4.17.19"
+          }
+        },
         "nock": {
           "version": "11.8.2",
           "requires": {
@@ -26139,137 +26517,6 @@
         }
       }
     },
-    "@oclif/dev-cli": {
-      "version": "1.22.2",
-      "requires": {
-        "@oclif/command": "^1.5.13",
-        "@oclif/config": "^1.12.12",
-        "@oclif/errors": "^1.2.2",
-        "@oclif/plugin-help": "^2.1.6",
-        "cli-ux": "^5.2.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "github-slugger": "^1.2.1",
-        "lodash": "^4.17.11",
-        "normalize-package-data": "^2.5.0",
-        "qqjs": "^0.3.10",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@oclif/plugin-help": {
-          "version": "2.2.3",
-          "requires": {
-            "@oclif/command": "^1.5.13",
-            "chalk": "^2.4.1",
-            "indent-string": "^4.0.0",
-            "lodash.template": "^4.4.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0",
-            "widest-line": "^2.0.1",
-            "wrap-ansi": "^4.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.1"
-        },
-        "emoji-regex": {
-          "version": "7.0.3"
-        },
-        "fs-extra": {
-          "version": "7.0.1",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.8.9"
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0"
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1"
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1"
-        },
-        "widest-line": {
-          "version": "2.0.1",
-          "requires": {
-            "string-width": "^2.1.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.1"
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "wrap-ansi": {
-          "version": "4.0.0",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.1"
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "@oclif/errors": {
       "version": "1.3.5",
       "requires": {
@@ -26701,9 +26948,6 @@
         }
       }
     },
-    "@oclif/screen": {
-      "version": "1.0.4"
-    },
     "@oclif/test": {
       "version": "2.2.21",
       "resolved": "https://registry.npmjs.org/@oclif/test/-/test-2.2.21.tgz",
@@ -26981,13 +27225,6 @@
         "@types/node": "*"
       }
     },
-    "@types/glob": {
-      "version": "7.2.0",
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/gradient-string": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/gradient-string/-/gradient-string-1.1.2.tgz",
@@ -27040,7 +27277,8 @@
       "version": "4.0.1"
     },
     "@types/minimatch": {
-      "version": "3.0.5"
+      "version": "3.0.5",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -27453,6 +27691,18 @@
     "array-union": {
       "version": "2.1.0"
     },
+    "array.prototype.every": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.every/-/array.prototype.every-1.1.4.tgz",
+      "integrity": "sha512-Aui35iRZk1HHLRAyF7QP0KAnOnduaQ6fo6k1NVWfRc0xTs2AZ70ytlXvOmkC6Di4JmUs2Wv3DYzGtCQFSk5uGg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "is-string": "^1.0.7"
+      }
+    },
     "arrgv": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
@@ -27486,7 +27736,6 @@
         "@hapi/hapi": "^20.1.3",
         "@oclif/command": "^1.8.16",
         "@oclif/config": "^1.18.3",
-        "@oclif/dev-cli": "^1.22.2",
         "@oclif/plugin-help": "^3.3.1",
         "@oclif/plugin-not-found": "^2.3.1",
         "archiver": "^5.3.1",
@@ -27643,6 +27892,22 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "artillery-engine-posthog": {
+      "version": "file:packages/artillery-engine-posthog",
+      "requires": {
+        "async": "^3.2.4",
+        "debug": "^4.3.4",
+        "posthog-node": "^2.2.3",
+        "tape": "^5.6.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
         }
       }
     },
@@ -29112,9 +29377,6 @@
         }
       }
     },
-    "chownr": {
-      "version": "1.1.4"
-    },
     "chunkd": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
@@ -29321,83 +29583,6 @@
             "ansi-styles": "^4.0.0",
             "astral-regex": "^2.0.0",
             "is-fullwidth-code-point": "^3.0.0"
-          }
-        }
-      }
-    },
-    "cli-ux": {
-      "version": "5.6.7",
-      "requires": {
-        "@oclif/command": "^1.8.15",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.4.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "7.2.0",
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            }
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -30061,6 +30246,39 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.6.0"
     },
@@ -30087,6 +30305,22 @@
     },
     "defer-to-connect": {
       "version": "2.0.1"
+    },
+    "define-properties": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
+      "requires": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "dev": true
     },
     "degenerator": {
       "version": "3.0.2",
@@ -30156,9 +30390,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-    },
-    "detect-indent": {
-      "version": "6.1.0"
     },
     "dezalgo": {
       "version": "1.0.4",
@@ -30249,6 +30480,15 @@
     },
     "dotenv": {
       "version": "16.0.1"
+    },
+    "dotignore": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "driftless": {
       "version": "2.0.3",
@@ -30431,6 +30671,94 @@
       "version": "1.3.2",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-error": {
@@ -31186,6 +31514,7 @@
     },
     "execa": {
       "version": "0.10.0",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^3.0.0",
@@ -31198,6 +31527,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "6.0.5",
+          "dev": true,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -31207,22 +31537,27 @@
           }
         },
         "path-key": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "dev": true
         },
         "semver": {
-          "version": "5.7.1"
+          "version": "5.7.1",
+          "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
+          "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
-          "version": "1.0.0"
+          "version": "1.0.0",
+          "dev": true
         },
         "which": {
           "version": "1.3.1",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -31316,9 +31651,6 @@
           }
         }
       }
-    },
-    "extract-stack": {
-      "version": "2.0.0"
     },
     "extsprintf": {
       "version": "1.3.0"
@@ -31690,8 +32022,26 @@
     "function-loop": {
       "version": "2.0.1"
     },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "gauge": {
@@ -31747,7 +32097,18 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "get-uri": {
       "version": "3.0.2",
@@ -31792,7 +32153,8 @@
       }
     },
     "github-slugger": {
-      "version": "1.5.0"
+      "version": "1.5.0",
+      "dev": true
     },
     "github-username": {
       "version": "6.0.0",
@@ -31839,6 +32201,15 @@
           "version": "0.20.2",
           "dev": true
         }
+      }
+    },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "globby": {
@@ -31970,8 +32341,39 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
+    "has-dynamic-import": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.0.1.tgz",
+      "integrity": "sha512-X3fbtsZmwb6W7fJGR9o7x65fZoodygCrZ3TVycvghP62yYQfS0t4RS0Qcz+j5tQYUKeSWS09tHkWW6WhFV3XhQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "4.0.0"
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.3"
@@ -32416,6 +32818,17 @@
         }
       }
     },
+    "internal-slot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "interpret": {
       "version": "1.4.0",
       "dev": true
@@ -32439,13 +32852,43 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1"
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-builtin-module": {
@@ -32471,8 +32914,18 @@
     },
     "is-core-module": {
       "version": "2.9.0",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-docker": {
@@ -32538,6 +32991,18 @@
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true
+    },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
     "is-npm": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
@@ -32546,6 +33011,15 @@
     },
     "is-number": {
       "version": "7.0.0"
+    },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-obj": {
       "version": "2.0.0",
@@ -32564,7 +33038,8 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "is-plain-object": {
       "version": "5.0.0",
@@ -32575,6 +33050,16 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-retry-allowed": {
       "version": "1.2.0"
@@ -32588,8 +33073,42 @@
         "scoped-regex": "^2.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
     "is-stream": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -32620,6 +33139,31 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
       "dev": true
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "is-windows": {
       "version": "1.0.2"
@@ -32827,7 +33371,8 @@
       "version": "1.0.2"
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "dev": true
     },
     "json-schema": {
       "version": "0.4.0"
@@ -32991,21 +33536,8 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.2.4"
-    },
-    "load-json-file": {
-      "version": "6.2.0",
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^5.0.0",
-        "strip-bom": "^4.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.6.0"
-        }
-      }
+      "version": "1.2.4",
+      "dev": true
     },
     "load-yaml-file": {
       "version": "0.2.0",
@@ -33043,7 +33575,8 @@
       "version": "4.17.21"
     },
     "lodash._reinterpolate": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0"
@@ -33074,6 +33607,7 @@
     },
     "lodash.template": {
       "version": "4.5.0",
+      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -33081,6 +33615,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
+      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -33426,7 +33961,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6"
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -33537,9 +34074,6 @@
       "requires": {
         "minimist": "^1.2.6"
       }
-    },
-    "mkdirp-classic": {
-      "version": "0.5.3"
     },
     "mkdirp-infer-owner": {
       "version": "2.0.0",
@@ -34366,12 +34900,14 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       },
       "dependencies": {
         "path-key": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "dev": true
         }
       }
     },
@@ -34442,8 +34978,36 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
     "object-treeify": {
       "version": "1.1.33"
+    },
+    "object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      }
     },
     "oclif": {
       "version": "3.4.3",
@@ -34638,7 +35202,8 @@
       }
     },
     "p-finally": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -34967,6 +35532,7 @@
     },
     "parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -35049,7 +35615,8 @@
       "version": "3.1.1"
     },
     "path-parse": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7"
@@ -35521,71 +36088,6 @@
     "q": {
       "version": "1.5.1"
     },
-    "qqjs": {
-      "version": "0.3.11",
-      "requires": {
-        "chalk": "^2.4.1",
-        "debug": "^4.1.1",
-        "execa": "^0.10.0",
-        "fs-extra": "^6.0.1",
-        "get-stream": "^5.1.0",
-        "glob": "^7.1.2",
-        "globby": "^10.0.1",
-        "http-call": "^5.1.2",
-        "load-json-file": "^6.2.0",
-        "pkg-dir": "^4.2.0",
-        "tar-fs": "^2.0.0",
-        "tmp": "^0.1.0",
-        "write-json-file": "^4.1.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "6.0.1",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "globby": {
-          "version": "10.0.2",
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.0.3",
-            "glob": "^7.1.3",
-            "ignore": "^5.1.1",
-            "merge2": "^1.2.3",
-            "slash": "^3.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "tmp": {
-          "version": "0.1.0",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        }
-      }
-    },
     "qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -35813,6 +36315,17 @@
       "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
       "dev": true
     },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "dev": true
@@ -35915,6 +36428,7 @@
     },
     "resolve": {
       "version": "1.22.0",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -35954,6 +36468,15 @@
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
       }
     },
     "retry": {
@@ -36024,6 +36547,17 @@
       "dev": true,
       "requires": {
         "regexp-tree": "~0.1.1"
+      }
+    },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
       }
     },
     "safer-buffer": {
@@ -36253,7 +36787,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.18.3",
         "chai": "^4",
-        "cli-highlight": "*",
+        "cli-highlight": "^2.1.11",
         "eslint": "^7.32.0",
         "eslint-config-oclif": "^4",
         "eslint-config-oclif-typescript": "^1.0.3",
@@ -36602,6 +37136,7 @@
     },
     "sort-keys": {
       "version": "4.2.0",
+      "dev": true,
       "requires": {
         "is-plain-obj": "^2.0.0"
       }
@@ -36637,23 +37172,27 @@
     },
     "spdx-correct": {
       "version": "3.1.1",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11"
+      "version": "3.0.11",
+      "dev": true
     },
     "split": {
       "version": "0.3.3",
@@ -36740,6 +37279,15 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "dev": true,
@@ -36778,6 +37326,39 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "strip-ansi": {
@@ -36825,7 +37406,8 @@
       }
     },
     "strip-eof": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -36938,7 +37520,8 @@
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "table": {
       "version": "6.8.1",
@@ -38171,6 +38754,62 @@
         "yaml": "^1.5.0"
       }
     },
+    "tape": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.6.3.tgz",
+      "integrity": "sha512-cUDDGSbyoSIpdUAqbqLI/r7i/S4BHuCB9M5j7E/LrLs/x/i4zeAJ798aqo+FGo+kr9seBZwr8AkZW6rjceyAMQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.every": "^1.1.4",
+        "call-bind": "^1.0.2",
+        "deep-equal": "^2.2.0",
+        "defined": "^1.0.1",
+        "dotignore": "^0.1.2",
+        "for-each": "^0.3.3",
+        "get-package-type": "^0.1.0",
+        "glob": "^7.2.3",
+        "has": "^1.0.3",
+        "has-dynamic-import": "^2.0.1",
+        "inherits": "^2.0.4",
+        "is-regex": "^1.1.4",
+        "minimist": "^1.2.7",
+        "object-inspect": "^1.12.3",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "resolve": "^2.0.0-next.4",
+        "resumer": "^0.0.0",
+        "string.prototype.trim": "^1.2.7",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
+    },
     "tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -38206,15 +38845,6 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
-      }
-    },
-    "tar-fs": {
-      "version": "2.1.1",
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
       }
     },
     "tar-stream": {
@@ -38585,6 +39215,17 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "requires": {
@@ -38594,6 +39235,18 @@
     "typescript": {
       "version": "4.9.3",
       "devOptional": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "unicode-length": {
       "version": "2.0.2",
@@ -38813,6 +39466,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -38927,6 +39581,31 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0"
     },
@@ -39025,17 +39704,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "write-json-file": {
-      "version": "4.3.0",
-      "requires": {
-        "detect-indent": "^6.0.0",
-        "graceful-fs": "^4.1.15",
-        "is-plain-obj": "^2.0.0",
-        "make-dir": "^3.0.0",
-        "sort-keys": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
       }
     },
     "ws": {

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -89,7 +89,6 @@
     "@aws-sdk/credential-providers": "^3.127.0",
     "@oclif/command": "^1.8.16",
     "@oclif/config": "^1.18.3",
-    "@oclif/dev-cli": "^1.22.2",
     "@oclif/plugin-help": "^3.3.1",
     "@oclif/plugin-not-found": "^2.3.1",
     "archiver": "^5.3.1",


### PR DESCRIPTION
Removing oclif/dev-cli as it's no longer supported by the authors. This is preventing from me being able to import this library within my organization.

All tests pass!

```
npm run test

> artillery@2.0.0-29 test
> export ARTILLERY_TELEMETRY_DEFAULTS='{"source":"test-suite"}' && tap --no-coverage --timeout=300 test/unit/*.test.js test/cli/*.test.js && bash test/lib/run.sh && node test/testcases/plugins/*.test.js

Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
 PASS  test/unit/ssms-buckets.test.js 1 OK 9.723ms
 PASS  test/unit/dist.test.js 13 OK 10.251ms
 SKIP  test/cli/run-lambda.test.js > no tests found 226.087ms
 PASS  test/cli/command-report.test.js 1 OK 919.951ms
 PASS  test/unit/ssms-basic.test.js 5 OK 2s
test/unit/ssms-multi-process.test.js 1> [ '1675328740000' ] [ '1675328740000' ]
test/unit/ssms-multi-process.test.js 1> h p99 =====> 3905.8
test/unit/ssms-multi-process.test.js 1> control p99 ======> 3905.8
test/unit/ssms-multi-process.test.js 1> h p99 =====> 4676.2
test/unit/ssms-multi-process.test.js 1> control p99 ======> 4676.2
test/unit/ssms-multi-process.test.js 1> h p99 =====> 3984.7
test/unit/ssms-multi-process.test.js 1> control p99 ======> 3984.7
test/unit/ssms-multi-process.test.js 1> h p99 =====> 10.9
test/unit/ssms-multi-process.test.js 1> control p99 ======> 10.9
test/unit/ssms-multi-process.test.js 1> h p99 =====> 18
test/unit/ssms-multi-process.test.js 1> control p99 ======> 18
test/unit/ssms-multi-process.test.js 1> h p99 =====> 19.1
test/unit/ssms-multi-process.test.js 1> control p99 ======> 19.1
test/unit/ssms-multi-process.test.js 1> h p99 =====> 21.1
test/unit/ssms-multi-process.test.js 1> control p99 ======> 21.1
test/unit/ssms-multi-process.test.js 1> h p99 =====> 22
test/unit/ssms-multi-process.test.js 1> control p99 ======> 22
test/unit/ssms-multi-process.test.js 1> h p99 =====> 10.9
test/unit/ssms-multi-process.test.js 1> control p99 ======> 10.9
test/unit/ssms-multi-process.test.js 1> h p99 =====> 6
test/unit/ssms-multi-process.test.js 1> control p99 ======> 6
 PASS  test/unit/ssms-multi-process.test.js 63 OK 5s
 PASS  test/cli/variables-from-external-files.test.js 1 OK 5s
 PASS  test/cli/suggested-exit-codes.test.js 1 OK 6s
 PASS  test/cli/run-smoke.test.js 3 OK 6s
 PASS  test/cli/errors-and-warnings.test.js 6 OK 13s
 PASS  test/unit/before_after_hooks.test.js 8 OK 22s
 PASS  test/cli/command-run.test.js 16 OK 1m
 SKIP  TAP
 ~ test/cli/run-lambda.test.js > no tests found




  🌈 SUMMARY RESULTS 🌈

 SKIP  test/cli/run-lambda.test.js > no tests found 226.087ms

Suites:   11 passed, 1 skip, 12 of 12 completed
Asserts:  118 passed, 1 skip, of 119
Time:   1m
TAP version 13
# Subtest: util - setup
    1..0
ok 1 - util - setup # time=1.349ms

# Subtest: formatting durations
    ok 1 - Durations with one second are formatted
    ok 2 - Durations with seconds are formatted
    ok 3 - Durations with one minute are formatted
    ok 4 - Durations with minutes are formatted
    ok 5 - Durations with one hour are formatted
    ok 6 - Durations with hours are formatted
    ok 7 - Durations with one day are formatted
    ok 8 - Durations with days are formatted
    1..8
ok 2 - formatting durations # time=1.383ms

# Subtest: readArtilleryConfig
    ok 1 - Returns an empty object if .artilleryrc is not present
    ok 2 - Returns the configuration as a JSON object
    1..2
ok 3 - readArtilleryConfig # time=2.547ms

# Subtest: updateArtilleryConfig
    ok 1 - Updates the existing configuration
    ok 2 - should be equal
    1..2
ok 4 - updateArtilleryConfig # time=0.63ms

# Subtest: padded
    ok 1 - pads the space between the name and the result according to the length
    ok 2 - truncates the name when longer than the allowed length
    ok 3 - no truncating when the string length exactly matches the allowed length
    1..3
ok 5 - padded # time=0.442ms

# Subtest: util - tear down
    1..0
ok 6 - util - tear down # time=0.181ms

# Subtest: Telemetry - setup
    1..0
ok 7 - Telemetry - setup # time=5.475ms

# Subtest: Telemetry
    ok 1 - Sends telemetry data
    1..1
ok 8 - Telemetry # time=1.245ms

# Subtest: Telemetry with defaults env var
    ok 1 - Sends telemetry data
    1..1
ok 9 - Telemetry with defaults env var # time=0.612ms

# Subtest: Telemetry - disable user info through environment variable
    ok 1 - Only basic ping is sent if user opted out
    1..1
ok 10 - Telemetry - disable user info through environment variable # time=0.338ms

Telemetry data: {"event":"test event","distinctId":"artillery-core","properties":{"version":"2.0.0-29","os":"darwin","isCi":false,"$ip":null}}
# Subtest: Telemetry - debug through environment variable
    ok 1 - Telemetry data: {"event":"test event","distinctId":"artillery-core","properties":{"version":"2.0.0-29"
    1..1
ok 11 - Telemetry - debug through environment variable # time=0.762ms

# Subtest: Telemetry - teardown
    1..0
ok 12 - Telemetry - teardown # time=0.941ms

# Subtest: validate script
    1..10
    ok 1 - it should return undefined for a valid script
    # Subtest: config.target
        ok 1 - config.target should be required if config.environments is not defined
        ok 2 - it should validate the script if config.environments is defined but config.target is missing
        1..2
    ok 2 - config.target # time=1.495ms

    # Subtest: scenario flow
        ok 1 - it should return an error if "scenarios.flow" property is missing
        1..1
    ok 3 - scenario flow # time=0.536ms

    # Subtest: url
        ok 1 - it should return an error if "url" property is missing
        1..1
    ok 4 - url # time=0.415ms

    # Subtest: custom engines
        ok 1 - it should not enforce validation for scenarios with custom engines
        ok 2 - it should not enforce validation for before sections when custom engines are configured
        ok 3 - it should not enforce validation for after sections when custom engines are configured
        1..3
    ok 5 - custom engines # time=0.826ms

    # Subtest: capture
        ok 1 - it should allow capture as object
        ok 2 - it should allow capture as an array of capture objects
        ok 3 - it should return an error if capture.as is missing
        1..3
    ok 6 - capture # time=0.955ms

    # Subtest: before/after sections
        ok 1 - it should validate before sections
        ok 2 - it should fail if before.flow is not an object
        ok 3 - it should fail if after.flow is not an object
        1..3
    ok 7 - before/after sections # time=0.853ms

    # Subtest: before/after scenario hooks
        ok 1 - it allows before/after scenario hooks as strings
        ok 2 - it allows before/after scenario hooks as arrays of strings
        ok 3 - it fails if beforeScenario is not a string
        ok 4 - it fails if afterScenario is not a string
        1..4
    ok 8 - before/after scenario hooks # time=0.847ms

    # Subtest: before/after scenario hooks
        ok 1 - it allows before/after request hooks as strings
        ok 2 - it allows before/after request hooks as arrays of strings
        ok 3 - it fails if beforeRequest is not a string
        ok 4 - it fails if afterResponse is not a string
        1..4
    ok 9 - before/after scenario hooks # time=0.89ms

    # Subtest: socketio
        ok 1 - it should validate a socketio flow
        ok 2 - it should fail validation if engine is socketio and emit.channel is not a string
        1..2
    ok 10 - socketio # time=0.613ms

ok 13 - validate script # time=18.186ms

1..13
# time=119.813ms
$ /<redacted>/artillery/packages/artillery/bin/run -V

        ___         __  _ ____
  _____/   |  _____/ /_(_) / /__  _______  __ ___
 /____/ /| | / ___/ __/ / / / _ \/ ___/ / / /____/
/____/ ___ |/ /  / /_/ / / /  __/ /  / /_/ /____/
    /_/  |_/_/   \__/_/_/_/\___/_/   \__  /
                                    /____/


VERSION INFO:

Artillery: 2.0.0-29
Node.js:   v18.13.0
OS:        darwin

TAP version 13
$ ARTILLERY_PLUGIN_PATH=/<redacted>/artillery/packages/artillery/test/plugins /<redacted>/artillery/packages/artillery/bin/run run --quiet --overrides $'{"config":{"phases":[{"duration":2,"arrivalRate":2}],"target":"http://localhost:52101","processor":"/<redacted>/artillery/packages/artillery/test/testcases/plugins/processor.js","plugins":{"httphooks":{}}}}' /<redacted>/artillery/packages/artillery/test/testcases/plugins/script.json
afterResponse hook
afterResponse hook
afterResponse hook
afterResponse hook
# Subtest: plugins can attach functions to processor object
    ok 1 - plugin output
    1..1
ok 1 - plugins can attach functions to processor object # time=4920.733ms

1..1
# time=4922.92ms
```