### PR TITLE
ci: release v1.1.5 of artillery-plugin-ensure

### DIFF
--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-plugin-ensure",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Why

A version with fix https://github.com/artilleryio/artillery/commit/d1136f37d492d61e91a41334549a08196980b26c was never released, and fargate uses this package, which is why it wasn't picking up the change.