### PR TITLE
chore(skytrace): remove readme from prepack script

### DIFF
--- a/packages/skytrace/package.json
+++ b/packages/skytrace/package.json
@@ -72,7 +72,7 @@
     "lint": "exit 0",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "npm -w skytrace run lint",
-    "prepack": "npm -w skytrace run build && oclif manifest && oclif readme",
+    "prepack": "npm -w skytrace run build && oclif manifest",
     "test": "exit 0",
     "version": "oclif readme && git add README.md"
   },


### PR DESCRIPTION
## Why

This is currently failing CI with:

```
TypeError: command.args.filter is not a function
``` 

As this Oclif feature is not currently being used for anything (we aren't auto-generating the docs anyway), I'm removing it for now, and we can fix this later (together with overall updating of oclif packages in Skytrace) when we want to actually auto-generate the docs.