### PR TITLE
chore: force double-quotes in yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
     "semi": true,
     "singleQuote": true,
     "useTabs": false,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "overrides": [
+      {
+        "files": "*.(yaml|yml)",
+        "options": {
+          "singleQuote": false
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
The Prettier config we have produces the wrong YAML formatting. This fixes it. 