### PR TITLE
ci(publish): use node version 18.x

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: | 

--- a/.github/workflows/npm-publish-artillery-engine-playwright.yml
+++ b/.github/workflows/npm-publish-artillery-engine-playwright.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-engine-playwright publish

--- a/.github/workflows/npm-publish-artillery-engine-posthog.yml
+++ b/.github/workflows/npm-publish-artillery-engine-posthog.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-engine-posthog publish

--- a/.github/workflows/npm-publish-artillery-plugin-apdex.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-apdex.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-apdex publish

--- a/.github/workflows/npm-publish-artillery-plugin-ensure.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-ensure.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-ensure publish

--- a/.github/workflows/npm-publish-artillery-plugin-expect.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-expect.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-expect publish

--- a/.github/workflows/npm-publish-artillery-plugin-metrics-by-endpoint.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-metrics-by-endpoint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-metrics-by-endpoint publish

--- a/.github/workflows/npm-publish-artillery-plugin-publish-metrics.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-publish-metrics.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-publish-metrics publish

--- a/.github/workflows/npm-publish-artillery.yml
+++ b/.github/workflows/npm-publish-artillery.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: PACKAGE_FOLDER_NAME=artillery node .github/workflows/scripts/rename-packages-to-latest.js

--- a/.github/workflows/npm-publish-int-commons.yml
+++ b/.github/workflows/npm-publish-int-commons.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w @artilleryio/int-commons publish

--- a/.github/workflows/npm-publish-int-core.yml
+++ b/.github/workflows/npm-publish-int-core.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: PACKAGE_FOLDER_NAME=core node .github/workflows/scripts/rename-packages-to-latest.js

--- a/.github/workflows/npm-publish-skytrace.yml
+++ b/.github/workflows/npm-publish-skytrace.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: PACKAGE_FOLDER_NAME=skytrace node .github/workflows/scripts/rename-packages-to-latest.js


### PR DESCRIPTION
## Why

We now use Node 18.x+ everywhere else, including platform-fargate.

This was causing an `npm install` in the publish scripts for Skytrace to fail. Took the opportunity to update it everywhere else in the publish scripts.