### PR TITLE
fix(publish-metrics): new relic accountid configuration

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -13,6 +13,18 @@ class NewRelicReporter {
       licenseKey: config.licenseKey
     };
 
+    if (!config.licenseKey) {
+      throw new Error(
+        'New Relic License Key not specified. In order to send metrics to New Relic `licenseKey` must be provided'
+      );
+    }
+
+    if (config.hasOwnProperty('event') && !config.event?.accountId) {
+      throw new Error(
+        'New Relic account ID not specified. In order to send events to New Relic `accountId` must be provided'
+      );
+    }
+
     if (config.event) {
       this.eventConfig = {
         attributes: config.event.attributes || [],
@@ -26,17 +38,10 @@ class NewRelicReporter {
         ...this.parseAttributes(this.eventConfig.attributes)
       };
 
-      if (!config.event.accountId) {
-        this.eventConfig.send = false;
-        debug(
-          'Events will not be sent to New Relic. In order to send events `accountId` must be provided'
-        );
-      } else {
-        this.eventsAPIEndpoint =
-          this.config.region === 'eu'
-            ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
-            : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
-      }
+      this.eventsAPIEndpoint =
+        this.config.region === 'eu'
+          ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
+          : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
     }
 
     this.metricsAPIEndpoint =

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -21,21 +21,21 @@ class NewRelicReporter {
       };
 
       this.eventOpts = {
-        eventType: config.event.eventType || `Artillery_io_Test`,
+        eventType: config.event.eventType || 'Artillery_io_Test',
         target: `${script.config.target}`,
         ...this.parseAttributes(this.eventConfig.attributes)
       };
+
+      this.eventsAPIEndpoint =
+        this.config.region === 'eu'
+          ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
+          : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
     }
 
     this.metricsAPIEndpoint =
       this.config.region === 'eu'
         ? 'https://metric-api.eu.newrelic.com/metric/v1'
         : 'https://metric-api.newrelic.com/metric/v1';
-
-    this.eventsAPIEndpoint =
-      this.config.region === 'eu'
-        ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
-        : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
 
     this.pendingRequests = 0;
 
@@ -76,7 +76,7 @@ class NewRelicReporter {
         }
         const timestamp = Date.now();
         this.eventOpts.timestamp = timestamp;
-        this.eventOpts.phase = `Test Started`;
+        this.eventOpts.phase = 'Test Started';
         await this.sendEvent(
           this.eventsAPIEndpoint,
           this.config.licenseKey,
@@ -264,7 +264,7 @@ class NewRelicReporter {
     if (this.startedEventSent) {
       const timestamp = Date.now();
       this.eventOpts.timestamp = timestamp;
-      this.eventOpts.phase = `Test Finished`;
+      this.eventOpts.phase = 'Test Finished';
 
       this.sendEvent(
         this.eventsAPIEndpoint,

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -26,10 +26,17 @@ class NewRelicReporter {
         ...this.parseAttributes(this.eventConfig.attributes)
       };
 
-      this.eventsAPIEndpoint =
-        this.config.region === 'eu'
-          ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
-          : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
+      if (!config.event.accountId) {
+        this.eventConfig.send = false;
+        debug(
+          'Events will not be sent to New Relic. In order to send events `accountId` must be provided'
+        );
+      } else {
+        this.eventsAPIEndpoint =
+          this.config.region === 'eu'
+            ? `https://insights-collector.eu01.nr-data.net/v1/accounts/${this.eventConfig.accountId}/events`
+            : `https://insights-collector.newrelic.com/v1/accounts/${this.eventConfig.accountId}/events`;
+      }
     }
 
     this.metricsAPIEndpoint =

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -199,10 +199,10 @@ class NewRelicReporter {
         debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`);
       }
 
-      // In case an error is generated during the Metric API asynchronous check (after succesfull response), UUID can be used to match error to request
+      // In case an error is generated during the Metric API asynchronous check (after succesfull response), requestId can be used to match error to request
       debug(
-        `Request to Metric API at ${body[0].common.timestamp} UUID: `,
-        JSON.parse(res.body).uuid
+        `Request to Metric API at ${body[0].common.timestamp} requestId: `,
+        JSON.parse(res.body).requestId
       );
     } catch (err) {
       debug(err);


### PR DESCRIPTION
## Expected behaviour 
`accountId` needs to be set only when user wants to send events to New Relic, it is not required for sending metrics.

## Bug
`eventsAPIEndpoint` configuration that uses `accountId` was not scoped properly to events, causing reporter to error even when `event` feature was not used, preventing sending the metrics to New Relic.

## Fix
Scoping configuration of `eventsAPIEndpoint` to only run when `event` has been set in the reporters config and `accountId` has been provided. 