### PR TITLE
feat: splunk publish metrics plugin target

### DIFF
--- a/packages/artillery-plugin-publish-metrics/README.md
+++ b/packages/artillery-plugin-publish-metrics/README.md
@@ -8,6 +8,7 @@ The plugin sends metrics and events from Artillery tests to external monitoring 
 
 - [AWS CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html)
 - Datadog - (via [agent](https://docs.datadoghq.com/agent/) or [HTTP API](https://docs.datadoghq.com/api/))
+- [Splunk](https://splunk.com)
 - [Prometheus](https://prometheus.io/docs/concepts/metric_types/) via [Pushgateway](https://prometheus.io/docs/instrumenting/pushing/)
 - [Honeycomb](https://honeycomb.io)
 - [Lightstep](https://lightstep.com)
@@ -23,5 +24,4 @@ The plugin sends metrics and events from Artillery tests to external monitoring 
 
 - NewRelic
 - InfluxDB (HTTP API)
-- Splunk
 - ELK

--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -20,6 +20,7 @@ module.exports = {
 };
 
 function Plugin(script, events) {
+  console.log('PLUGIN PULLED');
   this.script = script;
   this.events = events;
 
@@ -54,6 +55,7 @@ function Plugin(script, events) {
       );
     }
   });
+  console.log('REPORTERS:', this.reporters);
   return this;
 }
 

--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -7,6 +7,7 @@ const debug = require('debug')(NS);
 const A = require('async');
 
 const { createDatadogReporter } = require('./lib/datadog');
+const { createSplunkReporter } = require('./lib/splunk');
 const { createHoneycombReporter } = require('./lib/honeycomb');
 const { createLightstepReporter } = require('./lib/lightstep');
 const { createMixPanelReporter } = require('./lib/mixpanel');
@@ -30,6 +31,8 @@ function Plugin(script, events) {
       config.type === 'influxdb-statsd'
     ) {
       this.reporters.push(createDatadogReporter(config, events, script));
+    } else if (config.type === 'splunk') {
+      this.reporters.push(createSplunkReporter(config, events, script));
     } else if (config.type === 'honeycomb') {
       this.reporters.push(createHoneycombReporter(config, events, script));
     } else if (config.type === 'lightstep') {

--- a/packages/artillery-plugin-publish-metrics/lib/classifynewr.js
+++ b/packages/artillery-plugin-publish-metrics/lib/classifynewr.js
@@ -1,0 +1,387 @@
+const got = require('got')
+const debug = require('debug')('plugin:publish-metrics:newrelic');
+
+
+class NewRelicReporter {
+	constructor(config, events) {
+		// debug(Object.assign(config, { licenseKey: this.sanitize(config.licenseKey) }));
+
+		this.config = {
+			region: config.region || 'us',
+			prefix: config.prefix || 'artillery.',
+			excluded: config.excluded || [],
+			includeOnly: config.includeOnly || [],
+			attributes: config.attributes || [],
+			licenseKey: config.licenseKey,
+		};
+		
+		this.metricsAPIEndpoint = this.config.region === 'eu' 
+        ? "https://metric-api.eu.newrelic.com/metric/v1"
+        : 'https://metric-api.newrelic.com/metric/v1';
+		
+		this.eventsAPIEndpoint = this.config.region === 'eu' 
+				? 'https://insights-collector.eu01.nr-data.net' 
+				: 'https://insights-collector.newrelic.com';
+		
+		this.pendingRequests = 0;
+		
+		events.on('stats', async (stats) => {
+			const timestamp = Date.now();
+			const interval = Number(stats.lastCounterAt) - Number(stats.firstCounterAt);
+			
+			const rates = this.formatRatesForNewRelic(stats.rates, this.config);
+			const counters = this.formatCountersForNewRelic(stats.counters, this.config);
+			const summaries = this.formatSummariesForNewRelic(stats.summaries, this.config);
+			
+			const reqBody = this.createRequestBody(timestamp, interval, this.config.attributes, [...rates, ...counters, ...summaries]);
+			await this.sendStats(this.metricsAPIEndpoint, this.config.licenseKey, reqBody)
+			
+		});
+		
+		debug('init done');
+	}
+	
+	formatCountersForNewRelic (counters, config) {
+		debug('formating stats counters');
+		const statMetrics = []
+		for (const[name, value] of Object.entries(counters || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			const metric = {
+				name: config.prefix + name,
+				type: "count",
+				value
+			};
+			statMetrics.push(metric)
+		}
+		return statMetrics
+	}
+	
+	formatRatesForNewRelic (rates, config) {
+		debug('formating stats rates');
+		const statMetrics = []
+		for (const[name, value] of Object.entries(rates || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			const metric = {
+				name: config.prefix + name,
+				type: "gauge",
+				value
+			};
+			statMetrics.push(metric)
+		}
+		return statMetrics
+	}
+	
+	formatSummariesForNewRelic (summaries, config) {
+		debug('formating stats summaries');
+		const statMetrics = []
+		for (const[name, values] of Object.entries(summaries || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+			for (const [agreggation, value] of Object.entries(values)){
+				const metric = {
+					name: `${config.prefix}${name}.${agreggation}`,
+					type: "gauge",
+					value
+				}
+				statMetrics.push(metric)
+			};
+		}
+		return statMetrics
+	}
+	
+	createRequestBody (timestamp, interval, attributeList, metrics) { 
+		debug('creating request body')
+		const parsedAttributes = {};
+		if (attributeList.length > 0) {
+			for (const item of attributeList) {
+				const attribute = item.split(':')
+				parsedAttributes[attribute[0]] = attribute[1]
+			}
+		}
+		const body = [
+			{
+				common: {
+					timestamp,
+					'interval.ms': interval,
+					attributes: parsedAttributes,
+				},
+				metrics
+			}
+		]
+		return body
+	}
+	
+	async sendStats(url, licenseKey, body) {
+		this.pendingRequests += 1;
+		const headers = {
+			'Content-Type': 'application/json; charset=UTF-8',
+			'Api-Key': licenseKey,
+		};
+		const options = {
+			headers,
+			json: body
+		};
+		debug('sending metrics to New Relic')
+		try{
+			const res = await got.post(url, options)
+			if ( res.statusCode !== 202 ) {
+				debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`)
+			}
+		} catch (err) {
+			debug(err)
+		}
+		
+		this.pendingRequests -= 1;
+	}
+	
+	shouldSendMetric (metricName, excluded, includeOnly) {
+		if (excluded.includes(metricName)) {
+			return
+		};
+		
+		if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+			return
+		}
+		return true 
+	}
+	
+	sanitize (str) {
+    return `${str.substring(0, 3)}********************${str.substring(str.length - 3, str.length)}`;
+	}
+
+	async waitingForRequest() {
+		while (this.pendingRequests > 0) {
+			debug('Waiting for pending request ...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		} ;
+		
+		debug('Pending requests done');
+		return true;
+	}
+
+	cleanup(done) {
+		debug('cleaning up');
+		// done();
+		return this.waitingForRequest().then(done);
+	}
+	
+}
+
+function createNewRelicReporter (config, events, script) {
+	return new NewRelicReporter(config, events, script)
+};
+
+module.exports = {
+	createNewRelicReporter
+};
+
+
+
+
+
+
+// const got = require('got')
+// const debug = require('debug')('plugin:publish-metrics:newrelic');
+
+// function NewRelicReporter(config, events, script) {
+    // this.metricEndpoint = config.region && config.region === 'eu' 
+    //     ? "https://metric-api.eu.newrelic.com/metric/v1" 
+    //     : 'https://metric-api.newrelic.com/metric/v1';
+    
+//     this.reqHeaders = {
+//         'Content-Type': 'application/json; charset=UTF-8',
+//         'Api-Key': config.licenceKey,
+//     };
+
+    
+
+
+//     // TODO check in new relic the attributes?tags and how to call them -how they are called/used in the user platform 
+//     // TODO rewrite the formatConfig and rethink implementation 
+//     // TODO rethink the metric formater functions and their implementation
+//     // TODO turn to class
+
+
+
+//     debug('Creating NewRelicReporter with config');
+//     debug(Object.assign(config, { licenseKey: sanitize(config.licenseKey) }));
+    
+//     this.config = formatConfig(config)
+
+//     debug('awaiting stats');
+//     events.on('stats', async (stats) => {
+//         let timestamp = Date.now();
+//         const interval = stats.lastCounterAt - stats.firstCounterAt;
+
+//         const rates = formatRatesForNewRelic(stats.rates, this.config);
+//         const counters = formatCountersForNewRelic(stats.counters, this.config);
+//         const summaries = formatSummariesForNewRelic(stats.summaries, this.config);
+
+//         const reqBody = createRequestBody (timestamp, interval, this.config.attributes, [...rates, ...counters, ...summaries]);
+//         await sendStats (this.metricEndpoint, this.reqHeaders, reqBody)
+
+//     });
+
+//     return this
+// }; 
+
+// // function formatStatsForNewRelic (stats, propertyName) {
+// //     const statMetrics = [];
+// //     let metric = {
+// //         type: propertyName === "counters" ? "count" : "gauge",
+// //         name: "",
+// //         value: null
+// //     }
+// //     for (const[label, value] of Object.entries(stats || {})) {
+// //         if (propertyName === "summaries") {
+// //             for (const [agreggation, valueNum] of Object.entries(stats || {})) {
+// //                 metric.name = `artillery.${label}.${agreggation}`;
+// //                 metric.value = valueNum
+// //                 statMetrics.push(metric)
+// //             };
+// //         } else {
+// //             metric.name = "artillery." + label
+// //             metric.value = value
+// //             statMetrics.push(metric)
+// //         }
+// //     }
+// //     return statMetrics
+// // }
+
+// function formatConfig(config) {
+//     const formatedConfig = Object.assign(
+//         {
+//             prefix: 'artillery.',
+//             excluded: [],
+//             includeOnly: [],
+//             attributes: []
+//         },
+//         config
+//     );
+    
+//     if (formatedConfig.attributes.length > 0) {
+//         formatedConfig.attributes = {};
+//         for (const attribute of config.attributes) {
+//             formatedConfig.attributes[attribute.split(':')[0]] = attribute.split(':')[1]
+//         }
+//     }
+//     return formatedConfig
+// }
+
+// function formatCountersForNewRelic (counters, config) {
+//     debug('formating stats counters');
+//     const statMetrics = []
+//     for (const[name, value] of Object.entries(counters || {})) {
+//         if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+//             metric = {
+//                 name: config.prefix + name,
+//                 type: "count",
+//                 value
+//             };
+//             statMetrics.push(metric)
+//         }
+//     }
+//     // debug('LIST OF COUNTERS SENT TO NR:', statMetrics)
+//     return statMetrics
+// }
+
+
+// function formatRatesForNewRelic (rates, config) {
+//     debug('formating stats rates');
+//     const statMetrics = []
+//     for (const[name, value] of Object.entries(rates || {})) {
+//         if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+//             metric = {
+//                 name: config.prefix + name,
+//                 type: "gauge",
+//                 value
+//             };
+//             statMetrics.push(metric)
+//         };
+//     }
+//     return statMetrics
+// }
+
+// function formatSummariesForNewRelic (summaries, config) {
+//     debug('formating stats summaries');
+//     const statMetrics = []
+//     for (const[name, values] of Object.entries(summaries || {})) {
+//         if (shouldSendMetric(name, config.excluded, config.includeOnly)) {
+//             for (const [agreggation, value] of Object.entries(values)){
+//                 metric = {
+//                     name: `${config.prefix}${name}.${agreggation}`,
+//                     type: "gauge",
+//                     value
+//                 }
+//                 statMetrics.push(metric)
+//             };
+        
+//         };
+//     }
+//     return statMetrics
+// }
+
+// function createRequestBody (timestamp, interval, attributes, metrics) { 
+//     debug('creating request body')
+//     const body = [
+//         {
+//             common: {
+//                 timestamp,
+//                 "interval.ms": interval,
+//                 attributes,
+//             },
+//             metrics
+//         }
+//     ]
+//     return body
+// }
+
+// async function sendStats(url, headers, body) {
+//     const options = {
+//         headers,
+//         json: body
+//     }
+//     debug('sending metrics to New Relic')
+//     try{
+//         const res = await got.post(url, options)
+//         if ( res.statusCode !== 202 ) {
+//             debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`)
+//         }
+//     } catch (err) {
+//         debug(err)
+//     }
+// }
+
+function sanitize(str) {
+    return `${str.substring(0, 3)}********************${str.substring(str.length - 3, str.length)}`;
+}
+
+// function shouldSendMetric (metricName, excluded, includeOnly) {
+//     if (excluded.includes(metricName)) {
+//         return
+//     };
+
+//     if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+//         return
+//     }
+//     return true 
+// }
+
+
+// NewRelicReporter.prototype.cleanup = function (done) {
+//     done()
+// }
+
+// function createNewRelicReporter (config, events, script) {
+//    return new NewRelicReporter(config, events, script)
+// };
+
+// module.exports = {
+//     createNewRelicReporter
+// };
+

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/README.md
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/README.md
@@ -26,7 +26,7 @@ DEBUG=plugin:publish-metrics:splunk artillery run my-script.yaml
 
 ### Example: Splunk
 
-```
+```yaml
 config:
   plugins:
     publish-metrics:
@@ -34,7 +34,7 @@ config:
         realm: eu0
         # SP_ACCESS_TOKEN is an environment variable containing the API key
         accessToken: "{{ $processEnvironment.SP_ACCESS_TOKEN }}"
-        prefix: 'artillery.publish_metrics_plugin.'
+        prefix: "artillery.publish_metrics_plugin."
         dimensions:
           - "host:server_1"
           - "host_id:1.2.3.4"

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/README.md
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/README.md
@@ -1,0 +1,45 @@
+## Splunk
+
+The plugin supports sending metrics to Splunk Observability Cloud via Ingest API.
+
+By default, all Artillery metrics will be sent to Splunk. Each Artillery metric will create a custom Splunk metric, which will have an associated charge.
+
+You can configure a specific list of metrics to send with the includeOnly setting (see Configuration section below).
+
+- To send metrics to Splunk, set `type` to `splunk`.
+- Set `accessToken` to your organisation's `INGEST` access token
+- `realm` -- use this to override the default Splunk endpoint which is set to the `us0` realm. A realm is a self-contained deployment that hosts organizations. You can find your realm name on your profile page in the user interface.
+- `prefix` -- use a prefix for metric names created by Artillery; defaults to artillery.
+- `dimensions` -- a list of name:value strings to use as dimensions for all metrics sent during a test. [Dimensions](https://docs.splunk.com/Observability/metrics-and-metadata/metrics-dimensions-mts.html#dimensions) are metadata sent in along with the metrics in the form of key-value pairs. They provide additional information about the metric, such as the name of the host that sent the metric. See type of information suitable for dimensions [here](https://docs.splunk.com/Observability/metrics-and-metadata/metric-names.html#type-of-information-suitable-for-dimensions)
+- `excluded` -- A list of metric names which should not be sent to Splunk. Defaults to an empty list, i.e. all metrics are sent to Splunk.
+- `includeOnly` -- A list of specific metrics to send to Splunk. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent to Splunk.
+
+For information on how to manage data ingested through the Splunk API consult [Splunk docs](https://docs.splunk.com/Observability/metrics-and-metadata/metrics-finder-metadata-catalog.html#use-the-metric-finder-and-metadata-catalog).
+
+### Debugging
+
+Set DEBUG=plugin:publish-metrics:splunk when running your tests to print out helpful debugging messages when sending metrics to Splunk
+
+```
+DEBUG=plugin:publish-metrics:splunk artillery run my-script.yaml
+```
+
+### Example: Splunk
+
+```
+config:
+  plugins:
+    publish-metrics:
+      - type: splunk
+        realm: eu0
+        # SP_ACCESS_TOKEN is an environment variable containing the API key
+        accessToken: "{{ $processEnvironment.SP_ACCESS_TOKEN }}"
+        prefix: 'artillery.publish_metrics_plugin.'
+        dimensions:
+          - "host:server_1"
+          - "host_id:1.2.3.4"
+```
+
+### Not Currently Supported
+
+- Sending Events (e.g. test start/finish)

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
@@ -1,181 +1,193 @@
-const signalFx = require("signalfx");
-const debug = require('debug')('plugin:publish-metrics:splunk');
+const got = require("got");
+const debug = require("debug")("plugin:publish-metrics:splunk");
 
 class SplunkReporter {
   constructor(config, events) {
     this.config = {
-      realm: config.realm || 'us0',
-      prefix: config.prefix || 'artillery.',
+      realm: config.realm || "us0",
+      prefix: config.prefix || "artillery.",
       excluded: config.excluded || [],
       includeOnly: config.includeOnly || [],
       accessToken: config.accessToken,
     };
-    
-    this.pendingRequests = 0;
+
     this.config.dimensions = this.parseDimensions(config.dimensions);
+    this.ingestAPIEndpoint = `https://ingest.${ this.config.realm }.signalfx.com/v2/datapoint`;
 
-    this.ingestAPIEndpoint = `https://ingest.${this.config.realm}.signalfx.com`;
+    this.pendingRequests = 0;
 
-    this.client = new signalFx.IngestJson(this.config.accessToken, {
-      ingestEndpoint: this.ingestAPIEndpoint,
-      dimensions: this.config.dimensions
-    });
-    debug('client created');
-
-    events.on('stats', async (stats) => {
-      debug('received stats event');
+    events.on("stats", async (stats) => {
+      debug("received stats event");
       const timestamp = Number(stats.period);
 
-      const rates = this.formatRatesForSplunk(stats.rates, this.config, timestamp);
-      const summaries = this.formatSummariesForSplunk(stats.summaries, this.config, timestamp);
-      const counters = this.formatCountersForSplunk(stats.counters, this.config, timestamp);
+      const rates = this.formatRatesForSplunk(
+        stats.rates,
+        this.config,
+        timestamp
+      );
+      const summaries = this.formatSummariesForSplunk(
+        stats.summaries,
+        this.config,
+        timestamp
+      );
+      const counters = this.formatCountersForSplunk(
+        stats.counters,
+        this.config,
+        timestamp
+      );
 
-			//rates and summaries are both gauges for Splunk, so we're combining them
-			const gauges = rates.concat(summaries);
+      //rates and summaries are both gauges for Splunk, so we're combining them
+      const gauges = rates.concat(summaries);
 
-      await this.sendStats(this.client, gauges, counters);
+      await this.sendStats(
+        this.ingestAPIEndpoint,
+        this.config.accessToken,
+        gauges,
+        counters
+      );
     });
   };
 
-  formatCountersForSplunk (counters, config, timestamp) {
-		const statCounts = [];
+  formatCountersForSplunk(counters, config, timestamp) {
+    const statCounts = [];
 
-		for (const[name, value] of Object.entries(counters || {})) {
-			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
-				continue;
-			};
+    for (const [name, value] of Object.entries(counters || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      };
 
-			const count = {
-				metric: config.prefix + name,
-				value,
-        timestamp
-			};
+      const count = {
+        metric: config.prefix + name,
+        value,
+        dimensions: config.dimensions,
+        timestamp,
+      };
 
-			statCounts.push(count);
-		};
+      statCounts.push(count);
+    };
 
-		return statCounts;
-	};
-	
-	
-	formatRatesForSplunk (rates, config, timestamp) {
-		const statGauges = [];
-		for (const[name, value] of Object.entries(rates || {})) {
-			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
-				continue;
-			};
+    return statCounts;
+  };
 
-			const gauge = {
-				metric: config.prefix + name,
-				value,
-        timestamp
-			};
+  formatRatesForSplunk(rates, config, timestamp) {
+    const statGauges = [];
+    for (const [name, value] of Object.entries(rates || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      };
 
-			statGauges.push(gauge);
-		};
+      const gauge = {
+        metric: config.prefix + name,
+        value,
+        dimensions: config.dimensions,
+        timestamp,
+      };
 
-		return statGauges;
-	};
-	
+      statGauges.push(gauge);
+    };
 
-	formatSummariesForSplunk (summaries, config, timestamp) {
-		const statGauges = [];
-		for (const[name, values] of Object.entries(summaries || {})) {
-			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
-				continue
-			};
+    return statGauges;
+  };
 
-			for (const [agreggation, value] of Object.entries(values)){
-				const gauge = {
-					metric: `${config.prefix}${name}.${agreggation}`,
-					value,
-          timestamp
-				};
+  formatSummariesForSplunk(summaries, config, timestamp) {
+    const statGauges = [];
+    for (const [name, values] of Object.entries(summaries || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      };
 
-				statGauges.push(gauge);
-			};
-		};
+      for (const [agreggation, value] of Object.entries(values)) {
+        const gauge = {
+          metric: `${ config.prefix }${ name }.${ agreggation }`,
+          value,
+          dimensions: config.dimensions,
+          timestamp,
+        };
 
-		return statGauges;
-	};
-	
+        statGauges.push(gauge);
+      };
+    };
+
+    return statGauges;
+  }
 
   parseDimensions(dimensionList) {
     if (dimensionList && dimensionList.length === 0) {
       return {};
     };
 
-		const parsedDimensions = {};
+    const parsedDimensions = {};
 
     for (const item of dimensionList) {
-      const dimension = item.split(':');
+      const dimension = item.split(":");
       parsedDimensions[dimension[0]] = dimension[1];
     };
-    
-		return parsedDimensions;
-	};
-	
 
-	async sendStats(client, gauges, counters) {
-    const report = {
-      gauges,
-      counters
+    return parsedDimensions;
+  };
+
+  async sendStats(url, token, gaugeArray, counterArray) {
+    const headers = {
+      "Content-Type": "application/json; charset=UTF-8",
+      "X-SF-Token": token,
     };
 
-		this.pendingRequests += 1;
+    const options = {
+      headers,
+      json: {
+        gauge: gaugeArray,
+        count: counterArray,
+      },
+    };
 
-		debug(`sending metrics to Splunk: \n${JSON.stringify(report)}`);
-		try{
-			 const res = await client.send(report);
-       debug(res === "OK" ? "Metrics sucessfully sent" : `Metric API not OK, response:\n${res}`);
-		} catch (err) {
-			debug(err);
-		};
-		
-		this.pendingRequests -= 1;
-	};
-	
+    this.pendingRequests += 1;
 
-	// checks if metric should be sent by screening for it in the excluded and includeOnly lists
-	shouldSendMetric (metricName, excluded, includeOnly) {
-		if (excluded.includes(metricName)) {
-			return;
-		};
-		
-		if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
-			return;
-		};
+    debug("sending metrics to Splunk");
+    try {
+      const res = await got.post(url, options);
+      if (res.statusCode !== 200) {
+        debug(`Status Code: ${ res.statusCode }, ${ res.statusMessage }`);
+      };
+    } catch (err) {
+      debug(err);
+    };
 
-		return true;
-	};
+    this.pendingRequests -= 1;
+  };
 
+  // checks if metric should be sent by screening for it in the excluded and includeOnly lists
+  shouldSendMetric(metricName, excluded, includeOnly) {
+    if (excluded.includes(metricName)) {
+      return;
+    };
 
-	async waitingForRequest() {
-		while (this.pendingRequests > 0) {
-			debug('Waiting for pending request ...');
-			await new Promise((resolve) => setTimeout(resolve, 500));
-		};
-		
-		debug('Pending requests done');
-		return true;
-	};
+    if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+      return;
+    };
 
+    return true;
+  };
 
-	cleanup(done) {
-		debug('cleaning up');
-		return this.waitingForRequest().then(done);
-	};
-	
+  async waitingForRequest() {
+    while (this.pendingRequests > 0) {
+      debug("Waiting for pending request ...");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    };
+
+    debug("Pending requests done");
+    return true;
+  };
+
+  cleanup(done) {
+    debug("cleaning up");
+    return this.waitingForRequest().then(done);
+  };
 };
 
-
-function createSplunkReporter (config, events, script) {
-	return new SplunkReporter(config, events, script);
+function createSplunkReporter(config, events, script) {
+  return new SplunkReporter(config, events, script);
 };
-
 
 module.exports = {
-	createSplunkReporter
+  createSplunkReporter,
 };
-
-

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
@@ -1,0 +1,170 @@
+const signalFx = require("signalfx");
+const debug = require('debug')('plugin:publish-metrics:splunk');
+
+class SplunkReporter {
+  constructor(config, events) {
+    this.config = {
+      realm: config.realm || 'us0',
+      prefix: config.prefix || 'artillery.',
+      excluded: config.excluded || [],
+      includeOnly: config.includeOnly || [],
+      accessToken: config.accessToken,
+    };
+
+    this.pendingRequests = 0
+
+    this.config.dimensions = this.parseDimensions(config.dimensions);
+
+    this.ingestAPIEndpoint = `https://ingest.${this.config.realm}.signalfx.com/v2/`;
+
+    this.client = new signalFx.IngestJson(this.config.accessToken, {
+      ingestEndpoint: this.ingestAPIEndpoint,
+      dimensions: this.config.dimensions
+    });
+
+    events.on('stats', async (stats) => {
+      const timestamp = Number(stats.period);
+
+      const rates = this.formatRatesForSplunk(stats.rates, this.config, timestamp);
+      const summaries = this.formatSummariesForSplunk(stats.summaries, this.config, timestamp);
+
+      const gauges = rates.concat(summaries);
+      const counters = this.formatCountersForSplunk(stats.counters, this.config, timestamp);
+
+      this.sendStats(this.client, gauges, counters);
+    });
+  };
+
+  formatCountersForSplunk (counters, config, timestamp) {
+		const statCounts = [];
+
+		for (const[name, value] of Object.entries(counters || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+
+			const count = {
+				metric: config.prefix + name,
+				value,
+        timestamp
+			};
+
+			statCounts.push(count);
+		};
+
+		return statCounts;
+	};
+	
+	
+	formatRatesForSplunk (rates, config, timestamp) {
+		const statGauges = [];
+
+		for (const[name, value] of Object.entries(rates || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+
+			const gauge = {
+				metric: config.prefix + name,
+				value,
+        timestamp
+			};
+
+			statGauges.push(gauge);
+		};
+
+		return statGauges;
+	};
+	
+	formatSummariesForSplunk (summaries, config, timestamp) {
+		const statGauges = [];
+
+		for (const[name, values] of Object.entries(summaries || {})) {
+			if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+				continue
+			};
+
+			for (const [agreggation, value] of Object.entries(values)){
+				const gauge = {
+					metric: `${config.prefix}${name}.${agreggation}`,
+					value,
+          timestamp
+				};
+
+				statGauges.push(gauge);
+			};
+		};
+
+		return statGauges;
+	};
+	
+  parseDimensions(dimensionList) {
+    if (dimensionList && dimensionList.length === 0) {
+      return {}
+    }
+		parsedDimensions = {}
+    for (const item of dimensionList) {
+      const dimension = item.split(':');
+      parsedDimensions[dimension[0]] = dimension[1];
+    };
+    
+		return parsedDimensions;
+	};
+	
+	async sendStats(client, gauges, counters) {
+    const report = {
+      gauges,
+      counters
+    };
+
+		this.pendingRequests += 1;
+
+		debug('sending metrics to Splunk');
+		try{
+			 await client.send(report);
+		} catch (err) {
+			debug(err);
+		};
+		
+		this.pendingRequests -= 1;
+	};
+	
+	// checks if metric should be sent by screening for it in the excluded and includeOnly lists
+	shouldSendMetric (metricName, excluded, includeOnly) {
+		if (excluded.includes(metricName)) {
+			return;
+		};
+		
+		if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+			return;
+		};
+
+		return true;
+	};
+
+	async waitingForRequest() {
+		while (this.pendingRequests > 0) {
+			debug('Waiting for pending request ...');
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		};
+		
+		debug('Pending requests done');
+		return true;
+	};
+
+	cleanup(done) {
+		debug('cleaning up');
+		return this.waitingForRequest().then(done);
+	};
+	
+};
+
+function createSplunkReporter (config, events, script) {
+	return new SplunkReporter(config, events, script);
+};
+
+module.exports = {
+	createSplunkReporter
+};
+
+

--- a/packages/artillery-plugin-publish-metrics/lib/stats.txt
+++ b/packages/artillery-plugin-publish-metrics/lib/stats.txt
@@ -1,0 +1,75 @@
+{
+    counters: {
+      'vusers.created_by_name.0': 60,
+      'vusers.created': 60,
+      'http.requests': 180,
+      'http.codes.200': 120,
+      'http.responses': 180,
+      'plugins.expect.ok': 180,
+      'plugins.expect.ok.statusCode': 60,
+      'plugins.expect.ok.notStatusCode': 120,
+      'http.codes.404': 60,
+      'vusers.failed': 0,
+      'vusers.completed': 60
+    },
+    histograms: {
+      'http.response_time': BaseDDSketch {
+        mapping: [LogarithmicMapping],
+        store: [DenseStore],
+        negativeStore: [DenseStore],
+        zeroCount: 28,
+        count: 180,
+        min: 0,
+        max: 5,
+        sum: 213
+      },
+      'vusers.session_length': BaseDDSketch {
+        mapping: [LogarithmicMapping],
+        store: [DenseStore],
+        negativeStore: [DenseStore],
+        zeroCount: 0,
+        count: 60,
+        min: 6.510514,
+        max: 48.994247,
+        sum: 743.593006
+      }
+    },
+    rates: { 'http.request_rate': 21 },
+    'http.request_rate': NaN,
+    firstCounterAt: 1678050750622,
+    firstHistogramAt: 1678050750626,
+    lastCounterAt: 1678050759974,
+    lastHistogramAt: 1678050759974,
+    firstMetricAt: 1678050750622,
+    lastMetricAt: 1678050759974,
+    period: '1678050750000',
+    summaries: {
+      'http.response_time': {
+        min: 0,
+        max: 5,
+        count: 180,
+        p50: 1,
+        median: 1,
+        p75: 1,
+        p90: 2,
+        p95: 3,
+        p99: 5,
+        p999: 5
+      },
+      'vusers.session_length': {
+        min: 6.5,
+        max: 49,
+        count: 60,
+        p50: 10.7,
+        median: 10.7,
+        p75: 13.3,
+        p90: 16,
+        p95: 18.7,
+        p99: 46.1,
+        p999: 46.1
+      }
+    }
+  }
+
+
+  

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -26,6 +26,7 @@
     "opentracing": "^0.14.5",
     "prom-client": "^14.0.1",
     "semver": "^7.3.5",
+    "signalfx": "^7.4.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -26,7 +26,6 @@
     "opentracing": "^0.14.5",
     "prom-client": "^14.0.1",
     "semver": "^7.3.5",
-    "signalfx": "^7.4.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/artillery-plugin-publish-metrics/test/config-splunk.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-splunk.yaml
@@ -1,0 +1,9 @@
+config:
+  plugins:
+    publish-metrics:
+      - type: splunk
+        realm: eu0
+        accessToken: "{{ $processEnvironment.SP_ACCESS_TOKEN }}"
+        prefix: "artillery.publish_metrics_plugin."
+        dimensions:
+          - "testId:{{ $processEnvironment.TEST_ID }}"


### PR DESCRIPTION
## What
Splunk target for artillery-publish-metrics plugin. Supports sending metrics to Splunk Observability Cloud via Ingest API.

## How
SplunkReporter class that has the plugin config from test script and events as properties. On every 'stats' event it takes metrics from the stats object, formats and packs them into a format recognised by the ingest API, and sends the request using  `got` library. 

### Configuration options for users are:

`accessToken` -- org ingest access token must be provided,
`realm` --  defaults to `us0`. Must be set if the account's realm is different than `us0` as each realm has its own endpoint.
`prefix` -- prefix for metric names created by Artillery; defaults to artillery.
`dimensions` -- a list of name:value strings to use as dimensions for all metrics sent during a test.
`excluded` -- A list of metric names which should not be sent to Splunk. Defaults to an empty list, i.e. all metrics are sent.
`includeOnly` -- A list of specific metrics to send to Splunk. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent.
The class is then initialised with the `new` constructor inside `createSplunkReporter` function which is exported, and plugged into the main artillery-plugin-publish-metrics `index.js` with other target reporters.

The `README.md` has been updated by adding Splunk to targets list and removing it from wish list.
There is also a Splunk specific `README.md` file inside the splunk folder that has a plugin description consistent with the descriptions used for other targets in [artillery.io](https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#overview)

## Note:
At first I used the Splunk (SignalFx) Node.js SDK as per convention, but I ran into multiple issues with it:

- Installing versions 8.x.x-beta.x of the SDK would run into a webpack error `npm ERR! sh: 1: webpack: not found`. This error was inconsistent. In some versions (e.g. 8.0.0-beta.4) it was present, in others it was not;
- In some of the versions where the error above was not present, high and critical security vulnerabilities were present instead;
- Furthermore, these versions appeared released on NPM, but there was no release on Github or mention of the change.
- I ended up installing version 7.4.1. which seemed stable at the time, but yesterday presented with multiple high and one critical vulnerability
- The SDK did not have a lot of documentation;
- The error handling of the SDK was not the best. For example, even the success case just returns OK, and when it errors there is not much information coming from the error.
- Also for the functionality I am using, the SDK anyway doesn't add much.

Given all of the above, I decided to call the HTTP API directly instead.

## Testing
For now I have created a config.yaml file for the Splunk target equivalent to the ones set for other targets, and have tested the plugin manually. Everything seems to be working as it should, metrics get formatted correctly and successfully ingested by Splunk API.

## Screenshots
![Screenshot from 2023-03-20 16-37-32](https://user-images.githubusercontent.com/39635558/226408134-b795a194-0c41-46e7-81ff-dbcf0ca6f6d1.png)

![image](https://user-images.githubusercontent.com/39635558/226409404-d19745dd-cf44-426d-aaeb-85952b84f585.png)