### PR TITLE
fix: Cookies will work when url is a $loopElement

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -399,6 +399,20 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         );
         requestParams.headers = templatedHeaders;
 
+        // We compute the url here so that the cookies are set properly afterwards
+        let url = maybePrependBase(
+          template(requestParams.uri || requestParams.url, context),
+          config
+        );
+
+        if (requestParams.uri) {
+          // If a hook function sets requestParams.uri to something, request.js
+          // will pick that over .url, so we need to delete it.
+          delete requestParams.uri;
+        }
+
+        requestParams.url = url;
+
         if (
           typeof requestParams.cookie === 'object' ||
           typeof context._defaultCookie === 'object'
@@ -422,19 +436,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           requestParams.password = template(requestParams.auth.pass, context);
           delete requestParams.auth;
         }
-
-        let url = maybePrependBase(
-          template(requestParams.uri || requestParams.url, context),
-          config
-        );
-
-        if (requestParams.uri) {
-          // If a hook function sets requestParams.uri to something, request.js
-          // will pick that over .url, so we need to delete it.
-          delete requestParams.uri;
-        }
-
-        requestParams.url = url;
 
         // TODO: Bypass proxy if "proxy: false" is set
         requestParams.agent = {


### PR DESCRIPTION
The issue was that we were computing the url after setting the cookies if it was templated. This led to the cookies being set on '' domain in the cookie jar leading to it not being set on the request properly. The fix is to move the logic of url computation before setting the cookies. Tests are also added for the same so that we can detect if it would break in future due to code changes.

Fixes #1824 