### PR TITLE
test(expect): add timeout to test and remove container in cleanup

### DIFF
--- a/packages/artillery-plugin-expect/test/run.sh
+++ b/packages/artillery-plugin-expect/test/run.sh
@@ -10,8 +10,9 @@ MOCKINGJAY_VERSION="1.12.0"
 #
 
 cleanup() {
+    container_id=$(docker container ls -aqf "name=mockingjay")
 
-    docker stop mockingjay || true
+    (docker stop mockingjay && docker rm "$container_id") || true
 }
 
 trap cleanup EXIT
@@ -20,4 +21,4 @@ docker run --name mockingjay -p 9090:9090 -v "$DIR":/data "quii/mockingjay-serve
 
 sleep 10
 
-"$DIR"/../../../node_modules/.bin/ava $DIR/index.js $DIR/lib/formatters.js
+"$DIR"/../../../node_modules/.bin/ava --timeout 30s $DIR/index.js $DIR/lib/formatters.js


### PR DESCRIPTION
## Why

These tests are sometimes failing in CI despite no issue.
Additionally, in local execution, any two consecutive runs of this test suite will cause issues.

## How

- **Adds a timeout to Ava. Ava defaults to 10s - Increasing to 30s**: The reason for this is I noticed in some of the CI failures there were timeouts, so this might be the reason for the random failures. I ran the tests locally many times and could not reproduce issues, whilst before I added the timeout, I was randomly getting failures.
- **Removes container after stopping it:** Two consecutive local runs were failing because a container with the name `mockingjay` already existed. This removes the container after execution.

## Testing

Ran many times locally without issues. Hopefully the CI runs below will be green :).