### PR TITLE
fix: show templated qs in debug output

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -494,7 +494,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               requestInfo.qs = qs.encode(
                 Object.assign(
                   qs.parse(urlparse(requestParams.url).query),
-                  requestParams.qs
+                  template(requestParams.qs, context)
                 )
               );
             }


### PR DESCRIPTION
## What
This PR fixes issue #1741. 

The `requestInfo` object which is logged by the `debug` function was not templating the querystring. 

## How
I have simply added the templating function to the part of the code that checks for the existence of `qs` in order to add it to `requestInfo`. This templating function is exactly the same that gets used for templating the main code.

## Testing
Because this was just an output from debug, I have not added an automated test case for it. 

I have recreated the setup from the issue above locally and verified that `DEBUG=http` now outputs the templated string correctly.