### PR TITLE
chore(types): increase tap test timeout

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   ],
   "license": "MPL-2.0",
   "scripts": {
-    "test": "tap --ts --no-coverage --color test/**/*.test.ts",
+    "test": "tap --ts --no-coverage --color --timeout 60 test/**/*.test.ts",
     "build": "typescript-json-schema ./tsconfig.schema.json \"TestScript\" --required --noExtraProps -o ./schema.json",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build && npm test"


### PR DESCRIPTION
- Addresses a slow CI job at https://github.com/artilleryio/artillery/actions/runs/5819306125/job/15777434812

There's really nothing to take close to 30 seconds in these tests, even taking CI environment into consideration. We should look at migrating to a modern test runner like Vitest that's both fast and encourages better testing practices than `tap`. 