### PR TITLE
chore: add install step to types release

### DIFF
--- a/.github/workflows/npm-publish-artillery-types.yml
+++ b/.github/workflows/npm-publish-artillery-types.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
+      - run: npm ci
       - run: npm -w '@artilleryio/types' publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "tap --ts --no-coverage --color test/**/*.test.ts",
     "build": "typescript-json-schema ./tsconfig.schema.json \"TestScript\" --required --noExtraProps -o ./schema.json",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build && npm test"
   },
   "devDependencies": {
     "@types/tap": "^15.0.8",


### PR DESCRIPTION
- The `types` package needs to have its dependencies installed in order to be released. 
- Adds a `prepublishOnly` script to the `types` package so its built and tested before publishing. 