### PR TITLE
ci(skytrace): install before build/publish so deps are available

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -45,5 +45,7 @@ jobs:
       - run: npm -w artillery-engine-posthog publish --tag canary
       - run: npm -w artillery-engine-playwright publish --tag canary
       - run: npm -w artillery publish --tag canary
+      # Skytrace is a Typescript Package and needs to install -> build -> publish
+      - run: npm install -w skytrace
       - run: npm run build -w skytrace
       - run: npm -w skytrace publish --tag canary

--- a/.github/workflows/npm-publish-skytrace.yml
+++ b/.github/workflows/npm-publish-skytrace.yml
@@ -20,6 +20,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: PACKAGE_FOLDER_NAME=skytrace node .github/workflows/scripts/rename-packages-to-latest.js
+      - run: npm install -w skytrace
       - run: npm run build -w skytrace
       - run: npm -w skytrace publish
         env:


### PR DESCRIPTION
Skytrace publish has been failing for a while on `build` step, since it requires a `devDependency` that isn't available unless install is run.