### PR TITLE
ci(publish): add --ignore-scripts to skytrace install on canary

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -15,6 +15,7 @@ on:
       - 'packages/commons/**'
       - 'packages/core/**'
       - 'packages/skytrace/**'
+      - 'packages/artillery-plugin-memory-inspector/**'
       
 jobs:
   build:

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -46,7 +46,7 @@ jobs:
       - run: npm -w artillery-engine-playwright publish --tag canary
       - run: npm -w artillery publish --tag canary
       # Skytrace is a Typescript Package and needs to install -> build -> publish
-      - run: npm install -w skytrace
+      - run: npm install -w skytrace --ignore-scripts
       - run: npm run build -w skytrace
       - run: npm -w skytrace publish --tag canary
       - run: npm -w artillery-plugin-memory-inspector publish --tag canary


### PR DESCRIPTION
## Why

CI was still failing: https://github.com/artilleryio/artillery/actions/runs/5795602657/job/15707505909

The reason is the git hooks which require an `npm install` on the root of the repo. As these hooks are unneeded before publish, adding `--ignore-scripts` here.