### PR TITLE
feat: add initial version of apdex plugin

### DIFF
--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -39,6 +39,11 @@ class ApdexPlugin {
     global.artillery.ext({
       ext: 'beforeExit',
       method: async (testInfo) => {
+        if (typeof this.script?.config?.apdex === 'undefined' ||
+          typeof process.env.ARTILLERY_DISABLE_ENSURE !== 'undefined') {
+          return;
+        }
+
         const s = testInfo.report.counters['apdex_satisfied'] || 0;
         const t = testInfo.report.counters['apdex_tolerated'] || 0;
         const f = testInfo.report.counters['apdex_frustrated'] || 0;

--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -53,7 +53,7 @@ class ApdexPlugin {
           let ranking = '';
           if (apdexScore >= 0.94) {
             ranking = 'excellent';
-          }  else if (apdexScore >= 0.85) {
+          } else if (apdexScore >= 0.85) {
             ranking = 'good';
           } else if (apdexScore >= 0.7) {
             ranking = 'fair';
@@ -62,6 +62,11 @@ class ApdexPlugin {
           } else {
             ranking = 'unacceptable';
           }
+
+          global.artillery.apdexPlugin = {
+            apdex: apdexScore,
+            ranking
+          };
 
           console.log(`\nApdex score: ${apdexScore} (${ranking})`);
         } else {

--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const debug = require('debug')('plugin:apdex');
+
+class ApdexPlugin {
+  constructor(script, _events) {
+    this.script = script;
+
+    const t = script.config.apdex?.threshold || script.config.plugins.apdex?.threshold || 500;
+
+    if (!script.config.processor) {
+      script.config.processor = {};
+    }
+
+    script.scenarios.forEach(function (scenario) {
+      scenario.afterResponse = [].concat(scenario.afterResponse || []);
+      scenario.afterResponse.push('apdexAfterResponse');
+    });
+
+    function apdexAfterResponse(req, res, userContext, events, done) {
+      // apdex = ( satisfied + tolerating / 2 ) / total
+      const total = res.timings.phases.total;
+      if (total <= t) {
+        events.emit('counter', 'apdex_satisfied', 1);
+      } else if (total <= 4 * t) {
+        events.emit('counter', 'apdex_tolerated', 1);
+      } else {
+        events.emit('counter', 'apdex_frustrated', 1);
+      }
+
+      return done();
+    }
+
+    script.config.processor.apdexAfterResponse = apdexAfterResponse;
+  }
+}
+
+module.exports = {
+  Plugin: ApdexPlugin
+}

--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -4,7 +4,7 @@
   "description": "Calculate and report Apdex scores",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "exit 0"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "artillery-plugin-apdex",
+  "version": "0.0.1",
+  "description": "Calculate and report Apdex scores",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MPL-2.0"
+}

--- a/packages/artillery-plugin-ensure/index.js
+++ b/packages/artillery-plugin-ensure/index.js
@@ -45,7 +45,7 @@ class EnsurePlugin {
           }
 
           debug(JSON.stringify(data));
-          const vars = EnsurePlugin.statsToVars(data);
+          const vars = Object.assign({}, global.artillery.apdexPlugin || {}, EnsurePlugin.statsToVars(data));
           debug({vars});
 
           const checks = this.script.config.ensure;


### PR DESCRIPTION
Add support for Apdex [1] scores to Artillery.

- Threshold may be set via `config.apdex.threshold`
- Each HTTP request is compared against the threshold and classified as "satisfied", "tolerated" or "frustrated"
- Total number of each type of request is reported via `apdex_satisfied`, `apdex_tolerated`, and `apdex_frustrated` metrics
- Apdex score is calculated and reported at the end of the test run, along with a summary ("good" / "fair" / "poor")
- `ensure` checks may use the `apdex` variable in threshold & condition expressions

1. https://en.wikipedia.org/wiki/Apdex