### PR TITLE
feat: add config.http.defaults to cli

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -85,6 +85,10 @@ function HttpEngine(script) {
     this.config.http = {};
   }
 
+  if (typeof this.config.http.defaults === 'undefined') {
+    this.config.http.defaults = {};
+  }
+
   if (typeof this.config.http.cookieJarOptions === 'undefined') {
     this.config.http.cookieJarOptions = {};
   }
@@ -197,7 +201,10 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
   }
 
   if (typeof requestSpec.think !== 'undefined') {
-    return engineUtil.createThink(requestSpec, self.config.defaults.think);
+    return engineUtil.createThink(
+      requestSpec,
+      self.config.http.defaults.think || self.config.defaults.think
+    );
   }
 
   if (typeof requestSpec.log !== 'undefined') {
@@ -387,7 +394,8 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
         // Assign default headers then overwrite as needed
         let defaultHeaders = lowcaseKeys(
-          config.defaults.headers || { 'user-agent': USER_AGENT }
+          config.http.defaults.headers ||
+            config.defaults.headers || { 'user-agent': USER_AGENT }
         );
         const combinedHeaders = _.extend(
           defaultHeaders,
@@ -811,7 +819,9 @@ function lastRequest(res, requestParams) {
 HttpEngine.prototype.setInitialContext = function (initialContext) {
   initialContext._successCount = 0;
 
-  initialContext._defaultStrictCapture = this.config.defaults.strictCapture;
+  initialContext._defaultStrictCapture =
+    this.config.http.defaults.strictCapture ||
+    this.config.defaults.strictCapture;
   initialContext._jar = new tough.CookieJar(
     null,
     this.config.http.cookieJarOptions
@@ -819,8 +829,12 @@ HttpEngine.prototype.setInitialContext = function (initialContext) {
 
   initialContext._enableCookieJar = false;
   // If a default cookie is set, we will use the jar straightaway:
-  if (typeof this.config.defaults.cookie === 'object') {
-    initialContext._defaultCookie = this.config.defaults.cookie;
+  if (
+    typeof this.config.http.defaults.cookie === 'object' ||
+    typeof this.config.defaults.cookie === 'object'
+  ) {
+    initialContext._defaultCookie =
+      this.config.http.defaults.cookie || this.config.defaults.cookie;
     initialContext._enableCookieJar = true;
   }
 

--- a/packages/core/test/core/index.js
+++ b/packages/core/test/core/index.js
@@ -9,6 +9,7 @@ require('./test_probability');
 require('./test_if');
 require('./ws/test_options');
 require('./test_think');
+require('./test_headers');
 require('./test_basic_auth');
 require('./test_cookies');
 require('./test_concurrent_requests');

--- a/packages/core/test/core/test_cookies.js
+++ b/packages/core/test/core/test_cookies.js
@@ -124,6 +124,50 @@ test('default cookies', function (t) {
   });
 });
 
+test('default cookies from config.http.defaults instead', function (t) {
+  const script = l.cloneDeep(require('./scripts/defaults_cookies.json'));
+  const cookie = script.config.defaults.cookie;
+  delete script.config.defaults;
+  script.config.http = { defaults: { cookie } };
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+      t.ok(
+        report.codes[200] && report.codes[200] > 0,
+        'There should be some 200s'
+      );
+      t.ok(report.codes[403] === undefined, 'There should be no 403s');
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('default cookies from config.http.defaults should take precedence', function (t) {
+  const script = l.cloneDeep(require('./scripts/defaults_cookies.json'));
+  const cookie = script.config.defaults.cookie;
+  script.config.http = { defaults: { cookie } };
+  script.config.defaults.cookie = 'rubbishcookie';
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+      t.ok(
+        report.codes[200] && report.codes[200] > 0,
+        'There should be some 200s'
+      );
+      t.ok(report.codes[403] === undefined, 'There should be no 403s');
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
 test('no default cookie', function (t) {
   var script = require('./scripts/defaults_cookies.json');
   delete script.config.defaults.cookie;

--- a/packages/core/test/core/test_headers.js
+++ b/packages/core/test/core/test_headers.js
@@ -1,0 +1,136 @@
+const { test } = require('tap');
+const runner = require('../..').runner.runner;
+const { SSMS } = require('../../lib/ssms');
+
+test('Set header inside request', (t) => {
+  const xAuthHeader = 'secret';
+
+  const script = {
+    config: {
+      target: 'http://127.0.0.1:3003',
+      phases: [{ duration: 1, arrivalRate: 1 }]
+    },
+    scenarios: [
+      {
+        flow: [
+          {
+            get: {
+              url: '/expectsHeader',
+              headers: { 'x-auth': xAuthHeader }
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.equal(
+        report.codes[200],
+        1,
+        `Should have a 200 status code: ${JSON.stringify(report)}`
+      );
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('Set header from config.http.defaults', (t) => {
+  const xAuthHeader = 'secret';
+
+  const script = {
+    config: {
+      target: 'http://127.0.0.1:3003',
+      phases: [{ duration: 1, arrivalRate: 1 }],
+      http: {
+        defaults: {
+          headers: { 'x-auth': xAuthHeader }
+        }
+      }
+    },
+    scenarios: [
+      {
+        flow: [
+          {
+            get: {
+              url: '/expectsHeader'
+            }
+          },
+          {
+            get: {
+              url: '/expectsHeader'
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.equal(
+        report.codes[200],
+        2,
+        `Should have two 200 status code: ${JSON.stringify(report)}`
+      );
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('Set header from config.defaults', (t) => {
+  const xAuthHeader = 'secret';
+
+  const script = {
+    config: {
+      target: 'http://127.0.0.1:3003',
+      phases: [{ duration: 1, arrivalRate: 1 }],
+      defaults: {
+        headers: { 'x-auth': xAuthHeader }
+      }
+    },
+    scenarios: [
+      {
+        flow: [
+          {
+            get: {
+              url: '/expectsHeader'
+            }
+          },
+          {
+            get: {
+              url: '/expectsHeader'
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+
+      t.equal(
+        report.codes[200],
+        2,
+        `Should have two 200 status code: ${JSON.stringify(report)}`
+      );
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});

--- a/packages/core/test/core/test_think.js
+++ b/packages/core/test/core/test_think.js
@@ -1,14 +1,34 @@
 'use strict';
 
-var { test } = require('tap');
-var runner = require('../..').runner.runner;
+const { test } = require('tap');
+const runner = require('../..').runner.runner;
 const { SSMS } = require('../../lib/ssms');
+const l = require('lodash');
 
 test('think', function (t) {
   var script = require('./scripts/thinks_http.json');
   runner(script).then(function (ee) {
     ee.on('done', function (nr) {
       const report = SSMS.legacyReport(nr).report();
+      t.ok('stats should be empty', report.codes === {});
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('think - with defaults from config.http.defaults instead', function (t) {
+  const script = l.cloneDeep(require('./scripts/thinks_http.json'));
+  const think = script.config.defaults.think;
+  delete script.config.defaults;
+  script.config.http = { defaults: { think } };
+
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+
       t.ok('stats should be empty', report.codes === {});
       ee.stop().then(() => {
         t.end();


### PR DESCRIPTION
## Why

Addresses https://github.com/artilleryio/artillery/issues/2036. The intention was always to have `config.http.defaults`.

_Note: I gave priority to `config.http.defaults` over `config.defaults` in the code since that is the preferred option._

## Testing

Automated tests were added for all the options except `capture`. I am having some issues with the existing capture tests (I'm not sure they're failing when they're supposed to), so I may address this specific test separately. This change should be pretty transparent though, as the actual options remain the same as before, and I'm merely adding a new way to set them.