### PR TITLE
fix(http): set a data handler to make the end event handler fire

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -752,6 +752,8 @@ HttpEngine.prototype._handleResponse = function (
     res.on('data', (d) => {
       body += d;
     });
+  } else {
+    res.on('data', () => {});
   }
 
   res.on('end', () => {


### PR DESCRIPTION
Ref: https://github.com/artilleryio/artillery/issues/1799

The end event handler does not seem to be fired for requests in a redirect chain unless a data handler is attached.