### PR TITLE
feat: send events to dynatrace

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -4,7 +4,7 @@ const got = require('got');
 const debug = require('debug')('plugin:publish-metrics:dynatrace');
 
 class DynatraceReporter {
-  constructor(config, events) {
+  constructor(config, events, script) {
     this.config = {
       apiToken: config.apiToken,
       envUrl: config.envUrl,
@@ -17,6 +17,35 @@ class DynatraceReporter {
     if (!config.apiToken || !config.envUrl) {
       throw new Error(
         'Dynatrace API Access Token or Environment URL not specified. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
+      );
+    }
+
+    // Configure event if set - if event key is set but its value isn't we use defaults
+    if (config.hasOwnProperty('event')) {
+      this.eventConfig = {
+        properties: config.event?.properties || [],
+        send: config.event?.send || true,
+        entitySelector: config.event?.entitySelector
+      };
+
+      this.eventOpts = {
+        eventType: config.event?.eventType || 'CUSTOM_INFO',
+        title: config.event?.title || 'Artillery_io_test',
+        startTime: 0,
+        endTime: 0,
+        properties: {
+          target: script.config.target,
+          ...this.parseDimensions(this.eventConfig.properties, 'object')
+        }
+      };
+
+      if (this.eventConfig.entitySelector) {
+        this.eventOpts.entitySelector = String(this.eventConfig.entitySelector);
+      }
+
+      this.ingestEventsEndpoint = new URL(
+        '/api/v2/events/ingest',
+        this.config.envUrl
       );
     }
 
@@ -47,21 +76,45 @@ class DynatraceReporter {
       );
 
       const request = this.formRequest(
-        this.formPayload(counters, rates, summaries)
+        this.formMetricsPayload(counters, rates, summaries)
       );
       await this.sendRequest(this.ingestMetricsEndpoint, request);
     });
+
+    this.startedEventSent = false;
+    if (this.eventConfig && String(this.eventConfig.send) !== 'false') {
+      events.on('phaseStarted', async () => {
+        debug('phaseStarted event fired');
+        if (this.startedEventSent) {
+          return;
+        }
+        const timestamp = Date.now();
+        this.eventOpts.startTime = timestamp;
+        this.eventOpts.endTime = timestamp + 1;
+        this.eventOpts.properties.Phase = 'Test-Started';
+
+        await this.sendRequest(
+          this.ingestEventsEndpoint,
+          this.formRequest(JSON.stringify(this.eventOpts), 'event'),
+          'event'
+        );
+
+        this.startedEventSent = true;
+      });
+    }
   }
 
-  parseDimensions(dimensionList) {
+  parseDimensions(dimensionList, returnValue = 'list') {
     if (!dimensionList || (dimensionList && dimensionList.length === 0)) {
       return false;
     }
-    const parsedDimensions = [];
+    const parsedDimensions = returnValue === 'object' ? {} : [];
 
     for (const item of dimensionList) {
       const [name, value] = item.split(':');
-      parsedDimensions.push(`${name}="${value}"`);
+      returnValue === 'object'
+        ? (parsedDimensions[name] = value)
+        : parsedDimensions.push(`${name}="${value}"`);
     }
 
     return parsedDimensions;
@@ -134,15 +187,15 @@ class DynatraceReporter {
     return statGauges;
   }
 
-  formPayload(counters, rates, summaries) {
+  formMetricsPayload(counters, rates, summaries) {
     const payload = `${[...counters, ...rates, ...summaries].join('\n')}`;
     return payload;
   }
 
-  formRequest(payload) {
+  formRequest(payload, type = 'metrics') {
     const options = {
       headers: {
-        'Content-Type': 'text/plain',
+        'Content-Type': type === 'event' ? 'application/json' : 'text/plain',
         Authorization: `Api-Token ${this.config.apiToken}`
       },
       body: payload
@@ -151,20 +204,29 @@ class DynatraceReporter {
     return options;
   }
 
-  async sendRequest(url, options) {
+  async sendRequest(url, options, type = 'metrics') {
     this.pendingRequests += 1;
 
-    debug('Sending metrics to Dynatrace');
+    debug(`Sending ${type} to Dynatrace`);
     try {
       const res = await got.post(url, options);
 
-      if (res.statusCode !== 202) {
-        debug(`Status Code: ${res.statusCode}, ${res.statusMessage}`);
+      if (type === 'metrics' && res.statusCode !== 202) {
+        debug(
+          `Dynatrace Metric API response status: ${res.statusCode}, ${res.statusMessage}`
+        );
+      }
+
+      if (type === 'event') {
+        debug(
+          `Dynatrace Event API response status: ${res.statusCode}, ${res.statusMessage}`
+        );
+        debug(`Dynatrace EventIngestResult: ${res.body}`);
       }
     } catch (err) {
-      debug('An error occured when sending metrics to Dynatrace: ', err);
+      debug(`There has been an error in sending ${type} to Dynatrace: `, err);
     }
-    debug('Metrics sent to Dynatrace');
+    debug(`${type[0].toUpperCase() + type.slice(1)} sent to Dynatrace`);
 
     this.pendingRequests -= 1;
   }
@@ -180,7 +242,20 @@ class DynatraceReporter {
   }
 
   cleanup(done) {
-    console.log('cleaning up');
+    if (this.startedEventSent) {
+      const timestamp = Date.now();
+      this.eventOpts.startTime = timestamp;
+      this.eventOpts.endTime = timestamp + 1;
+      this.eventOpts.properties.Phase = 'Test-Finished';
+
+      this.sendRequest(
+        this.ingestEventsEndpoint,
+        this.formRequest(JSON.stringify(this.eventOpts), 'event'),
+        'event'
+      );
+    }
+
+    debug('Cleaning up');
     return this.waitingForRequest().then(done);
   }
 }

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -35,7 +35,7 @@ class DynatraceReporter {
         endTime: 0,
         properties: {
           target: script.config.target,
-          ...this.parseDimensions(this.eventConfig.properties, 'object')
+          ...this.parseProperties(this.eventConfig.properties)
         }
       };
 
@@ -104,20 +104,32 @@ class DynatraceReporter {
     }
   }
 
-  parseDimensions(dimensionList, returnValue = 'list') {
+  parseDimensions(dimensionList) {
     if (!dimensionList || (dimensionList && dimensionList.length === 0)) {
       return false;
     }
-    const parsedDimensions = returnValue === 'object' ? {} : [];
+    const parsedDimensions = [];
 
     for (const item of dimensionList) {
       const [name, value] = item.split(':');
-      returnValue === 'object'
-        ? (parsedDimensions[name] = value)
-        : parsedDimensions.push(`${name}="${value}"`);
+      parsedDimensions.push(`${name}="${value}"`);
     }
 
     return parsedDimensions;
+  }
+
+  parseProperties(propertyList) {
+    if (!propertyList || (propertyList && propertyList.length === 0)) {
+      return false;
+    }
+    const parsedProperties = {};
+
+    for (const item of propertyList) {
+      const [name, value] = item.split(':');
+      parsedProperties[name] = value;
+    }
+
+    return parsedProperties;
   }
 
   shouldSendMetric(metricName, excluded, includeOnly) {

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -34,7 +34,7 @@ class DynatraceReporter {
         startTime: 0,
         endTime: 0,
         properties: {
-          target: script.config.target,
+          Target: script.config.target,
           ...this.parseProperties(this.eventConfig.properties)
         }
       };

--- a/packages/artillery-plugin-publish-metrics/test/config-dynatrace.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-dynatrace.yaml
@@ -12,3 +12,7 @@ config:
         dimensions:
           - 'testId:{{ $processEnvironment.TEST_ID }}'
           - 'reporterType:dynatrace-metric-api'
+        event:
+          title: 'Plugin integration test'
+          properties:
+            - 'testId:{{ $processEnvironment.TEST_ID }}'


### PR DESCRIPTION
# What

Events feature for the Dynatrace reporter of the `publish-metrics` plugin. Supports sending events marking the start and the end of a test to Dynatrace through Event API.

**Configuration for users:**

Set `event` under Dynatrace configuration to send events.

- `eventType` -- the type of the event. It can be one of the values listed [here](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/events-v2/post-event#request-body-objects). Defaults to `CUSTOM_INFO`
- `title` -- the title of the event. Defaults to `Artillery_io_Test`.
- `send` -- set to `false` to turn off the event. By default, if an event is configured, it will be sent.
- `entitySelector` -- string. The [entity selector](https://www.dynatrace.com/support/help/dynatrace-api/environment-api/entity-v2/entity-selector), defining a set of Dynatrace entities to be associated with the event.
- `properties` -- a list of `name:value` strings to use as properties for events sent to Dynatrace. By default Artillery sends the `Target: <target set in the script config>` and `Phase: 'Test-Started' / 'Test-Finished'` properties. Any `properties` set in script will be sent in addition to the default ones.

```yaml
config:
  target: "https://my_website.com"
  plugins:
    publish-metrics:
      - type: dynatrace
        envUrl: "{{ $processEnvironment.DY_ENV_URL }}"
        apiKey: "{{ $processEnvironment.DY_API_KEY }}"
        event:
          title: "Artillery.load_test"
          properties:
            - "testId:{{ $processEnvironment.TEST_ID }}"
            - "Tool:Artillery"
            - "Load per minute:100"
            - "Load pattern:production"
```

# Testing

`config-dynatrace.yaml` file for Dynatrace has been updated to include the event feature.

I have tested manually with different scripts and combinations to make sure everything is formatted properly and that the events arrive as they should to Dynatrace and in those tests I did not notice any issues.

# Screenshots
<img width="703" alt="Screenshot 2023-08-03 at 11 36 31" src="https://github.com/artilleryio/artillery/assets/39635558/5799665c-1182-4162-a5bd-874c0151c1bd">
<img width="832" alt="Screenshot 2023-08-03 at 11 28 30" src="https://github.com/artilleryio/artillery/assets/39635558/5cc29053-2be6-4a97-806b-e76618431981">

# Notes
- I know the property names with capital letters seem a bit off but this is the exact example from their docs, and I've found that they are positioned differently if capitalised (at the top of the event view in the dashboard rather than alphabetically) and are more catchy/readable that way 

- I've noticed that the current behaviour of reporters that support events is that they send the 'end of test' event even if the test exited with an error without any information that the error occurred. Should we maybe also emit an event if the test fails or at least add a property to the 'end of test' event that sends that info across? 
Thoughts @hassy?