### PR TITLE
test(ensure): add tests for ensure plugin integration with artillery run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "artillery-plugin",
+  "name": "artillery",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -22245,11 +22245,189 @@
       "dependencies": {
         "debug": "^4.3.3",
         "filtrex": "^2.2.3"
+      },
+      "devDependencies": {
+        "tap": "^16.3.8",
+        "zx": "^7.2.3"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/@types/node": {
+      "version": "18.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
+      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==",
+      "dev": true
+    },
+    "packages/artillery-plugin-ensure/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "packages/artillery-plugin-ensure/node_modules/filtrex": {
       "version": "2.2.3",
       "license": "MIT"
+    },
+    "packages/artillery-plugin-ensure/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/globby": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dev": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "packages/artillery-plugin-ensure/node_modules/zx": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.2.3.tgz",
+      "integrity": "sha512-QODu38nLlYXg/B/Gw7ZKiZrvPkEsjPN3LQ5JFXM7h0JvwhEdPNNl+4Ao1y4+o3CLNiDUNcwzQYZ4/Ko7kKzCMA==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^11.0.1",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^18.16.3",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^3.0.0",
+        "chalk": "^5.2.0",
+        "fs-extra": "^11.1.1",
+        "fx": "*",
+        "globby": "^13.1.4",
+        "minimist": "^1.2.8",
+        "node-fetch": "3.3.1",
+        "ps-tree": "^1.2.0",
+        "webpod": "^0",
+        "which": "^3.0.0",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "packages/artillery-plugin-expect": {
       "version": "2.3.1",
@@ -23851,7 +24029,8 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.0.0",
+      "version": "0.1.2",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",
         "ajv": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21978,8 +21978,9 @@
     },
     "node_modules/zx": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-4.3.0.tgz",
+      "integrity": "sha512-KuEjpu5QFIMx0wWfzknDRhY98s7a3tWNRmYt19XNmB7AfOmz5zISA4+3Q8vlJc2qguxMn89uSxhPDCldPa3YLA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/fs-extra": "^9.0.12",
         "@types/minimist": "^1.2.2",
@@ -22248,186 +22249,12 @@
       },
       "devDependencies": {
         "tap": "^16.3.8",
-        "zx": "^7.2.3"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/@types/fs-extra": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
-      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/@types/node": {
-      "version": "18.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
-      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==",
-      "dev": true
-    },
-    "packages/artillery-plugin-ensure/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
+        "zx": "^4.3.0"
       }
     },
     "packages/artillery-plugin-ensure/node_modules/filtrex": {
       "version": "2.2.3",
       "license": "MIT"
-    },
-    "packages/artillery-plugin-ensure/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "dev": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
-      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/artillery-plugin-ensure/node_modules/zx": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/zx/-/zx-7.2.3.tgz",
-      "integrity": "sha512-QODu38nLlYXg/B/Gw7ZKiZrvPkEsjPN3LQ5JFXM7h0JvwhEdPNNl+4Ao1y4+o3CLNiDUNcwzQYZ4/Ko7kKzCMA==",
-      "dev": true,
-      "dependencies": {
-        "@types/fs-extra": "^11.0.1",
-        "@types/minimist": "^1.2.2",
-        "@types/node": "^18.16.3",
-        "@types/ps-tree": "^1.1.2",
-        "@types/which": "^3.0.0",
-        "chalk": "^5.2.0",
-        "fs-extra": "^11.1.1",
-        "fx": "*",
-        "globby": "^13.1.4",
-        "minimist": "^1.2.8",
-        "node-fetch": "3.3.1",
-        "ps-tree": "^1.2.0",
-        "webpod": "^0",
-        "which": "^3.0.0",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "zx": "build/cli.js"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
     },
     "packages/artillery-plugin-expect": {
       "version": "2.3.1",

--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "exit 0"
+    "test": "tap ./test/*.spec.mjs --timeout 300 --no-coverage --color"
   },
   "keywords": [],
   "author": "Artillery.io <team@artillery.io>",
