### PR TITLE
fix(cloud): send metadata with testrun init event

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -40,9 +40,7 @@ class ArtilleryCloudPlugin {
       console.log(`Run URL: ${this.baseUrl}/load-tests/${this.testRunId}`);
 
       try {
-        await this._event('testrun:init', {});
-        await this._event('testrun:changestatus', { status: 'INITIALIZING' });
-        await this._event('testrun:addmetadata', {
+        await this._event('testrun:init', {
           metadata: testInfo.metadata
         });
         if (typeof testInfo.flags.note !== 'undefined') {


### PR DESCRIPTION
This PR fixes a behaviour in Artillery Cloud whereby "Untitled Test" appears for a few seconds when the test starts, by sending the test metadata together with the `testrun:init` event.

Notes:

- In doing so, we are also able to remove the `testrun:addmetadata` event, which is no longer needed, since it's sent in the init;
- Additionally, Artillery Cloud already sets `status` to `INITIALIZING`, so the `changestatus` event is unneeded.

### Testing

This was tested against a new version of Artillery Cloud expecting the new metadata information to be sent, and is working appropriately.