### PR TITLE
fix(examples): use correct url so that all web vital metrics display

### DIFF
--- a/examples/browser-load-testing-playwright/advanced-custom-metric-for-subflow.yml
+++ b/examples/browser-load-testing-playwright/advanced-custom-metric-for-subflow.yml
@@ -1,5 +1,5 @@
 config:
-  target: "https://artillery.io"
+  target: "https://www.artillery.io"
   phases:
     - arrivalRate: 1
       duration: 10

--- a/examples/browser-load-testing-playwright/browser-load-test.yml
+++ b/examples/browser-load-testing-playwright/browser-load-test.yml
@@ -1,5 +1,5 @@
 config:
-  target: "https://artillery.io"
+  target: "https://www.artillery.io"
   phases:
     - arrivalRate: 1
       duration: 10

--- a/examples/browser-load-testing-playwright/browser-smoke-test.yml
+++ b/examples/browser-load-testing-playwright/browser-smoke-test.yml
@@ -1,5 +1,5 @@
 config:
-  target: "https://artillery.io"
+  target: "https://www.artillery.io"
   payload:
     - path: ./pages.csv
       fields: ["url"]

--- a/examples/browser-load-testing-playwright/flows.js
+++ b/examples/browser-load-testing-playwright/flows.js
@@ -1,14 +1,17 @@
 //
 // The code in this function was generated with
 // playwright codegen
-// https://playwright.dev/docs/cli/#generate-code
+// https://playwright.dev/docs/codegen
 //
 async function cloudWaitlistSignupFlow(page) {
   await page.goto('https://www.artillery.io/');
-  await page.click('text=Cloud');
-  // assert.equal(page.url(), 'https://artillery.io/cloud/');
-  await page.click('text=Join');
-  // await page.pause();
+  await page
+    .getByLabel('Main navigation')
+    .getByRole('link', { name: 'Cloud' })
+    .click();
+  await page
+    .getByRole('button', { name: 'Join Artillery Cloud early access waitlist' })
+    .click();
 }
 
 //

--- a/examples/browser-load-testing-playwright/pages.csv
+++ b/examples/browser-load-testing-playwright/pages.csv
@@ -1,3 +1,3 @@
-https://artillery.io/
-https://artillery.io/docs
-https://artillery.io/pro
+https://www.artillery.io/
+https://www.artillery.io/docs
+https://www.artillery.io/pro


### PR DESCRIPTION
# Why

These examples weren't displaying web vital metrics by default. 

The reason was the Artillery Playwright engine looks for `window.location.href` as the url, and tries to match that with the `target` to decide on whether to show them or not. Since navigating to the website directs to `www`, that check was failing, and so no extended metrics were showing.

_Note:_ I also fixed the `cloudWaitlistSignupFlow` which wasn't working properly. I used playwright's codegen as the previous one for an updated exmaple.