### PR TITLE
chore(examples): make playwright example csv use cloud url

### DIFF
--- a/examples/browser-load-testing-playwright/pages.csv
+++ b/examples/browser-load-testing-playwright/pages.csv
@@ -1,3 +1,3 @@
 https://www.artillery.io/
 https://www.artillery.io/docs
-https://www.artillery.io/pro
+https://www.artillery.io/cloud


### PR DESCRIPTION
## Why

This causes a redirect when this URL is randomly chosen in the test, so web vital metrics are not displayed, as test exits too early.