### PR TITLE
fix: y-axis title for counter charts

### DIFF
--- a/packages/artillery/lib/report/index.html.ejs
+++ b/packages/artillery/lib/report/index.html.ejs
@@ -627,7 +627,7 @@
               beginAtZero: true,
               title: {
                 display: true,
-                text: "ms",
+                text: "count",
               },
             },
           },
@@ -762,7 +762,7 @@
                   beginAtZero: true,
                   title: {
                     display: true,
-                    text: "ms",
+                    text: "count",
                   },
                   ticks: {
                     color: '#9b9b9b',


### PR DESCRIPTION
Show `count` instead of `ms` as y-axis title for counter charts in HTML reports