### PR TITLE
ci: release v0.1.2 @artilleryio/types

### DIFF
--- a/.github/workflows/npm-publish-artillery-types.yml
+++ b/.github/workflows/npm-publish-artillery-types.yml
@@ -20,6 +20,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm ci
-      - run: npm -w '@artilleryio/types' publish
+      - run: npm -w '@artilleryio/types' publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -253,10 +253,9 @@ export type Scenario = {
        * @title Scenario flow
        */
       flow: Array<
-        | HttpFlow
         | WebSocketFlow
         | ({
-            loop: Array<HttpFlow | WebSocketFlow>;
+            loop: Array<WebSocketFlow>;
             whileTrue?: string;
           } & (FixedLoop | DynamicLoop))
       >;
@@ -270,9 +269,10 @@ export type Scenario = {
        * @title Scenario flow
        */
       flow: Array<
+        | HttpFlow
         | SocketIoFlow
         | ({
-            loop: Array<SocketIoFlow>;
+            loop: Array<HttpFlow | SocketIoFlow>;
             whileTrue?: string;
           } & (FixedLoop | DynamicLoop))
       >;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artilleryio/types",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "files": [
     "./definitions.ts",
     "./schema.json"

--- a/packages/types/test/simple.test.ts
+++ b/packages/types/test/simple.test.ts
@@ -48,7 +48,7 @@ config:
   tap.end();
 });
 
-tap.test('supports HTTP flow properties for "websockets" engine', (tap) => {
+tap.test('supports HTTP flow properties for "socketio" engine', (tap) => {
   const errors = validateTestScript(`
 config:
   target: http://localhost:3000
@@ -56,16 +56,20 @@ config:
     - duration: 10
       rampTo: 50
 scenarios:
-  - engine: websocket
+  - engine: socketio
     flow:
       - get:
           url: /resource
       - think: 500
-      - send: "hello"
+      - emit:
+          channel: "echoResponse"
+          data: "hello"
       - loop:
           - post:
               url: /resource
-          - send: "world"
+          - emit:
+              channel: "anotherChannel"
+              data: "world"
         count: 5
 `);
 


### PR DESCRIPTION
- Sets the `--access public` flag on the `npm publish` command for the `@artilleryio/types` package (fixing https://github.com/artilleryio/artillery/actions/runs/5799049948/job/15718160240) 
- Removes the HTTP flow compliance from the `websocket` engine and adds it to the `socketio` engine. 
