### PR TITLE
Bernardobridge/art 1205 platform is missing from metadata from tests run on lambda

### DIFF
--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -33,6 +33,8 @@ class RunLambdaCommand extends Command {
       flags['platform-opt'].push(`subnet-ids=${flags['subnet-ids']}`);
     }
 
+    flags.platform = 'aws:lambda';
+
     RunCommand.runCommandImplementation(flags, argv, args);
   }
 }

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -347,7 +347,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       metadata: {
         testId: testRunId,
         startedAt: Date.now(),
-        count: runnerOpts.count,
+        count: runnerOpts.count || Number(flags.count),
         tags: tagResult.tags,
         launchType: flags.platform,
         artilleryVersion: {


### PR DESCRIPTION
## Explanation

- Because `run-lambda` uses the common entrypoint of `run`, it shares this code to send the Platform to Cloud:
https://github.com/artilleryio/artillery/blob/main/packages/artillery/lib/cmds/run.js#L352 . For local runs, `platform` was correctly set to local (the default), but it wasn't being overridden by the Lambda entrypoint.

- Additionally, I noticed `count` wasn't being sent correctly to Cloud either (it was getting -1, its default). I sneaked a fix for that in here, since I was touching this part of the code. On local runs `runnerOpts.count` is set; when it's not set, it looks for the value from flags instead, converting it to a Number*.

_*this is because the API doesn't accept a string currently. we should handle this better in the API too._

## Testing

- Ran Lambda test and confirmed that metadata is correctly being sent to Artillery Cloud.