### PR TITLE
feat: enable sending events to new relic

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
@@ -1,0 +1,59 @@
+## New Relic
+
+To send metrics and/or events to New Relic set `type` to `newrelic`:
+
+```yaml
+config:
+  plugins:
+    publish-metrics:
+      - type: newrelic
+        apiKey: '{{ $processEnvironment.NEW_RELIC_LICENSE_KEY }}'
+        prefix: 'artillery.'
+        attributes:
+          - 'type:soak-test'
+          - 'service:my-service'
+```
+
+By default, all Artillery metrics will be sent to New Relic. Each Artillery metric will create a custom New Relic metric, which may have an associated cost.
+
+### Configuration options
+
+- To send metrics to New Relic, set `type` to `newrelic`.
+- Set `licenseKey` to the license key for the account you want to send the metrics to
+- `region` -- `us` (default) or `eu`. Thes sets default New Relic endpoint. If your account hosts data in the EU data center set the region to eu.
+- `prefix` -- set a prefix for metric names created by Artillery; defaults to `artillery`.
+- `attributes` -- a list of `name:value` strings to use as tags for all metrics sent during a test
+- `excluded` -- a list of metric names which should not be sent to New Relic. Defaults to an empty list, i.e. all metrics are sent to New Relic.
+- `includeOnly` -- a list of specific metrics to send to New Relic. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent to New Relic.
+- `event` -- set to send a New Relic event when the test starts/finishes.
+  - `accountId` -- your New Relic [account ID](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/).
+  - `eventType` -- set to customize the event's name, defaults to `Artillery_io_Test`. Must be a string that is a combination of alphanumeric characters, underscores, and colons.
+  - `send` -- set to `false` to turn off the event. By default, if an event is configured, it will be sent. This option makes it possible to turn event creation on/off on the fly (e.g. via an environment variable)
+  - `attributes` -- optional list of `name:value` strings to use as attributes/tags for events sent during a test. By default Artillery sends the `target: <target set in the script config>`, `timestamp: <timestamp of start/end of test>` and `phase: 'Test Started' / 'Test Finished'` attributes. Any `attributes` set will be sent in addition to the default ones. Check character [restrictions] for attributes [here](https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#instrument)
+
+```yaml
+config:
+  plugins:
+    publish-metrics:
+      - type: newrelic
+        apiKey: '{{ $processEnvironment.NEW_RELIC_LICENSE_KEY }}'
+        prefix: 'artillery.'
+        attributes:
+          - 'type:soak-test'
+          - 'service:my-service'
+        event:
+          accountId: '{{ $processEnvironment.NEW_RELIC_ACCOUNT_ID }}'
+          eventType: 'Artillery_load_test'
+          dimensions:
+            'alertType:info'
+            'priority:low'
+            'testId:myTest123'
+```
+
+### Debugging
+
+Set DEBUG=plugin:publish-metrics:newrelic when running your tests to print out helpful debugging messages when sending metrics to New Relic.
+
+```
+DEBUG=plugin:publish-metrics:newrelic artillery run my-script.yaml
+```

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/README.md
@@ -44,7 +44,7 @@ config:
         event:
           accountId: '{{ $processEnvironment.NEW_RELIC_ACCOUNT_ID }}'
           eventType: 'Artillery_load_test'
-          dimensions:
+          attributes:
             'alertType:info'
             'priority:low'
             'testId:myTest123'

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -133,9 +133,9 @@ class NewRelicReporter {
         continue;
       }
 
-      for (const [agreggation, value] of Object.entries(values)) {
+      for (const [aggregation, value] of Object.entries(values)) {
         const metric = {
-          name: `${config.prefix}${name}.${agreggation}`,
+          name: `${config.prefix}${name}.${aggregation}`,
           type: 'gauge',
           value
         };

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -266,7 +266,7 @@ class NewRelicReporter {
       this.eventOpts.timestamp = timestamp;
       this.eventOpts.phase = `Test Finished`;
 
-      const res = this.sendEvent(
+      this.sendEvent(
         this.eventsAPIEndpoint,
         this.config.licenseKey,
         this.eventOpts

--- a/packages/artillery-plugin-publish-metrics/test/config-newrelic-api.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-newrelic-api.yaml
@@ -7,9 +7,14 @@ config:
     publish-metrics:
       - type: newrelic
         region: 'us'
-        licenseKey: "{{ $processEnvironment.NR_LICENSE_KEY }}"
+        licenseKey: '{{ $processEnvironment.NR_LICENSE_KEY }}'
         prefix: 'artillery.publish_metrics_plugin.'
         attributes:
-          - "testId:{{ $processEnvironment.TEST_ID }}"
-          - "reporterType:newrelic-metric-api"
-
+          - 'testId:{{ $processEnvironment.TEST_ID }}'
+          - 'reporterType:newrelic-metric-api'
+        event:
+          accountId: '{{ $processEnvironment.NEW_RELIC_ACCOUNT_ID }}'
+          eventType: 'Plugin_integration_test'
+          attributes:
+            - 'priority:low'
+            - 'testId:myTest123'


### PR DESCRIPTION
## What

Events feature for the New Relic reporter of `artillery-publish-metrics` plugin. Supports sending events marking the start and the end of a test to New Relic through **Event API**.

## How

To handle sending events to New Relic's Event API, the `sendEvent` method is implemented, which formats the `HTTP POST` request and utilizes the `got` library to send it. The `sendEvent` method is called when the first `phaseStarted` event occurs to send the event for the test's start. Additionally, it is also utilized within the existing `cleanup` method to send the event marking the test's end.

The `startedEventSent` property acts as a toggle, storing the state of the test. It is checked before sending the event to ensure that the start event is only sent upon the first occurrence of the `phaseStarted` event. This mechanism guarantees that the event for the test's start is sent solely at the beginning of the test, rather than at the start of each phase. Moreover, it ensures that the code related to the event feature in the `cleanup` method is executed only when the feature is actually used.

Configuration for users:

To send events to New Relic `event` needs to be set in the New Relic reporter configuration in the test script. Event configuration options are:

- `accountId` -- users New Relic account ID is required,
- `eventType` -- event's name, defaults to `Artillery_io_Test`
- `send` -- set to false to turn off the event. By default, if an event is configured, it will be sent. This option makes it possible to turn event creation on/off on the fly (e.g. via an environment variable)
- `attributes` -- optional list of `name:value` strings to use as attributes/tags for events sent during a test. By default, the following attributes are set for every event: `target: <target set in script config>`, `timestamp: <timestamp of start/end of test>` and `phase: 'Test Started' / 'Test Finished'`. Any `attributes` set by user will be sent in addition to the default ones.

```yaml
config:
  target: 'http://mytestwebsite.com'
  plugins:
    publish-metrics:
      - type: newrelic
        licenseKey: '{{ $processEnvironment.NEW_RELIC_LICENSE_KEY }}'
        event:
          accountId: '{{ $processEnvironment.NEW_RELIC_ACCOUNT_ID }}'
          eventType: 'Plugin_integration_test'
          attributes:
            - 'priority:low'
            - 'testId:myTest123'
```

The New Relic specific `README.md` file (sent in the original PR for the New Relic Reporter) has been updated to reflect the addition of the event feature and I have included it in this PR. Its style formatting is still consistent with the one used in Artillery's docs for other reporters.

## Testing

`config-newrelic-api.yaml` file for New Relic has been updated to include the event feature.

I have tested manually with different scripts and combinations to make sure everything is formatted properly and that the events arrive as they should to New Relic and in those tests I did not notice any issues.

## Screenshots
![Image 28-06-2023 at 18 34](https://github.com/artilleryio/artillery/assets/39635558/4f0eec69-46c3-4290-be28-7186521b36dc)
