### PR TITLE
fix(skytrace): send parsed json body correctly to expect plugin

### DIFF
--- a/packages/skytrace/src/commands/ping.ts
+++ b/packages/skytrace/src/commands/ping.ts
@@ -433,7 +433,14 @@ class PingCommand extends Command {
       const isJSON = /json/gi.test(contentType)
       const isXML = /html/gi.test(contentType) || /xml/gi.test(contentType);
 
-      const parsedBody = (isJSON) ? JSON.parse(context.vars.body) : context.vars.body
+      let parsedBody;
+
+      try {
+        parsedBody = (isJSON) ? JSON.parse(context.vars.body) : context.vars.body
+      } catch (err) {
+        console.error(chalk.red(`Error JSON body: ${err.message}`));
+        process.exit(1);
+      }
 
       if (flags.showBody) {
         let language;


### PR DESCRIPTION
## Context

The Skytrace Smoke tests have been failing, due to a regression introduced by: https://github.com/artilleryio/artillery/commit/8a3e5c22d849d8a7495704273b0bda65bbbe48b6

In reality, that logic is fine, but Skytrace was sending the body as a string when it should be an object (JSON).

This PR does the following:
- Checks for contentType using `test` instead of `match` instead, so a boolean is returned (rather than null) when there is no match
- If it's a JSON, parses it to an object, otherwise sends content as is.

## Testing

The following commands were used to test this:

**(the failing test):**
```
./node_modules/skytrace/bin/run ping TEST_URL/api/load-tests/:uuid \
          -H "X-Auth-Token: API_KEY_HERE" \
          -bp \
          -e "statusCode: 200" \
          -e "contentType: application/json; charset=utf-8" \
          -e "jmespath: report.aggregate.summaries.[\"browser.page.FCP.https://www.artillery.io/docs\"][0].max != null"
```

```
./node_modules/skytrace/bin/run ping TEST_URL/api/user/whoami \                                             
          -H "X-Auth-Token: API_KEY_HERE" \
          -bp \
          -e "statusCode: 200" \
          -e "contentType: application/json; charset=utf-8"
```

```
./node_modules/skytrace/bin/run http post TEST_URL/api/load-tests/:uuid/note \
          -H "X-Auth-Token: API_KEY_HERE" \
          --json "{text: another note from skytrace}" \
          -e "statusCode: 204"
```