### PR TITLE
fix: Distribute csv payload across workers

### DIFF
--- a/packages/artillery/test/unit/dist.test.js
+++ b/packages/artillery/test/unit/dist.test.js
@@ -186,7 +186,7 @@ tap.test('maxVusers distributes evenly in all phases', (t) => {
   };
 
   const phases = divideWork(script, numWorkers);
-  for (let i = 0; i < script.config.phases.length - 1; i++) {
+  for (let i = 0; i < script.config.phases.length; i++) {
     let activeMaxVusers = phases
       .map(p => p.config.phases[i])
       .filter(p => p.arrivalRate > 0 || p.arrivalCount > 0 || p.rampTo > 0)


### PR DESCRIPTION
Ref #1221

This is a fix for a bug where the payload would get copied for each worker, and therefore each CSV row will get duplicate calls.
In my case, it meant that, when running artillery on unique historical data, it would create 1 new request and hit cache from the rest of the workers.

It would be nice to have this bug at least documented in docs, but I noticed that arrival rates are already divided between workers, so in the same place, the payload could be divided as well.

I have split this task into 2 commits:
* First refactoring the `diviedWork` functionality so that it's more readable and adding the ability to more easily update it without changing it's behavior.
* Then, adding the functionality for dividing payload between workers.