### PR TITLE
fix(commons): only check for match group if there are groups

### DIFF
--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -606,9 +606,9 @@ function extractRegExp(doc, expr, opts) {
   if (!match) {
     return '';
   }
-  const potentialGroupMatch = match.groups[group];
-  if (group && potentialGroupMatch) {
-    return potentialGroupMatch;
+  
+  if (group && match.groups) {
+    return match.groups[group];
   } else if (match[0]) {
     return match[0];
   } else {


### PR DESCRIPTION
This [logic](https://github.com/artilleryio/artillery/pull/1922) was breaking when a `regex` without groups was done. Tests were not catching it due to the issue in local/ci setup of not using `*`, which is why it started being caught here https://github.com/artilleryio/artillery/pull/2005

## Testing

Given that this branch doesn't contain the changes in https://github.com/artilleryio/artillery/pull/2005 yet, the automated tests in CI won't run against the right version, so it will be a false positive. However, I ran the same change against the branch in that PR, and all tests are passing. 👍 