### PR TITLE
feat: new relic publish metrics plugin target

### DIFF
--- a/packages/artillery-plugin-publish-metrics/README.md
+++ b/packages/artillery-plugin-publish-metrics/README.md
@@ -11,9 +11,10 @@ The plugin sends metrics and events from Artillery tests to external monitoring 
 - [Prometheus](https://prometheus.io/docs/concepts/metric_types/) via [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/)
 - [Honeycomb](https://honeycomb.io)
 - [Lightstep](https://lightstep.com)
+- [New Relic](https://newrelic.com/)
 - [Mixpanel](https://mixpanel.com)
 - InfluxDB with [Telegraf + StatsD plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd)
-- StatsD
+- StatsD 
 
 ## Docs
 
@@ -21,7 +22,6 @@ The plugin sends metrics and events from Artillery tests to external monitoring 
 
 ## Wishlist
 
-- NewRelic
 - InfluxDB (HTTP API)
 - Splunk
 - ELK

--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -12,6 +12,7 @@ const { createLightstepReporter } = require('./lib/lightstep');
 const { createMixPanelReporter } = require('./lib/mixpanel');
 const { createPrometheusReporter } = require('./lib/prometheus');
 const { createCloudWatchReporter } = require('./lib/cloudwatch');
+const { createNewRelicReporter } = require('./lib/newrelic');
 
 module.exports = {
   Plugin,
@@ -40,6 +41,8 @@ function Plugin(script, events) {
       this.reporters.push(createPrometheusReporter(config, events, script));
     } else if (config.type === 'cloudwatch') {
       this.reporters.push(createCloudWatchReporter(config, events, script));
+    } else if (config.type === 'newrelic') {
+      this.reporters.push(createNewRelicReporter(config, events, script));
     } else {
       events.emit(
         'userWarning',

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic.js
@@ -1,202 +1,181 @@
 const got = require('got')
 const debug = require('debug')('plugin:publish-metrics:newrelic');
 
-function NewRelicReporter(config, events, script) {
-    this.metricEndpoint = config.region && config.region === 'eu' 
-        ? "https://metric-api.eu.newrelic.com/metric/v1" 
+
+class NewRelicReporter {
+	constructor(config, events) {
+		// debug(Object.assign(config, { licenseKey: this.sanitize(config.licenseKey) }));
+
+		this.config = {
+			region: config.region || 'us',
+			prefix: config.prefix || 'artillery.',
+			excluded: config.excluded || [],
+			includeOnly: config.includeOnly || [],
+			attributes: config.attributes || [],
+			licenseKey: config.licenseKey,
+		};
+		
+		this.metricsAPIEndpoint = this.config.region === 'eu' 
+        ? "https://metric-api.eu.newrelic.com/metric/v1"
         : 'https://metric-api.newrelic.com/metric/v1';
-    
-    this.reqHeaders = {
-        'Content-Type': 'application/json; charset=UTF-8',
-        'Api-Key': config.licenceKey,
-    };
-
-    
-
-
-    // TODO check in new relic the attributes?tags and how to call them -how they are called/used in the user platform 
-    // TODO rewrite the formatConfig and rethink implementation 
-    // TODO rethink the metric formater functions and their implementation
-    // TODO turn to class
-
-
-
-    debug('Creating NewRelicReporter with config');
-    debug(Object.assign(config, { licenceKey: sanitize(config.licenceKey) }));
-    
-    this.config = formatConfig(config)
-
-    debug('awaiting stats');
-    events.on('stats', async (stats) => {
-        let timestamp = Date.now();
-        const interval = stats.lastCounterAt - stats.firstCounterAt;
-
-        const rates = formatRatesForNewRelic(stats.rates, this.config);
-        const counters = formatCountersForNewRelic(stats.counters, this.config);
-        const summaries = formatSummariesForNewRelic(stats.summaries, this.config);
-
-        const reqBody = createRequestBody (timestamp, interval, this.attributes, [...rates, ...counters, ...summaries]);
-        await sendStats (this.metricEndpoint, this.reqHeaders, reqBody)
-
-    });
-
-    return this
-}; 
-
-// function formatStatsForNewRelic (stats, propertyName) {
-//     const statMetrics = [];
-//     let metric = {
-//         type: propertyName === "counters" ? "count" : "gauge",
-//         name: "",
-//         value: null
-//     }
-//     for (const[label, value] of Object.entries(stats || {})) {
-//         if (propertyName === "summaries") {
-//             for (const [agreggation, valueNum] of Object.entries(stats || {})) {
-//                 metric.name = `artillery.${label}.${agreggation}`;
-//                 metric.value = valueNum
-//                 statMetrics.push(metric)
-//             };
-//         } else {
-//             metric.name = "artillery." + label
-//             metric.value = value
-//             statMetrics.push(metric)
-//         }
-//     }
-//     return statMetrics
-// }
-
-function formatConfig(config) {
-    const formatedConfig = Object.assign(
-        {
-            prefix: 'artillery.',
-            excluded: [],
-            includeOnly: [],
-            attributes: []
-        },
-        config
-    );
-    
-    // TODO change  
-    formatedConfig.attributes = 
-        config.attributes.reduce(
-            (acc, attribute) => {
-                 return acc[attribute.split(':')[0]] = attribute.split(':')[1]
-            },
-            {}
-        ) ?? [];
-    return formatedConfig
-}
-
-function formatCountersForNewRelic (counters, config) {
-    debug('formating stats counters');
-    const statMetrics = []
-    for (const[name, value] of Object.entries(counters || {})) {
-        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
-            metric = {
-                name: config.prefix + name,
-                type: "count",
-                value
-            };
-            statMetrics.push(metric)
-        }
-    }
-    // debug('LIST OF COUNTERS SENT TO NR:', statMetrics)
-    return statMetrics
-}
-
-
-function formatRatesForNewRelic (rates, config) {
-    debug('formating stats rates');
-    const statMetrics = []
-    for (const[name, value] of Object.entries(rates || {})) {
-        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
-            metric = {
-                name: config.prefix + name,
-                type: "gauge",
-                value
-            };
-            statMetrics.push(metric)
-        };
-    }
-    return statMetrics
-}
-
-function formatSummariesForNewRelic (summaries, config) {
-    debug('formating stats summaries');
-    const statMetrics = []
-    for (const[name, values] of Object.entries(summaries || {})) {
-        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
-            for (const [agreggation, value] of Object.entries(values)){
-                metric = {
-                    name: `${config.prefix}${name}.${agreggation}`,
-                    type: "gauge",
-                    value
-                }
-                statMetrics.push(metric)
-            };
-        
-        };
-    }
-    return statMetrics
-}
-
-function createRequestBody (timestamp, interval, attributes, metrics) { 
-    debug('creating request body')
-    const body = [
-        {
-            common: {
-                timestamp,
-                "interval.ms": interval,
-                attributes,
-            },
-            metrics
-        }
-    ]
-    return body
-}
-
-async function sendStats(url, headers, body) {
-    const options = {
-        headers,
-        json: body
-    }
-    debug('sending metrics to New Relic')
-    try{
-        const res = await got.post(url, options)
-        if ( res.statusCode !== 202 ) {
-            debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`)
-        }
-    } catch (err) {
-        debug(err)
-    }
-}
-
-function sanitize(str) {
+		
+		this.eventsAPIEndpoint = this.config.region === 'eu' 
+				? 'https://insights-collector.eu01.nr-data.net' 
+				: 'https://insights-collector.newrelic.com';
+		
+		this.pendingRequests = 0;
+		
+		events.on('stats', async (stats) => {
+			const timestamp = Date.now();
+			const interval = Number(stats.lastCounterAt) - Number(stats.firstCounterAt);
+			
+			const rates = this.formatRatesForNewRelic(stats.rates, this.config);
+			const counters = this.formatCountersForNewRelic(stats.counters, this.config);
+			const summaries = this.formatSummariesForNewRelic(stats.summaries, this.config);
+			
+			const reqBody = this.createRequestBody(timestamp, interval, this.config.attributes, [...rates, ...counters, ...summaries]);
+			await this.sendStats(this.metricsAPIEndpoint, this.config.licenseKey, reqBody)
+			
+		});
+		
+		debug('init done');
+	}
+	
+	formatCountersForNewRelic (counters, config) {
+		debug('formating stats counters');
+		const statMetrics = []
+		for (const[name, value] of Object.entries(counters || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			const metric = {
+				name: config.prefix + name,
+				type: "count",
+				value
+			};
+			statMetrics.push(metric)
+		}
+		return statMetrics
+	}
+	
+	formatRatesForNewRelic (rates, config) {
+		debug('formating stats rates');
+		const statMetrics = []
+		for (const[name, value] of Object.entries(rates || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			const metric = {
+				name: config.prefix + name,
+				type: "gauge",
+				value
+			};
+			statMetrics.push(metric)
+		}
+		return statMetrics
+	}
+	
+	formatSummariesForNewRelic (summaries, config) {
+		debug('formating stats summaries');
+		const statMetrics = []
+		for (const[name, values] of Object.entries(summaries || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			for (const [agreggation, value] of Object.entries(values)){
+				const metric = {
+					name: `${config.prefix}${name}.${agreggation}`,
+					type: "gauge",
+					value
+				}
+				statMetrics.push(metric)
+			};
+		}
+		return statMetrics
+	}
+	
+	createRequestBody (timestamp, interval, attributeList, metrics) { 
+		debug('creating request body')
+		const parsedAttributes = {};
+		if (attributeList.length > 0) {
+			for (const item of attributeList) {
+				const attribute = item.split(':')
+				parsedAttributes[attribute[0]] = attribute[1]
+			}
+		}
+		const body = [
+			{
+				common: {
+					timestamp,
+					'interval.ms': interval,
+					attributes: parsedAttributes,
+				},
+				metrics
+			}
+		]
+		return body
+	}
+	
+	async sendStats(url, licenseKey, body) {
+		this.pendingRequests += 1;
+		const headers = {
+			'Content-Type': 'application/json; charset=UTF-8',
+			'Api-Key': licenseKey,
+		};
+		const options = {
+			headers,
+			json: body
+		};
+		debug('sending metrics to New Relic')
+		try{
+			const res = await got.post(url, options)
+			if ( res.statusCode !== 202 ) {
+				debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`)
+			}
+		} catch (err) {
+			debug(err)
+		}
+		
+		this.pendingRequests -= 1;
+	}
+	
+	shouldSendMetric (metricName, excluded, includeOnly) {
+		if (excluded.includes(metricName)) {
+			return
+		};
+		
+		if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+			return
+		}
+		return true 
+	}
+	
+	sanitize (str) {
     return `${str.substring(0, 3)}********************${str.substring(str.length - 3, str.length)}`;
-}
+	}
 
-function shouldSendMetric (metricName, excluded, includeOnly) {
-    if (excluded.includes(metricName)) {
-        return
-    };
+	async waitingForRequest() {
+		while (this.pendingRequests > 0) {
+			debug('Waiting for pending request ...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		} ;
+		
+		debug('Pending requests done');
+		return true;
+	}
 
-    if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
-        return
-    }
-    return true 
-}
-
-
-NewRelicReporter.prototype.cleanup = function (done) {
-    done()
+	cleanup(done) {
+		debug('cleaning up');
+		// done();
+		return this.waitingForRequest().then(done);
+	}
+	
 }
 
 function createNewRelicReporter (config, events, script) {
-   return new NewRelicReporter(config, events, script)
+	return new NewRelicReporter(config, events, script)
 };
 
 module.exports = {
-    createNewRelicReporter
+	createNewRelicReporter
 };
-

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic.js
@@ -1,0 +1,202 @@
+const got = require('got')
+const debug = require('debug')('plugin:publish-metrics:newrelic');
+
+function NewRelicReporter(config, events, script) {
+    this.metricEndpoint = config.region && config.region === 'eu' 
+        ? "https://metric-api.eu.newrelic.com/metric/v1" 
+        : 'https://metric-api.newrelic.com/metric/v1';
+    
+    this.reqHeaders = {
+        'Content-Type': 'application/json; charset=UTF-8',
+        'Api-Key': config.licenceKey,
+    };
+
+    
+
+
+    // TODO check in new relic the attributes?tags and how to call them -how they are called/used in the user platform 
+    // TODO rewrite the formatConfig and rethink implementation 
+    // TODO rethink the metric formater functions and their implementation
+    // TODO turn to class
+
+
+
+    debug('Creating NewRelicReporter with config');
+    debug(Object.assign(config, { licenceKey: sanitize(config.licenceKey) }));
+    
+    this.config = formatConfig(config)
+
+    debug('awaiting stats');
+    events.on('stats', async (stats) => {
+        let timestamp = Date.now();
+        const interval = stats.lastCounterAt - stats.firstCounterAt;
+
+        const rates = formatRatesForNewRelic(stats.rates, this.config);
+        const counters = formatCountersForNewRelic(stats.counters, this.config);
+        const summaries = formatSummariesForNewRelic(stats.summaries, this.config);
+
+        const reqBody = createRequestBody (timestamp, interval, this.attributes, [...rates, ...counters, ...summaries]);
+        await sendStats (this.metricEndpoint, this.reqHeaders, reqBody)
+
+    });
+
+    return this
+}; 
+
+// function formatStatsForNewRelic (stats, propertyName) {
+//     const statMetrics = [];
+//     let metric = {
+//         type: propertyName === "counters" ? "count" : "gauge",
+//         name: "",
+//         value: null
+//     }
+//     for (const[label, value] of Object.entries(stats || {})) {
+//         if (propertyName === "summaries") {
+//             for (const [agreggation, valueNum] of Object.entries(stats || {})) {
+//                 metric.name = `artillery.${label}.${agreggation}`;
+//                 metric.value = valueNum
+//                 statMetrics.push(metric)
+//             };
+//         } else {
+//             metric.name = "artillery." + label
+//             metric.value = value
+//             statMetrics.push(metric)
+//         }
+//     }
+//     return statMetrics
+// }
+
+function formatConfig(config) {
+    const formatedConfig = Object.assign(
+        {
+            prefix: 'artillery.',
+            excluded: [],
+            includeOnly: [],
+            attributes: []
+        },
+        config
+    );
+    
+    // TODO change  
+    formatedConfig.attributes = 
+        config.attributes.reduce(
+            (acc, attribute) => {
+                 return acc[attribute.split(':')[0]] = attribute.split(':')[1]
+            },
+            {}
+        ) ?? [];
+    return formatedConfig
+}
+
+function formatCountersForNewRelic (counters, config) {
+    debug('formating stats counters');
+    const statMetrics = []
+    for (const[name, value] of Object.entries(counters || {})) {
+        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+            metric = {
+                name: config.prefix + name,
+                type: "count",
+                value
+            };
+            statMetrics.push(metric)
+        }
+    }
+    // debug('LIST OF COUNTERS SENT TO NR:', statMetrics)
+    return statMetrics
+}
+
+
+function formatRatesForNewRelic (rates, config) {
+    debug('formating stats rates');
+    const statMetrics = []
+    for (const[name, value] of Object.entries(rates || {})) {
+        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+            metric = {
+                name: config.prefix + name,
+                type: "gauge",
+                value
+            };
+            statMetrics.push(metric)
+        };
+    }
+    return statMetrics
+}
+
+function formatSummariesForNewRelic (summaries, config) {
+    debug('formating stats summaries');
+    const statMetrics = []
+    for (const[name, values] of Object.entries(summaries || {})) {
+        if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+            for (const [agreggation, value] of Object.entries(values)){
+                metric = {
+                    name: `${config.prefix}${name}.${agreggation}`,
+                    type: "gauge",
+                    value
+                }
+                statMetrics.push(metric)
+            };
+        
+        };
+    }
+    return statMetrics
+}
+
+function createRequestBody (timestamp, interval, attributes, metrics) { 
+    debug('creating request body')
+    const body = [
+        {
+            common: {
+                timestamp,
+                "interval.ms": interval,
+                attributes,
+            },
+            metrics
+        }
+    ]
+    return body
+}
+
+async function sendStats(url, headers, body) {
+    const options = {
+        headers,
+        json: body
+    }
+    debug('sending metrics to New Relic')
+    try{
+        const res = await got.post(url, options)
+        if ( res.statusCode !== 202 ) {
+            debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`)
+        }
+    } catch (err) {
+        debug(err)
+    }
+}
+
+function sanitize(str) {
+    return `${str.substring(0, 3)}********************${str.substring(str.length - 3, str.length)}`;
+}
+
+function shouldSendMetric (metricName, excluded, includeOnly) {
+    if (excluded.includes(metricName)) {
+        return
+    };
+
+    if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+        return
+    }
+    return true 
+}
+
+
+NewRelicReporter.prototype.cleanup = function (done) {
+    done()
+}
+
+function createNewRelicReporter (config, events, script) {
+   return new NewRelicReporter(config, events, script)
+};
+
+module.exports = {
+    createNewRelicReporter
+};
+

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
@@ -1,0 +1,50 @@
+## New Relic
+
+The plugin supports sending metrics to the New Relic Metric API.
+
+By default, all Artillery metrics will be sent to New Relic. Each Artillery metric will create a custom New Relic metric, which will have an associated charge.
+
+You can configure a specific list of metrics to send with the includeOnly setting (see Configuration section below).
+
+- To send metrics to New Relic, set `type` to `newrelic`.
+- Set `licenseKey` to the license key for the account you want to send the metrics to
+- `region` -- use this to override the default New Relic endpoint which is set to the US region. If your account hosts data in the EU data center make sure you set the region to `eu`.
+- `prefix` -- use a prefix for metric names created by Artillery; defaults to artillery.
+- `attributes` -- a list of name:value strings to use as tags for all metrics sent during a test
+- `excluded` -- A list of metric names which should not be sent to New Relic. Defaults to an empty list, i.e. all metrics are sent to New Relic.
+- `includeOnly` -- A list of specific metrics to send to New Relic. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent to New Relic.
+
+
+For information on how to query data ingested through the Metrics API consult [New Relic docs](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/introduction-metric-api/#find-data). 
+
+
+### Debugging
+
+Set DEBUG=plugin:publish-metrics:newrelic when running your tests to print out helpful debugging messages when sending metrics to New Relic
+
+```
+DEBUG=plugin:publish-metrics:newrelic artillery run my-script.yaml
+```
+
+
+### Example: New Relic
+
+```
+config:
+  plugins:
+    publish-metrics:
+      - type: newrelic
+        region: eu
+        # NR_LICENSE_KEY is an environment variable containing the API key
+        apiKey: "{{ $processEnvironment.NR_LICENSE_KEY }}"
+        prefix: 'artillery.publish_metrics_plugin.'
+        attributes:
+          - "testId:mytest123"
+          - "type:loadtest"
+
+```
+
+### Not Currently Supported
+
+- Sending Events (e.g. test start/finish)
+- New Relic Agent

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -35,7 +35,6 @@ class NewRelicReporter {
 			
 			const reqBody = this.createRequestBody(timestamp, interval, this.config.attributes, [...rates, ...counters, ...summaries]);
 			await this.sendStats(this.metricsAPIEndpoint, this.config.licenseKey, reqBody);
-			
 		});
 		
 	};
@@ -47,6 +46,7 @@ class NewRelicReporter {
 			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
 				continue
 			};
+
 			const metric = {
 				name: config.prefix + name,
 				type: "count",
@@ -54,6 +54,7 @@ class NewRelicReporter {
 			};
 			statMetrics.push(metric);
 		};
+
 		return statMetrics;
 	};
 	
@@ -64,6 +65,7 @@ class NewRelicReporter {
 			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
 				continue
 			};
+
 			const metric = {
 				name: config.prefix + name,
 				type: "gauge",
@@ -71,6 +73,7 @@ class NewRelicReporter {
 			};
 			statMetrics.push(metric);
 		};
+
 		return statMetrics;
 	};
 	
@@ -81,6 +84,7 @@ class NewRelicReporter {
 			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
 				continue
 			};
+
 			for (const [agreggation, value] of Object.entries(values)){
 				const metric = {
 					name: `${config.prefix}${name}.${agreggation}`,
@@ -90,6 +94,7 @@ class NewRelicReporter {
 				statMetrics.push(metric);
 			};
 		};
+
 		return statMetrics;
 	};
 	
@@ -102,6 +107,7 @@ class NewRelicReporter {
 				parsedAttributes[attribute[0]] = attribute[1];
 			};
 		};
+
 		const body = [
 			{
 				common: {
@@ -112,6 +118,7 @@ class NewRelicReporter {
 				metrics
 			}
 		]
+
 		return body;
 	};
 	
@@ -125,6 +132,7 @@ class NewRelicReporter {
 			headers,
 			json: body
 		};
+
 		debug('sending metrics to New Relic');
 		try{
 			const res = await got.post(url, options);
@@ -141,13 +149,14 @@ class NewRelicReporter {
 	// checks if metric should be sent by screening for it in the excluded and includeOnly lists
 	shouldSendMetric (metricName, excluded, includeOnly) {
 		if (excluded.includes(metricName)) {
-			return
+			return;
 		};
 		
 		if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
-			return
+			return;
 		};
-		return true 
+
+		return true;
 	};
 
 	async waitingForRequest() {

--- a/packages/artillery-plugin-publish-metrics/test/config-newrelic-api.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-newrelic-api.yaml
@@ -1,0 +1,15 @@
+config:
+  target: https://artillery.io
+  phases:
+    - duration: 11
+      arrivalRate: 1
+  plugins:
+    publish-metrics:
+      - type: newrelic
+        region: 'us'
+        licenseKey: "{{ $processEnvironment.NR_LICENSE_KEY }}"
+        prefix: 'artillery.publish_metrics_plugin.'
+        attributes:
+          - "testId:{{ $processEnvironment.TEST_ID }}"
+          - "reporterType:newrelic-metric-api"
+


### PR DESCRIPTION
## What
New Relic target for `artillery-publish-metrics` plugin. Supports sending metrics to New Relic through **Metric API**. 

## How
`NewRelicReporter` class that has the plugin `config` from test script and `events` as properties. On every `'stats'` event it takes metrics from the `stats` object, formats and packs them into `HTTP POST` request in format recognised by New Relic Metric API, and sends the request using `got`  library. 

Configuration options for users are:

- `licenseKey` -- license key must be provided,
- `region` -- two regions available for New Relic, `us` and `eu`, defaults to `us`. Each region has its own endpoint so it is required to set region as `eu` if users New Relic account hosts data in the EU data center.
- `prefix` -- prefix for metric names created by Artillery; defaults to `artillery.`
- `attributes` -- a list of name:value strings to use as attributes/tags for all metrics sent during a test. 
- `excluded` -- A list of metric names which should not be sent to New Relic. Defaults to an empty list, i.e. all metrics are sent to New Relic.
- `includeOnly` -- A list of specific metrics to send to New Relic. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent to New Relic.

The class is then initialised with the `new` constructor inside `createNewRelicReporter` function which is exported, and plugged into the main artillery-plugin-publish-metrics `index.js` with other target reporters. 

The `README.md` has been updated by adding New Relic to targets list and removing it from wish list. 
There is also a New Relic specific `README.md` file inside the newrelic folder that has a plugin description consistent with the descriptions used for other targets in [artillery.io](https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#overview)

## Testing
As no testing has been set yet (from what I could see) for the targets in this plugin, I did not write specific tests yet. I did see that `config.yaml` files were added for each target so to reflect that I created an equivalent file for the New Relic target.

I have however tested the plugin manually with different scripts and combinations to make sure everything is created/ formatted properly and that  the metrics arrive as they should to New Relic and in those tests I did not notice any issues. 

## Screenshots

![Screenshot from 2023-03-14 16-48-54](https://user-images.githubusercontent.com/39635558/225078569-7c93e66a-315d-4cae-877c-7a1ba315124b.png)
![Screenshot from 2023-03-14 16-50-06](https://user-images.githubusercontent.com/39635558/225078594-9c73f1f6-cecb-400f-bc83-0ca171e49314.png)
