### PR TITLE
fix(artillery): get lambdaRoleArn from platformConfig

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -83,7 +83,7 @@ class PlatformLambda {
     this.memorySize = platformConfig['memory-size'] || 4096;
 
     this.testRunId = platformOpts.testRunId || randomUUID();
-    this.lambdaRoleArn = platformOpts.lambdaRoleArn;
+    this.lambdaRoleArn = platformConfig['lambdaRoleArn'];
 
     this.platformOpts = platformOpts;
 


### PR DESCRIPTION
`platformOpts.lambdaRoleArn` always returns undefined. Test scripts always try to create or reuse the default Lambda role. The user-specified Lambda role needs to be fetched from the `platformConfig`.