### PR TITLE
test(core): set proper malformed cookie instead of empty in server

### DIFF
--- a/packages/core/test/core/targets/simple.js
+++ b/packages/core/test/core/targets/simple.js
@@ -217,7 +217,7 @@ function route(server) {
       method: 'GET',
       path: '/malformed_cookie',
       handler: function (request, h) {
-        return h.response().header('Set-Cookie', '').code(200);
+        return h.response().header('Set-Cookie', 'malformed').code(200);
       }
     }
   ]);


### PR DESCRIPTION
## Why

This test https://github.com/artilleryio/artillery/blob/main/packages/core/test/core/test_cookies.js#L59-L80 is consistently failing. This started happening due to this dependency upgrade: https://github.com/artilleryio/artillery/commit/9dcda2ac8e41ef350a414e7193eabea9301cb1f1?short_path=053150b#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519 . Which moved tough-cookie from 4.0.0 (>2 years old) to 4.1.3.

## How

This logic from `tough-cookie` https://github.com/salesforce/tough-cookie/commit/1b25269dbb0478232f910c26386b3cac4ec9d857#diff-2d82e6dd06f50c43f369547b8edcc1937fd3a9e403480d2e87541f6c125a70d9R462-R466 means that the `Cookie.parse` returns null, which causes the library to error. This is a check before looseMode, and seems to be intended behaviour. It seems looseMode is only intended for cookies that are non-empty.

Fixes the test server by sending a malformed cookie that is non-empty.