### PR TITLE
feat(publish-metrics): fail early if required config missing

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -7,7 +7,7 @@ class DynatraceReporter {
   constructor(config, events, script) {
     if (!config.apiToken || !config.envUrl) {
       throw new Error(
-        'Dynatrace API Access Token or Environment URL not specified. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
+        'Dynatrace reporter: both apiToken and envUrl must be set. More info in the docs (https://docs.art/reference/extensions/publish-metrics#dynatrace)'
       );
     }
 

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -5,6 +5,12 @@ const debug = require('debug')('plugin:publish-metrics:dynatrace');
 
 class DynatraceReporter {
   constructor(config, events, script) {
+    if (!config.apiToken || !config.envUrl) {
+      throw new Error(
+        'Dynatrace API Access Token or Environment URL not specified. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
+      );
+    }
+
     this.config = {
       apiToken: config.apiToken,
       envUrl: config.envUrl,
@@ -13,12 +19,6 @@ class DynatraceReporter {
       includeOnly: config.includeOnly || [],
       dimensions: this.parseDimensions(config.dimensions)
     };
-
-    if (!config.apiToken || !config.envUrl) {
-      throw new Error(
-        'Dynatrace API Access Token or Environment URL not specified. In order to send metrics to Dynatrace both `apiToken` and `envUrl` must be set'
-      );
-    }
 
     // Configure event if set - if event key is set but its value isn't we use defaults
     if (config.hasOwnProperty('event')) {

--- a/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
+++ b/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
@@ -12,7 +12,7 @@ class HoneycombReporter {
   constructor(config, events, script) {
     if (!config.apiKey || !config.writeKey) {
       throw new Error(
-        'Honeycomb API/write Key not specified. In order to send traces to Honeycomb `apiKey` or `writeKey` must be provided'
+        'Honeycomb reporter: apiKey or writeKey must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#honeycomb)'
       );
     }
     this.hnyOpts = {

--- a/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
+++ b/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
@@ -10,6 +10,11 @@ const { URL } = require('url');
 
 class HoneycombReporter {
   constructor(config, events, script) {
+    if (!config.apiKey || !config.writeKey) {
+      throw new Error(
+        'Honeycomb API/write Key not specified. In order to send traces to Honeycomb `apiKey` or `writeKey` must be provided'
+      );
+    }
     this.hnyOpts = {
       writeKey: config.apiKey || config.writeKey,
       dataset: config.dataset,

--- a/packages/artillery-plugin-publish-metrics/lib/lightstep.js
+++ b/packages/artillery-plugin-publish-metrics/lib/lightstep.js
@@ -15,7 +15,7 @@ class LightstepReporter {
   constructor(config, events, script) {
     if (!config.accessToken || !config.componentName) {
       throw new Error(
-        'Lightstep access token or component name not specified. In order to send traces to Lightstep `accessToken` and `componentName` must be provided'
+        'Lightstep reporter: accessToken and componentName must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#lightstep)'
       );
     }
     this.lightstepOpts = {

--- a/packages/artillery-plugin-publish-metrics/lib/lightstep.js
+++ b/packages/artillery-plugin-publish-metrics/lib/lightstep.js
@@ -13,6 +13,11 @@ const { URL } = require('url');
 
 class LightstepReporter {
   constructor(config, events, script) {
+    if (!config.accessToken || !config.componentName) {
+      throw new Error(
+        'Lightstep access token or component name not specified. In order to send traces to Lightstep `accessToken` and `componentName` must be provided'
+      );
+    }
     this.lightstepOpts = {
       accessToken: config.accessToken,
       componentName: config.componentName,
@@ -45,6 +50,7 @@ class LightstepReporter {
       component_name: this.lightstepOpts.componentName,
       access_token: this.lightstepOpts.accessToken
     });
+
     opentracing.initGlobalTracer(this.tracer);
 
     attachScenarioHooks(script, [

--- a/packages/artillery-plugin-publish-metrics/lib/mixpanel.js
+++ b/packages/artillery-plugin-publish-metrics/lib/mixpanel.js
@@ -6,7 +6,7 @@ class MixPanelReporter {
   constructor(config, events, script) {
     if (!config.projectToken) {
       throw new Error(
-        'Mixpanel project token not specified. In order to send metrics to Mixpanel `projectToken` must be provided'
+        'Mixpanel reporter: projectToken must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#mixpanel)'
       );
     }
     this.mixPanelOpts = {

--- a/packages/artillery-plugin-publish-metrics/lib/mixpanel.js
+++ b/packages/artillery-plugin-publish-metrics/lib/mixpanel.js
@@ -4,6 +4,11 @@ const debug = require('debug')('plugin:publish-metrics:mixpanel');
 
 class MixPanelReporter {
   constructor(config, events, script) {
+    if (!config.projectToken) {
+      throw new Error(
+        'Mixpanel project token not specified. In order to send metrics to Mixpanel `projectToken` must be provided'
+      );
+    }
     this.mixPanelOpts = {
       projectToken: config.projectToken
     };
@@ -15,9 +20,7 @@ class MixPanelReporter {
         })`
       );
     }
-    if (!this.mixPanelOpts.projectToken) {
-      console.error('mix panel project token not specified');
-    }
+
     this.mixpanel = Mixpanel.init(this.mixPanelOpts.projectToken);
     this.sendToMixPanel(config, events, script);
     debug('init done');

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -5,7 +5,7 @@ class NewRelicReporter {
   constructor(config, events, script) {
     if (!config.licenseKey) {
       throw new Error(
-        'New Relic License Key not specified. In order to send metrics to New Relic `licenseKey` must be provided'
+        'New Relic reporter: licenseKey must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#newrelic)'
       );
     }
 

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -3,6 +3,12 @@ const debug = require('debug')('plugin:publish-metrics:newrelic');
 
 class NewRelicReporter {
   constructor(config, events, script) {
+    if (!config.licenseKey) {
+      throw new Error(
+        'New Relic License Key not specified. In order to send metrics to New Relic `licenseKey` must be provided'
+      );
+    }
+
     // Set each config value as matching user config if exists, else default values
     this.config = {
       region: config.region || 'us',
@@ -12,12 +18,6 @@ class NewRelicReporter {
       attributes: config.attributes || [],
       licenseKey: config.licenseKey
     };
-
-    if (!config.licenseKey) {
-      throw new Error(
-        'New Relic License Key not specified. In order to send metrics to New Relic `licenseKey` must be provided'
-      );
-    }
 
     if (config.hasOwnProperty('event') && !config.event?.accountId) {
       throw new Error(

--- a/packages/artillery-plugin-publish-metrics/lib/prometheus.js
+++ b/packages/artillery-plugin-publish-metrics/lib/prometheus.js
@@ -11,6 +11,11 @@ const COUNTERS_STATS = 'counters', // counters stats
 
 class PrometheusReporter {
   constructor(config, events) {
+    if (!config.pushgateway) {
+      throw new Error(
+        'URL of the Pushgateway instance not specified. In order to send metrics to Prometheus `pushgateway` must be provided'
+      );
+    }
     this.hasPendingRequest = false;
     this.workerID = process.env.WORKER_ID || uuid.v4();
     this.config = Object.assign(
@@ -25,11 +30,6 @@ class PrometheusReporter {
       pushgatewayUrl: config.pushgateway,
       ca: config.ca
     };
-
-    debug('ensuring pushgatewayUrl is configured');
-    if (!this.prometheusOpts.pushgatewayUrl) {
-      console.error(`the prometheus [pushgateway] url was not specified`);
-    }
 
     debug('setting default labels');
     PromClient.register.setDefaultLabels(this.tagsToLabels(this.config.tags));

--- a/packages/artillery-plugin-publish-metrics/lib/prometheus.js
+++ b/packages/artillery-plugin-publish-metrics/lib/prometheus.js
@@ -13,7 +13,7 @@ class PrometheusReporter {
   constructor(config, events) {
     if (!config.pushgateway) {
       throw new Error(
-        'URL of the Pushgateway instance not specified. In order to send metrics to Prometheus `pushgateway` must be provided'
+        'Prometheus reporter: pushgateway must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#prometheus-pushgateway)'
       );
     }
     this.hasPendingRequest = false;

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
@@ -5,7 +5,7 @@ class SplunkReporter {
   constructor(config, events, script) {
     if (!config.accessToken) {
       throw new Error(
-        'Splunk Access Token not specified. In order to send metrics to Splunk `accessToken` must be provided'
+        'Splunk reporter: accessToken must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#splunk)'
       );
     }
 

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
@@ -3,6 +3,12 @@ const debug = require('debug')('plugin:publish-metrics:splunk');
 
 class SplunkReporter {
   constructor(config, events, script) {
+    if (!config.accessToken) {
+      throw new Error(
+        'Splunk Access Token not specified. In order to send metrics to Splunk `accessToken` must be provided'
+      );
+    }
+
     this.config = {
       realm: config.realm || 'us0',
       prefix: config.prefix || 'artillery.',
@@ -18,7 +24,7 @@ class SplunkReporter {
       // Event API endpoint requires request payload to be an array of objects
       this.eventOpts = [
         {
-          eventType: config.event.eventType || `Artillery_io_Test`,
+          eventType: config.event.eventType || 'Artillery_io_Test',
           dimensions: {
             target: script.config.target,
             ...this.parseDimensions(config.event.dimensions)
@@ -217,7 +223,7 @@ class SplunkReporter {
     if (this.startedEventSent) {
       const timestamp = Date.now();
       this.eventOpts[0].timestamp = timestamp;
-      this.eventOpts[0].dimensions.phase = `Test-Finished`;
+      this.eventOpts[0].dimensions.phase = 'Test-Finished';
 
       this.sendRequest(this.ingestAPIEventEndpoint, this.eventOpts, 'event');
     }


### PR DESCRIPTION
# What
Making the `publish-metrics` reporters' behaviour consistent - all reporters will fail the test early if required config setting is not provided by user (e.g. API key). 
The exceptions for this are `Datadog` and `Cloudwatch` reporters as Datadog defaults to default settings and Cloudwatch pulls from the users environment, not the script. 

## Why 
Currently, if a user doesn't set a required config key (e.g. an API token), reporters behave in various ways.
Some don't let the user know at all and let the test continue, others just log a message that can easily be missed while test is running, and then some let the test fail with error when attempting to send the data.

If a user sets the `publish-metrics` plugin with its `type` in a script I believe that that shows clear intent to send the test data to one of the targets. It can be frustrating to see all your tests ran but no data arrived to destination, with no messages shown unless in debug mode. If we know the cause, we can fail early.