### PR TITLE
fix(ensure): check in beforeExit for both ensure plugin interfaces

### DIFF
--- a/packages/artillery-plugin-ensure/index.js
+++ b/packages/artillery-plugin-ensure/index.js
@@ -38,13 +38,14 @@ class EnsurePlugin {
     this.script = script;
     this.events = events;
 
-    const checks = this.script.config?.ensure || this.script.config?.plugins?.ensure;
+    const checks =
+      this.script.config?.ensure || this.script.config?.plugins?.ensure;
 
     global.artillery.ext({
       ext: 'beforeExit',
       method: async (data) => {
         if (
-          typeof this.script?.config?.ensure === 'undefined' ||
+          !checks ||
           typeof process.env.ARTILLERY_DISABLE_ENSURE !== 'undefined'
         ) {
           return;


### PR DESCRIPTION
## What

Ensure plugin was not running checks at the end if config is passed like this:

```
  plugins:
    ensure:
      thresholds:
        - http.response_time.p99: 100
        - http.response_time.p95: 75
```

This happened since the `beforeExit` ext was not looking for the second input option.

## Testing

Tested with:

```yaml
config:
  target: http://asciiart.artillery.io:8080
  phases:
    - duration: 10
      arrivalRate: 1
  plugins:
    ensure:
      thresholds:
        - http.response_time.p99: 100
        - http.response_time.p95: 75
scenarios:
  - flow:
    - get:
        url: "/dino"
```

Also tried other variations (ensure outside of `plugins`), and no checks. All worked appropriately.