### PR TITLE
feat: send exit code to artillery cloud

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -122,7 +122,10 @@ class ArtilleryCloudPlugin {
     global.artillery.ext({
       ext: 'onShutdown',
       method: async (opts) => {
-        await this._event('testrun:end', { ts: testEndInfo.endTime });
+        await this._event('testrun:end', {
+          ts: testEndInfo.endTime,
+          suggestedExitCode: global.artillery.suggestedExitCode || opts.exitCode
+        });
         await this._event('testrun:changestatus', {
           status: opts.earlyStop ? 'EARLY_STOP' : 'COMPLETED'
         });

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -124,7 +124,7 @@ class ArtilleryCloudPlugin {
       method: async (opts) => {
         await this._event('testrun:end', {
           ts: testEndInfo.endTime,
-          suggestedExitCode: global.artillery.suggestedExitCode || opts.exitCode
+          exitCode: global.artillery.suggestedExitCode || opts.exitCode
         });
         await this._event('testrun:changestatus', {
           status: opts.earlyStop ? 'EARLY_STOP' : 'COMPLETED'


### PR DESCRIPTION
## Why

Sending exit code to cloud so the dashboard has information about the CLI exit code to display in the future.

## Testing

Tested with Fargate, Lambda and Local with successful exit code and failure (using ensure plugin).