### PR TITLE
dep(artillery): upgrade @artilleryio/sketches-js to 2.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "main": "./index.js",
   "dependencies": {
     "@artilleryio/int-commons": "latest",
-    "@artilleryio/sketches-js": "^1.0.4",
+    "@artilleryio/sketches-js": "^2.1.0",
     "agentkeepalive": "^4.1.0",
     "arrivals": "^2.1.2",
     "async": "^2.6.4",


### PR DESCRIPTION
Update our fork of Datadog's sketches-js to latest version.

https://github.com/artilleryio/sketches-js