### PR TITLE
feat: dynatrace reporter

### DIFF
--- a/packages/artillery-plugin-publish-metrics/README.md
+++ b/packages/artillery-plugin-publish-metrics/README.md
@@ -15,7 +15,8 @@ The plugin sends metrics and events from Artillery tests to external monitoring 
 - [New Relic](https://newrelic.com/)
 - [Mixpanel](https://mixpanel.com)
 - InfluxDB with [Telegraf + StatsD plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd)
-- StatsD 
+- StatsD
+- [Dynatrace](https://dynatrace.com/)
 
 ## Docs
 

--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -14,6 +14,7 @@ const { createMixPanelReporter } = require('./lib/mixpanel');
 const { createPrometheusReporter } = require('./lib/prometheus');
 const { createCloudWatchReporter } = require('./lib/cloudwatch');
 const { createNewRelicReporter } = require('./lib/newrelic');
+const { createDynatraceReporter } = require('./lib/dynatrace');
 
 module.exports = {
   Plugin,
@@ -46,6 +47,8 @@ function Plugin(script, events) {
       this.reporters.push(createCloudWatchReporter(config, events, script));
     } else if (config.type === 'newrelic') {
       this.reporters.push(createNewRelicReporter(config, events, script));
+    } else if (config.type === 'dynatrace') {
+      this.reporters.push(createDynatraceReporter(config, events, script));
     } else {
       events.emit(
         'userWarning',

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const got = require('got');
+const debug = require('debug')('plugin:publish-metrics:dynatrace');
+
+class DynatraceReporter {
+  constructor(config, events) {
+    this.config = {
+      apiToken: config.apiToken,
+      envUrl: config.envUrl,
+      prefix: config.prefix || 'artillery.',
+      excluded: config.excluded || [],
+      includeOnly: config.includeOnly || [],
+      dimensions: this.parseDimensions(config.dimensions)
+    };
+
+    if (!config.apiToken || !config.envUrl) {
+      throw new Error(
+        'Dynatrace reporter configuration incomplete: `apiToken` or `envUrl` missing. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
+      );
+    }
+
+    this.ingestMetricsEndpoint = new URL(
+      '/api/v2/metrics/ingest',
+      this.config.envUrl
+    );
+
+    this.pendingRequests = 0;
+
+    events.on('stats', async (stats) => {
+      const timestamp = Date.now();
+      const counters = this.formatCountersForDynatrace(
+        stats.counters,
+        this.config,
+        timestamp
+      );
+      const rates = this.formatRatesForDynatrace(
+        stats.rates,
+        this.config,
+        timestamp
+      );
+      const summaries = this.formatSummariesForDynatrace(
+        stats.summaries,
+        this.config,
+        timestamp
+      );
+
+      const request = this.formRequest(
+        this.formPayload(counters, rates, summaries)
+      );
+      await this.sendRequest(this.ingestMetricsEndpoint, request);
+    });
+  }
+
+  parseDimensions(dimensionList) {
+    if (!dimensionList || (dimensionList && dimensionList.length === 0)) {
+      return false;
+    }
+    const parsedDimensions = [];
+
+    for (const item of dimensionList) {
+      const [name, value] = item.split(':');
+      parsedDimensions.push(`${name}="${value}"`);
+    }
+
+    return parsedDimensions;
+  }
+
+  shouldSendMetric(metricName, excluded, includeOnly) {
+    if (excluded.includes(metricName)) {
+      return;
+    }
+
+    if (includeOnly.length > 0 && !includeOnly.includes(metricName)) {
+      return;
+    }
+
+    return true;
+  }
+
+  formatCountersForDynatrace(counters, config, timestamp) {
+    debug('Formating counters for Dynatrace');
+    const statCounts = [];
+
+    for (const [name, value] of Object.entries(counters || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      }
+
+      const count = `${config.prefix + name},${config.dimensions.join(
+        ','
+      )} count,delta=${value} ${timestamp}`; //TODO check if need to add value to previous values https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/metric-ingestion-protocol#payload
+      statCounts.push(count);
+    }
+
+    return statCounts;
+  }
+
+  formatRatesForDynatrace(rates, config, timestamp) {
+    const statGauges = [];
+    for (const [name, value] of Object.entries(rates || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      }
+
+      const gauge = `${config.prefix + name},${config.dimensions.join(
+        ','
+      )} gauge,${value} ${timestamp}`;
+      statGauges.push(gauge);
+    }
+
+    return statGauges;
+  }
+
+  formatSummariesForDynatrace(summaries, config, timestamp) {
+    const statGauges = [];
+    for (const [name, values] of Object.entries(summaries || {})) {
+      if (!this.shouldSendMetric(name, config.excluded, config.includeOnly)) {
+        continue;
+      }
+      for (const [agreggation, value] of Object.entries(values)) {
+        const gauge = `${
+          config.prefix
+        }${name}.${agreggation},${config.dimensions.join(
+          ','
+        )} gauge,${value} ${timestamp}`;
+
+        statGauges.push(gauge);
+      }
+    }
+
+    return statGauges;
+  }
+
+  formPayload(counters, rates, summaries) {
+    const payload = `${[...counters, ...rates, ...summaries].join('\n')}`;
+    debug(payload);
+    return payload;
+  }
+
+  formRequest(payload) {
+    const options = {
+      headers: {
+        'Content-Type': 'text/plain',
+        Authorization: `Api-Token ${this.config.apiToken}`
+      },
+      body: String(payload)
+    };
+
+    return options;
+  }
+
+  async sendRequest(url, options) {
+    this.pendingRequests += 1;
+    // const options = this.formRequest(payload);
+
+    debug('Sending metrics to Dynatrace');
+    try {
+      const res = await got.post(url, options);
+
+      if (res.statusCode !== 202) {
+        debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`);
+      }
+    } catch (err) {
+      debug('There has been an error: ', err);
+    }
+    debug('Metrics sent to Dynatrace');
+
+    this.pendingRequests -= 1;
+  }
+
+  async waitingForRequest() {
+    while (this.pendingRequests > 0) {
+      debug('Waiting for pending request ...');
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    debug('Pending requests done');
+    return true;
+  }
+
+  cleanup(done) {
+    console.log('cleaning up');
+    return this.waitingForRequest().then(done);
+  }
+}
+
+function createDynatraceReporter(config, events, script) {
+  return new DynatraceReporter(config, events, script);
+}
+
+module.exports = {
+  createDynatraceReporter
+};

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -136,7 +136,6 @@ class DynatraceReporter {
 
   formPayload(counters, rates, summaries) {
     const payload = `${[...counters, ...rates, ...summaries].join('\n')}`;
-    debug(payload);
     return payload;
   }
 
@@ -146,7 +145,7 @@ class DynatraceReporter {
         'Content-Type': 'text/plain',
         Authorization: `Api-Token ${this.config.apiToken}`
       },
-      body: String(payload)
+      body: payload
     };
 
     return options;
@@ -154,7 +153,6 @@ class DynatraceReporter {
 
   async sendRequest(url, options) {
     this.pendingRequests += 1;
-    // const options = this.formRequest(payload);
 
     debug('Sending metrics to Dynatrace');
     try {
@@ -164,7 +162,7 @@ class DynatraceReporter {
         debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`);
       }
     } catch (err) {
-      debug('There has been an error: ', err);
+      debug('An error occured when sending metrics to Dynatrace: ', err);
     }
     debug('Metrics sent to Dynatrace');
 

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -121,12 +121,11 @@ class DynatraceReporter {
         continue;
       }
       for (const [agreggation, value] of Object.entries(values)) {
-        const type = agreggation === 'count' ? 'count,delta=' : 'gauge,';
         const gauge = `${
           config.prefix
         }${name}.${agreggation},${config.dimensions.join(
           ','
-        )} ${type}${value} ${timestamp}`;
+        )} gauge,${value} ${timestamp}`;
 
         statGauges.push(gauge);
       }

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -34,6 +34,7 @@ class DynatraceReporter {
         this.config,
         timestamp
       );
+
       const rates = this.formatRatesForDynatrace(
         stats.rates,
         this.config,
@@ -87,9 +88,10 @@ class DynatraceReporter {
         continue;
       }
 
-      const count = `${config.prefix + name},${config.dimensions.join(
+      const count = `${config.prefix}${name},${config.dimensions.join(
         ','
-      )} count,delta=${value} ${timestamp}`; //TODO check if need to add value to previous values https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/metric-ingestion-protocol#payload
+      )} count,delta=${value} ${timestamp}`;
+
       statCounts.push(count);
     }
 
@@ -119,11 +121,12 @@ class DynatraceReporter {
         continue;
       }
       for (const [agreggation, value] of Object.entries(values)) {
+        const type = agreggation === 'count' ? 'count,delta=' : 'gauge,';
         const gauge = `${
           config.prefix
         }${name}.${agreggation},${config.dimensions.join(
           ','
-        )} gauge,${value} ${timestamp}`;
+        )} ${type}${value} ${timestamp}`;
 
         statGauges.push(gauge);
       }

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -16,7 +16,7 @@ class DynatraceReporter {
 
     if (!config.apiToken || !config.envUrl) {
       throw new Error(
-        'Dynatrace reporter configuration incomplete: `apiToken` or `envUrl` missing. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
+        'Dynatrace API Access Token or Environment URL not specified. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
       );
     }
 

--- a/packages/artillery-plugin-publish-metrics/test/config-dynatrace.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-dynatrace.yaml
@@ -1,0 +1,14 @@
+config:
+  target: https://artillery.io
+  phases:
+    - duration: 11
+      arrivalRate: 1
+  plugins:
+    publish-metrics:
+      - type: dynatrace
+        envUrl: '{{ $processEnvironment.DY_ENV_URL }}'
+        apiKey: '{{ $processEnvironment.DY_API_KEY }}'
+        prefix: 'artillery.publish_metrics_plugin.'
+        dimensions:
+          - 'testId:{{ $processEnvironment.TEST_ID }}'
+          - 'reporterType:dynatrace-metric-api'


### PR DESCRIPTION
## What

Dynatrace target for `publish-metrics` plugin. Supports sending metrics to Dynatrace's Metric API v2.

## How

`DynatraceReporter` is initialised within the `publish-metrics` `Plugin` class.

It subscribes to `stats` event to access the metrics for each reporting period, and then it formats those metrics into the payload to be sent with `HTTP POST` request to Dynatrace's Metric API endpoint. It uses `got` library to send the request.

**Configuration:**

- To send metrics to Dynatrace, set `type` to `dynatrace`.
- `apiToken` -- required. The Access Token with `metrics.ingest` value
- `envUrl` -- required. The Dynatrace environment URL.
- `prefix` -- prefix for metric names created by Artillery; defaults to artillery.
- `dimensions` -- a list of `name:value` strings to use as dimensions for all metrics sent during a test.
- `excluded` -- A list of metric names which should not be sent to Dynatrace. Defaults to an empty list, i.e. all metrics are sent to Dynatrace.
- `includeOnly` -- A list of specific metrics to send to Dynatrace. No other metrics will be sent. Defaults to an empty list, i.e. all metrics are sent to Dynatrace.

## Testing

I have created the `config-dynatrace.yaml` file to match the ones for other reporters.

The reporter was tested manually with different scripts and combinations to make sure everything is created/ formatted properly and that the metrics arrive as they should to Dynatrace and in those tests I did not notice any issues.

<img width="440" alt="Screenshot 2023-07-31 at 16 30 56" src="https://github.com/artilleryio/artillery/assets/39635558/0bc37794-8da7-4a5c-b132-185e05c90f0a">

<img width="932" alt="Screenshot 2023-08-01 at 14 07 32" src="https://github.com/artilleryio/artillery/assets/39635558/f4ca4bd9-0521-405b-991b-250ab6f67cf8">