@@ -12,5 +12,9 @@
   "dependencies": {
     "debug": "^4.3.3",
     "filtrex": "^2.2.3"
+  },
+  "devDependencies": {
+    "tap": "^16.3.8",
+    "zx": "^7.2.3"
   }
 }

--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "tap ./test/*.spec.mjs --timeout 300 --no-coverage --color"
+    "test": "tap ./test/*.spec.js --timeout 300 --no-coverage --color"
   },
   "keywords": [],
   "author": "Artillery.io <team@artillery.io>",
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "tap": "^16.3.8",
-    "zx": "^7.2.3"
+    "zx": "^4.3.0"
   }
 }

--- a/packages/artillery-plugin-ensure/test/fixtures/scenario.yml
+++ b/packages/artillery-plugin-ensure/test/fixtures/scenario.yml
@@ -1,0 +1,12 @@
+config:
+  target: "http://asciiart.artillery.io:8080"
+  phases:
+    - duration: 2
+      arrivalRate: 1
+      name: "Phase 1"
+
+scenarios:
+  - name: ensurePluginTest
+    flow:
+      - get:
+          url: "/"

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -1,5 +1,5 @@
-import { test, afterEach } from 'tap';
-import { $ } from 'zx';
+const { test, afterEach } = require('tap');
+const { $ } = require('zx');
 
 afterEach(async () => {
   delete process.env.ARTILLERY_DISABLE_ENSURE;
@@ -20,12 +20,19 @@ test('works with multiple thresholds set', async (t) => {
   });
 
   //Act: run the test
-  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
 
   // Assert
   t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
-  t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
-  t.ok(output.stdout.includes('ok: http.response_time.p99 < 10000'), 'Console did not include http.response_time.p99 check');
+  t.ok(
+    output.stdout.includes('ok: vusers.created < 3'),
+    'Console did not include vusers.created check'
+  );
+  t.ok(
+    output.stdout.includes('ok: http.response_time.p99 < 10000'),
+    'Console did not include http.response_time.p99 check'
+  );
 });
 
 test('works with config under config.plugins.ensure instead', async (t) => {
@@ -44,12 +51,19 @@ test('works with config under config.plugins.ensure instead', async (t) => {
   });
 
   //Act: run the test
-  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
 
   // Assert
   t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
-  t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
-  t.ok(output.stdout.includes('ok: http.response_time.p99 < 10000'), 'Console did not include http.response_time.p99 check');
+  t.ok(
+    output.stdout.includes('ok: vusers.created < 3'),
+    'Console did not include vusers.created check'
+  );
+  t.ok(
+    output.stdout.includes('ok: http.response_time.p99 < 10000'),
+    'Console did not include http.response_time.p99 check'
+  );
 });
 
 test('fails thresholds correctly', async (t) => {
@@ -67,12 +81,17 @@ test('fails thresholds correctly', async (t) => {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
   } catch (output) {
-
     //Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
-    t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
-    t.ok(output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 failed check');
+    t.ok(
+      output.stdout.includes('ok: vusers.created < 3'),
+      'Console did not include vusers.created check'
+    );
+    t.ok(
+      output.stdout.includes('fail: http.response_time.p99 < 1'),
+      'Console did not include http.response_time.p99 failed check'
+    );
   }
 });
 
@@ -89,13 +108,20 @@ test('disables plugin correctly when process.env.ARTILLERY_DISABLE_ENSURE is set
 
   //Act: run the test
   process.env.ARTILLERY_DISABLE_ENSURE = true;
-  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
 
   //Assert
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
   t.ok(!output.stdout.includes('Checks:'), 'Console did not include Checks');
-  t.ok(!output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
-  t.ok(!output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 failed check');
+  t.ok(
+    !output.stdout.includes('ok: vusers.created < 3'),
+    'Console did not include vusers.created check'
+  );
+  t.ok(
+    !output.stdout.includes('fail: http.response_time.p99 < 1'),
+    'Console did not include http.response_time.p99 failed check'
+  );
 });
 
 test('passes and fails correctly multiple conditions and thresholds', async (t) => {
@@ -120,13 +146,21 @@ test('passes and fails correctly multiple conditions and thresholds', async (t) 
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
   } catch (output) {
-
     //Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
-    t.ok(output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 threshold check');
-    t.ok(output.stdout.includes(`fail: ${failingExpression}`), 'Console did not include failing expression check');
-    t.ok(output.stdout.includes(`ok: ${passingExpression}`), 'Console did not include passing expression check');
+    t.ok(
+      output.stdout.includes('fail: http.response_time.p99 < 1'),
+      'Console did not include http.response_time.p99 threshold check'
+    );
+    t.ok(
+      output.stdout.includes(`fail: ${failingExpression}`),
+      'Console did not include failing expression check'
+    );
+    t.ok(
+      output.stdout.includes(`ok: ${passingExpression}`),
+      'Console did not include passing expression check'
+    );
   }
 });
 
@@ -148,13 +182,20 @@ test('strict: false does not fail conditions correctly', async (t) => {
   });
 
   //Act: run the test
-  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
   t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
 
-  t.ok(output.stdout.includes(`fail: ${failingExpression} (optional)`), 'Console did not include failing expression check with optional from strict');
-  t.ok(output.stdout.includes(`ok: ${passingExpression}`), 'Console did not include passing expression check');
+  t.ok(
+    output.stdout.includes(`fail: ${failingExpression} (optional)`),
+    'Console did not include failing expression check with optional from strict'
+  );
+  t.ok(
+    output.stdout.includes(`ok: ${passingExpression}`),
+    'Console did not include passing expression check'
+  );
 });
 
 test('works with legacy thresholds (passing and failing) together with new thresholds', async (t) => {
@@ -177,9 +218,18 @@ test('works with legacy thresholds (passing and failing) together with new thres
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
-    t.ok(output.stdout.includes('ok: p99 < 10000'), 'Console did not p99 check');
-    t.ok(output.stdout.includes('fail: http.response_time.p95 < 1'), 'Console did not include p95 check');
-    t.ok(output.stdout.includes('fail: max < 1'), 'Console did not include max check');
+    t.ok(
+      output.stdout.includes('ok: p99 < 10000'),
+      'Console did not p99 check'
+    );
+    t.ok(
+      output.stdout.includes('fail: http.response_time.p95 < 1'),
+      'Console did not include p95 check'
+    );
+    t.ok(
+      output.stdout.includes('fail: max < 1'),
+      'Console did not include max check'
+    );
   }
 });
 
@@ -202,6 +252,9 @@ test('works with legacy maxErrorRate', async (t) => {
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
-    t.ok(output.stdout.includes('fail: maxErrorRate < 0'), 'Console did not include maxErrorRate check');
+    t.ok(
+      output.stdout.includes('fail: maxErrorRate < 0'),
+      'Console did not include maxErrorRate check'
+    );
   }
 });

--- a/packages/artillery-plugin-ensure/test/index.spec.mjs
+++ b/packages/artillery-plugin-ensure/test/index.spec.mjs
@@ -2,7 +2,6 @@ import { test, afterEach } from 'tap';
 import { $ } from 'zx';
 
 afterEach(async () => {
-  //cleanup output file after each test
   delete process.env.ARTILLERY_DISABLE_ENSURE;
 });
 

--- a/packages/artillery-plugin-ensure/test/index.spec.mjs
+++ b/packages/artillery-plugin-ensure/test/index.spec.mjs
@@ -1,0 +1,208 @@
+import { test, afterEach } from 'tap';
+import { $ } from 'zx';
+
+afterEach(async () => {
+  //cleanup output file after each test
+  delete process.env.ARTILLERY_DISABLE_ENSURE;
+});
+
+test('works with multiple thresholds set', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [
+          { 'vusers.created': 3 },
+          { 'http.response_time.p99': 10000 }
+        ]
+      }
+    }
+  });
+
+  //Act: run the test
+  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+
+  // Assert
+  t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
+  t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
+  t.ok(output.stdout.includes('ok: http.response_time.p99 < 10000'), 'Console did not include http.response_time.p99 check');
+});
+
+test('works with config under config.plugins.ensure instead', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: {
+        ensure: {
+          thresholds: [
+            { 'vusers.created': 3 },
+            { 'http.response_time.p99': 10000 }
+          ]
+        }
+      }
+    }
+  });
+
+  //Act: run the test
+  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+
+  // Assert
+  t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+  t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
+  t.ok(output.stdout.includes('ok: http.response_time.p99 < 10000'), 'Console did not include http.response_time.p99 check');
+});
+
+test('fails thresholds correctly', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [{ 'vusers.created': 3 }, { 'http.response_time.p99': 1 }]
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  } catch (output) {
+
+    //Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
+    t.ok(output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
+    t.ok(output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 failed check');
+  }
+});
+
+test('disables plugin correctly when process.env.ARTILLERY_DISABLE_ENSURE is set', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [{ 'vusers.created': 3 }, { 'http.response_time.p99': 1 }]
+      }
+    }
+  });
+
+  //Act: run the test
+  process.env.ARTILLERY_DISABLE_ENSURE = true;
+  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+
+  //Assert
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.ok(!output.stdout.includes('Checks:'), 'Console did not include Checks');
+  t.ok(!output.stdout.includes('ok: vusers.created < 3'), 'Console did not include vusers.created check');
+  t.ok(!output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 failed check');
+});
+
+test('passes and fails correctly multiple conditions and thresholds', async (t) => {
+  //Arrange: Plugin overrides
+  const failingExpression = 'vusers.created < 2 and vusers.failed == 0';
+  const passingExpression =
+    'http.downloaded_bytes > 0 or http.response_time.min > 1000';
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [{ 'http.response_time.p99': 1 }],
+        conditions: [
+          { expression: failingExpression },
+          { expression: passingExpression }
+        ]
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  } catch (output) {
+
+    //Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+    t.ok(output.stdout.includes('fail: http.response_time.p99 < 1'), 'Console did not include http.response_time.p99 threshold check');
+    t.ok(output.stdout.includes(`fail: ${failingExpression}`), 'Console did not include failing expression check');
+    t.ok(output.stdout.includes(`ok: ${passingExpression}`), 'Console did not include passing expression check');
+  }
+});
+
+test('strict: false does not fail conditions correctly', async (t) => {
+  //Arrange: Plugin overrides
+  const failingExpression = 'vusers.created < 2 and vusers.failed == 0';
+  const passingExpression =
+    'http.downloaded_bytes > 0 or http.response_time.min > 1000';
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        conditions: [
+          { expression: failingExpression, strict: false },
+          { expression: passingExpression }
+        ]
+      }
+    }
+  });
+
+  //Act: run the test
+  const output = await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+
+  t.ok(output.stdout.includes(`fail: ${failingExpression} (optional)`), 'Console did not include failing expression check with optional from strict');
+  t.ok(output.stdout.includes(`ok: ${passingExpression}`), 'Console did not include passing expression check');
+});
+
+test('works with legacy thresholds (passing and failing) together with new thresholds', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        p99: 10000,
+        max: 1,
+        thresholds: [{ 'http.response_time.p95': 1 }]
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  } catch (output) {
+    // Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+    t.ok(output.stdout.includes('ok: p99 < 10000'), 'Console did not p99 check');
+    t.ok(output.stdout.includes('fail: http.response_time.p95 < 1'), 'Console did not include p95 check');
+    t.ok(output.stdout.includes('fail: max < 1'), 'Console did not include max check');
+  }
+});
+
+test('works with legacy maxErrorRate', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      target: 'http://notarealserver',
+      plugins: { ensure: {} },
+      ensure: {
+        maxErrorRate: 0
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  } catch (output) {
+    // Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
+    t.ok(output.stdout.includes('fail: maxErrorRate < 0'), 'Console did not include maxErrorRate check');
+  }
+});


### PR DESCRIPTION
## Why

As far as I could tell, there was a single ensure test in the repo, as part of an expect test. As this is an important part of the CLI (including Cloud), I'm adding tests there. 

Pulled this up in priority, as I'm working on related ensure work and may need to make a change in this part of the code, but I didn't want to do it without any tests.

_Note: I disabled coverage because we don't have it anywhere else in the repo, but actually these tests (accidentally) gave it about 90% coverage. It's only not 100% because of debug logs and error cases that would be best suited to unit tests._