### PR TITLE
fix(artillery): update payload path when using environments

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -420,8 +420,10 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
   for (const fn of inputFiles) {
     const data = await readScript(fn);
     const parsedData = await parseScript(data);
-    script1 = await checkConfig(_.merge(script1, parsedData), fn, flags);
+    script1 = _.merge(script1, parsedData);
   }
+
+  script1 = await checkConfig(script1, inputFiles[0], flags)
 
   if (flags.config) {
     const absoluteConfigPath = path.resolve(process.cwd(), flags.config);

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -160,10 +160,11 @@ async function checkConfig(script, scriptPath, flags) {
   //
   const absoluteScriptPath = path.resolve(process.cwd(), scriptPath);
   _.forEach(script.config.payload, function (payloadSpec) {
-    payloadSpec.path = path.resolve(
+    const resolvedPathToPayload = path.resolve(
       path.dirname(absoluteScriptPath),
       payloadSpec.path
     );
+    payloadSpec.path = resolvedPathToPayload;
   });
 
   // if environment feature is used, then payload paths in environment must be replaced too
@@ -176,10 +177,12 @@ async function checkConfig(script, scriptPath, flags) {
       script.config.environments[flags.environment]
     ) {
       _.forEach(script.config.environments[flags.environment].payload, function (payloadSpec) {
-        payloadSpec.path = path.resolve(
+        const resolvedPathToPayload = path.resolve(
           path.dirname(absoluteScriptPath),
           payloadSpec.path
         );
+
+        payloadSpec.path = resolvedPathToPayload;
       });
     }}
 

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -167,35 +167,6 @@ async function checkConfig(script, scriptPath, flags) {
     payloadSpec.path = resolvedPathToPayload;
   });
 
-  // if environment feature is used, then payload paths in environment must be replaced too
-  // this is so that multiple calls of checkConfig function don't override each other, as can happen if you specify a scenario + config file
-  // otherwise the second call to checkConfig will use a non-resolved path from the script.config.environments and merge that above, causing the whole thing to fail
-  // Addresses: https://github.com/artilleryio/artillery/issues/1961
-  if (flags.environment) {
-    if (
-      script.config.environments &&
-      script.config.environments[flags.environment]
-    ) {
-      _.forEach(
-        script.config.environments[flags.environment].payload,
-        function (payloadSpec) {
-          if (!payloadSpec.path) {
-            //path may not be present if -p is used (payload is an object). in that case this is unnecessary, as the payload will already have been added above.
-            //and this logic would error as there would be no path
-            return;
-          }
-
-          const resolvedPathToPayload = path.resolve(
-            path.dirname(absoluteScriptPath),
-            payloadSpec.path
-          );
-
-          payloadSpec.path = resolvedPathToPayload;
-        }
-      );
-    }
-  }
-
   return script;
 }
 

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -177,6 +177,12 @@ async function checkConfig(script, scriptPath, flags) {
       script.config.environments[flags.environment]
     ) {
       _.forEach(script.config.environments[flags.environment].payload, function (payloadSpec) {
+        if (!payloadSpec.path) {
+          //path may not be present if -p is used (payload is an object). in that case this is unnecessary, as the payload will already have been added above.
+          //and this logic would error as there would be no path
+          return;
+        }
+
         const resolvedPathToPayload = path.resolve(
           path.dirname(absoluteScriptPath),
           payloadSpec.path

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -27,7 +27,7 @@ module.exports = {
   template,
   formatDuration,
   padded,
-  rainbow,
+  rainbow
 };
 
 async function readScript(scriptPath) {
@@ -176,21 +176,25 @@ async function checkConfig(script, scriptPath, flags) {
       script.config.environments &&
       script.config.environments[flags.environment]
     ) {
-      _.forEach(script.config.environments[flags.environment].payload, function (payloadSpec) {
-        if (!payloadSpec.path) {
-          //path may not be present if -p is used (payload is an object). in that case this is unnecessary, as the payload will already have been added above.
-          //and this logic would error as there would be no path
-          return;
+      _.forEach(
+        script.config.environments[flags.environment].payload,
+        function (payloadSpec) {
+          if (!payloadSpec.path) {
+            //path may not be present if -p is used (payload is an object). in that case this is unnecessary, as the payload will already have been added above.
+            //and this logic would error as there would be no path
+            return;
+          }
+
+          const resolvedPathToPayload = path.resolve(
+            path.dirname(absoluteScriptPath),
+            payloadSpec.path
+          );
+
+          payloadSpec.path = resolvedPathToPayload;
         }
-
-        const resolvedPathToPayload = path.resolve(
-          path.dirname(absoluteScriptPath),
-          payloadSpec.path
-        );
-
-        payloadSpec.path = resolvedPathToPayload;
-      });
-    }}
+      );
+    }
+  }
 
   return script;
 }

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -42,6 +42,36 @@ tap.test(
   }
 );
 
+tap.test(
+  'Run a script with config/processor in different folders and processor resolved relative to scenario (backwards compatibility)',
+  async (t) => {
+    const [exitCode, output] = await execute([
+      'run',
+      'test/scripts/scenario-config-different-folder/scenario.yml',
+      '--config',
+      'test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml'
+    ]);
+    console.log(output)
+
+    t.ok(exitCode === 0 && output.stdout.includes('Successfully ran with id myTestId123'));
+  }
+);
+
+tap.test(
+  'Run a script with config/processor in different folders and processor resolved relative to config',
+  async (t) => {
+    const [exitCode, output] = await execute([
+      'run',
+      'test/scripts/scenario-config-different-folder/scenario.yml',
+      '--config',
+      'test/scripts/scenario-config-different-folder/config/config.yml'
+    ]);
+    console.log(output)
+
+    t.ok(exitCode === 0 && output.stdout.includes('Successfully ran with id myTestId123'));
+  }
+);
+
 tap.test('Environment specified with -e should be used', async (t) => {
   const [exitCode, output] = await execute([
     'run',

--- a/packages/artillery/test/cli/variables-from-external-files.test.js
+++ b/packages/artillery/test/cli/variables-from-external-files.test.js
@@ -34,3 +34,22 @@ tap.test('Load variables from single CSV successfully', async (t) => {
       !output.stdout.includes('http.codes.400')
   );
 });
+
+tap.test('Load variables from single CSV successfully', async (t) => {
+  const [exitCode, output] = await execute([
+    'run',
+    '--environment',
+    'staging',
+    './test/scripts/scenario-payload-with-envs/scenario.yml',
+    '--config',
+    './test/scripts/scenario-payload-with-envs/config/artillery-config.yml',
+  ]);
+
+  t.ok(
+    exitCode === 0 &&
+      output.stdout.includes('Successfully ran with id') && (
+        output.stdout.includes('abc12345') ||
+        output.stdout.includes('abc56789')
+      )
+  );
+});

--- a/packages/artillery/test/cli/variables-from-external-files.test.js
+++ b/packages/artillery/test/cli/variables-from-external-files.test.js
@@ -35,21 +35,23 @@ tap.test('Load variables from single CSV successfully', async (t) => {
   );
 });
 
-tap.test('Load variables from single CSV successfully', async (t) => {
-  const [exitCode, output] = await execute([
-    'run',
-    '--environment',
-    'staging',
-    './test/scripts/scenario-payload-with-envs/scenario.yml',
-    '--config',
-    './test/scripts/scenario-payload-with-envs/config/artillery-config.yml',
-  ]);
+tap.test(
+  'Load variables from CSV when using array payload and an environment from a config file',
+  async (t) => {
+    const [exitCode, output] = await execute([
+      'run',
+      '--environment',
+      'staging',
+      './test/scripts/scenario-payload-with-envs/scenario.yml',
+      '--config',
+      './test/scripts/scenario-payload-with-envs/config/artillery-config.yml'
+    ]);
 
-  t.ok(
-    exitCode === 0 &&
-      output.stdout.includes('Successfully ran with id') && (
-        output.stdout.includes('abc12345') ||
-        output.stdout.includes('abc56789')
-      )
-  );
-});
+    t.ok(
+      exitCode === 0 &&
+        output.stdout.includes('Successfully ran with id') &&
+        (output.stdout.includes('abc12345') ||
+          output.stdout.includes('abc56789'))
+    );
+  }
+);

--- a/packages/artillery/test/scripts/scenario-config-different-folder/__processor__/index.js
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/__processor__/index.js
@@ -1,0 +1,10 @@
+function setId(context, ee, next) {
+    //Change your function name and add your logic here.
+    //For more information, check: https://artillery.io/docs/http-reference/#function-signatures
+    context.vars.artilleryTestId = "myTestId123"
+    next();
+};
+
+module.exports = {
+    setId
+}

--- a/packages/artillery/test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml
@@ -5,4 +5,4 @@ config:
       arrivalRate: 1
       maxVusers: 1
       name: "low level"
-  processor: ./__processor__/index.js #relative to the path of scenario.yml
+  processor: ./__processor__/index.js #relative to the path of scenario.yml (backward compatible mode)

--- a/packages/artillery/test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml
@@ -1,0 +1,8 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      maxVusers: 1
+      name: "low level"
+  processor: ./__processor__/index.js #relative to the path of scenario.yml

--- a/packages/artillery/test/scripts/scenario-config-different-folder/config/config.yml
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/config/config.yml
@@ -1,0 +1,8 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      maxVusers: 1
+      name: "low level"
+  processor: ../__processor__/index.js #relative to the path of scenario.yml

--- a/packages/artillery/test/scripts/scenario-config-different-folder/config/config.yml
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/config/config.yml
@@ -5,4 +5,4 @@ config:
       arrivalRate: 1
       maxVusers: 1
       name: "low level"
-  processor: ../__processor__/index.js #relative to the path of scenario.yml
+  processor: ../__processor__/index.js #relative to the path of the config (new behaviour)

--- a/packages/artillery/test/scripts/scenario-config-different-folder/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-config-different-folder/scenario.yml
@@ -1,0 +1,5 @@
+scenarios:
+  - name: Test Scenario
+    beforeScenario: "setId"
+    flow:
+      - log: "Successfully ran with id {{ artilleryTestId }}"

--- a/packages/artillery/test/scripts/scenario-payload-with-envs/config/artillery-config.yml
+++ b/packages/artillery/test/scripts/scenario-payload-with-envs/config/artillery-config.yml
@@ -1,0 +1,5 @@
+config:
+  plugins:
+    metrics-by-endpoint:
+      useOnlyRequestNames: true
+      stripQueryString: true

--- a/packages/artillery/test/scripts/scenario-payload-with-envs/data/my-data.csv
+++ b/packages/artillery/test/scripts/scenario-payload-with-envs/data/my-data.csv
@@ -1,0 +1,3 @@
+id,name
+abc12345,christopher
+abc56789,not-christopher

--- a/packages/artillery/test/scripts/scenario-payload-with-envs/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-payload-with-envs/scenario.yml
@@ -9,7 +9,7 @@ config:
           skipHeader: true
           path: "./data/my-data.csv"
           order: sequence
-  target: https://http.cat
+  target: http://asciiart.artillery.io:8080
   phases:
     - duration: 1
       arrivalRate: 1
@@ -18,4 +18,4 @@ config:
 scenarios:
   - name: Test Scenario
     flow:
-      - log: "Successfully ran with id: {{ id }}"
+      - log: "Successfully ran with id {{ id }}"

--- a/packages/artillery/test/scripts/scenario-payload-with-envs/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-payload-with-envs/scenario.yml
@@ -1,0 +1,21 @@
+#https://github.com/artilleryio/artillery/issues/1961
+config:
+  environments:
+    staging:
+      payload:
+        - fields:
+            - "id"
+            - "name"
+          skipHeader: true
+          path: "./data/my-data.csv"
+          order: sequence
+  target: https://http.cat
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      maxVusers: 1
+      name: "low level"
+scenarios:
+  - name: Test Scenario
+    flow:
+      - log: "Successfully ran with id: {{ id }}"


### PR DESCRIPTION
## What

Fixes https://github.com/artilleryio/artillery/issues/1961

## How

This was happening because checkConfig gets called twice when you pass in a scenario + config. In that situation, if you have `environments`, the first time `checkConfig` gets called, it correctly creates the `payload` in the root `config` and replaces those paths. 

However, it doesn't do the same to `config.environments.payload`. So the second time `checkConfig` is called, the `_.merge` overrides the payload path with the `config.environment.payload` unresolved path, causing the issue.

The PR addresses that by ensuring that it no longer gets called twice.

## Testing

This was tested with the test scripts provided in the issue (very helpful), against Artillery Local.

Two things are missing:

- [x] Verify this against non-local runs. This may still need to be accounted for, as I'm not sure if it uses the same logic, looking at `create-bom.js`;
- [x] I am still in the process of figuring out a potential automated test for this.



