### PR TITLE
fix(artillery): template config vars after flag vars have been added

### DIFF
--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -71,21 +71,21 @@ async function addVariables(script, flags) {
     script.config.variables[k] = v;
   }
 
-  script.config.variables = engineUtil.template(script.config.variables, {
-    vars: JSON.parse(flags.variables)
-  });
-
   return script;
 }
 
 async function resolveConfigTemplates(script, flags) {
+  const cliVariables = flags.variables ? JSON.parse(flags.variables) : {};
+
   script.config = engineUtil.template(script.config, {
     vars: {
       $processEnvironment: process.env,
-      $environment: flags.environment
+      $environment: flags.environment,
+      ...cliVariables
     },
     funcs: contextFuncs
   });
+
   return script;
 }
 

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -70,6 +70,11 @@ async function addVariables(script, flags) {
   for (const [k, v] of Object.entries(variables)) {
     script.config.variables[k] = v;
   }
+
+  script.config.variables = engineUtil.template(script.config.variables, {
+    vars: JSON.parse(flags.variables)
+  });
+
   return script;
 }
 

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -152,7 +152,7 @@ tap.test('Run a script overwriting default options (output)', async (t) => {
 });
 
 tap.test(
-  'Run a script with overwriting config variables with cli variables (including templated vars)',
+  'Run a script with overwriting templated variables in variables config with cli variables',
   async (t) => {
     const variableOverride = {
       bar: 'this is me',
@@ -160,7 +160,7 @@ tap.test(
     };
     const [exitCode, output] = await execute([
       'run',
-      'test/scripts/scenario-with-cli-variables.yml',
+      'test/scripts/scenario-cli-variables/scenario-with-variables.yml',
       '--variables',
       JSON.stringify(variableOverride)
     ]);
@@ -168,15 +168,54 @@ tap.test(
     t.ok(exitCode === 0);
     t.ok(
       output.stdout.includes(`foo is ${variableOverride.myVar}`),
-      'Templated foo variable is not showing'
+      'Templated foo nested config variable is not showing'
+    );
+    t.ok(
+      output.stdout.includes(`other is ${variableOverride.myVar}`),
+      'other variable from config variable not showing'
     );
     t.ok(
       output.stdout.includes(`bar is ${variableOverride.bar}`),
-      'bar variable from config not showing'
+      'bar variable from --variables not showing'
     );
     t.ok(
       output.stdout.includes(`myVar is ${variableOverride.myVar}`),
       'myVar variable from --variables not showing'
+    );
+  }
+);
+
+tap.test(
+  'Run a script with overwriting templated variables in other nested config with cli variables',
+  async (t) => {
+    const variableOverride = {
+      myVar: 3,
+      defaultCookie: 'abc123',
+      anotherCookie: 'hellothere'
+    };
+    const [exitCode, output] = await execute([
+      'run',
+      'test/scripts/scenario-cli-variables/scenario-with-other-nested-config.yml',
+      '--variables',
+      JSON.stringify(variableOverride)
+    ]);
+
+    t.ok(exitCode === 0);
+    t.ok(
+      output.stdout.includes(`other is ${variableOverride.myVar}`),
+      'other variable from config variable not showing'
+    );
+    t.ok(
+      output.stdout.includes(`HTTP timeout is: ${variableOverride.myVar}`),
+      'Templated variable in other nested config (http) is not showing'
+    );
+    t.ok(
+      output.stdout.includes('Has default cookie: true'),
+      'Templated variable in other nested config (cookie) is not showing'
+    );
+    t.ok(
+      output.stdout.includes('Has cookie from flow: true'),
+      'Templated variable in nested scenario option is not showing'
     );
   }
 );

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -152,7 +152,7 @@ tap.test('Run a script overwriting default options (output)', async (t) => {
 });
 
 tap.test(
-  'Run a script with overwriting templated variables in variables config with cli variables',
+  'Run a script with overwriting variables in config with cli variables',
   async (t) => {
     const variableOverride = {
       bar: 'this is me',
@@ -186,7 +186,7 @@ tap.test(
 );
 
 tap.test(
-  'Run a script with overwriting templated variables in other nested config with cli variables',
+  'Run a script with overwriting variables in other nested config with cli variables',
   async (t) => {
     const variableOverride = {
       myVar: 3,

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -51,9 +51,11 @@ tap.test(
       '--config',
       'test/scripts/scenario-config-different-folder/config/config-processor-backward-compatibility.yml'
     ]);
-    console.log(output)
 
-    t.ok(exitCode === 0 && output.stdout.includes('Successfully ran with id myTestId123'));
+    t.ok(
+      exitCode === 0 &&
+        output.stdout.includes('Successfully ran with id myTestId123')
+    );
   }
 );
 
@@ -66,9 +68,11 @@ tap.test(
       '--config',
       'test/scripts/scenario-config-different-folder/config/config.yml'
     ]);
-    console.log(output)
 
-    t.ok(exitCode === 0 && output.stdout.includes('Successfully ran with id myTestId123'));
+    t.ok(
+      exitCode === 0 &&
+        output.stdout.includes('Successfully ran with id myTestId123')
+    );
   }
 );
 
@@ -146,6 +150,36 @@ tap.test('Run a script overwriting default options (output)', async (t) => {
       output.stdout.includes('Log file: artillery_report_custom.json')
   );
 });
+
+tap.test(
+  'Run a script with overwriting config variables with cli variables (including templated vars)',
+  async (t) => {
+    const variableOverride = {
+      bar: 'this is me',
+      myVar: 3
+    };
+    const [exitCode, output] = await execute([
+      'run',
+      'test/scripts/scenario-with-cli-variables.yml',
+      '--variables',
+      JSON.stringify(variableOverride)
+    ]);
+
+    t.ok(exitCode === 0);
+    t.ok(
+      output.stdout.includes(`foo is ${variableOverride.myVar}`),
+      'Templated foo variable is not showing'
+    );
+    t.ok(
+      output.stdout.includes(`bar is ${variableOverride.bar}`),
+      'bar variable from config not showing'
+    );
+    t.ok(
+      output.stdout.includes(`myVar is ${variableOverride.myVar}`),
+      'myVar variable from --variables not showing'
+    );
+  }
+);
 
 tap.test('Script using hook functions', async (t) => {
   const [exitCode, output] = await execute([

--- a/packages/artillery/test/scripts/scenario-cli-variables/processor.js
+++ b/packages/artillery/test/scripts/scenario-cli-variables/processor.js
@@ -1,0 +1,19 @@
+function myAfterResponseHandler(req, res, context, ee, next) {
+  //These are being console.logged so they can be asserted on by the test framework on the output
+  console.log(`HTTP timeout is: ${req.timeout}`);
+  console.log(
+    `Has default cookie: ${JSON.stringify(context._jar.store).includes(
+      'abc123'
+    )}`
+  );
+  console.log(
+    `Has cookie from flow: ${JSON.stringify(context._jar.store).includes(
+      'hellothere'
+    )}`
+  );
+  next();
+}
+
+module.exports = {
+  myAfterResponseHandler
+};

--- a/packages/artillery/test/scripts/scenario-cli-variables/scenario-with-other-nested-config.yml
+++ b/packages/artillery/test/scripts/scenario-cli-variables/scenario-with-other-nested-config.yml
@@ -1,0 +1,23 @@
+config:
+  target: http://asciiart.artillery.io
+  processor: "./processor.js"
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      name: "Phase 1"
+  variables:
+    other: "{{ myVar }}"
+  http:
+    timeout: "{{ myVar }}"
+  defaults:
+    cookie:
+      myCookie: "{{ defaultCookie }}"
+
+scenarios:
+  - flow:
+      - log: "other is {{ other }}"
+      - get:
+          url: "/"
+          cookie:
+            bar: "{{ anotherCookie }}"
+          afterResponse: myAfterResponseHandler

--- a/packages/artillery/test/scripts/scenario-cli-variables/scenario-with-variables.yml
+++ b/packages/artillery/test/scripts/scenario-cli-variables/scenario-with-variables.yml
@@ -5,10 +5,13 @@ config:
       arrivalRate: 1
       name: "Phase 1"
   variables:
-    foo: "{{ myVar }}"
+    foo:
+      nested: "{{ myVar }}"
+    other: "{{ myVar }}"
 
 scenarios:
   - flow:
-      - log: "foo is {{ foo }}"
+      - log: "foo is {{ foo.nested }}"
       - log: "bar is {{ bar }}"
+      - log: "other is {{ other }}"
       - log: "myVar is {{ myVar }}"

--- a/packages/artillery/test/scripts/scenario-with-cli-variables.yml
+++ b/packages/artillery/test/scripts/scenario-with-cli-variables.yml
@@ -1,0 +1,14 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      name: "Phase 1"
+  variables:
+    foo: "{{ myVar }}"
+
+scenarios:
+  - flow:
+      - log: "foo is {{ foo }}"
+      - log: "bar is {{ bar }}"
+      - log: "myVar is {{ myVar }}"


### PR DESCRIPTION
Solves https://github.com/artilleryio/artillery/issues/1560 by templating all config parameters taking into account `flags.variables` too.