### PR TITLE
chore: post slack notifications only on failures in main

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           FORCE_COLOR: 1
       - name: Notify about failures
-        if: failure()
+        if: failure() && github.ref == 'refs/heads/main'
         uses: slackapi/slack-github-action@v1
         with:
           payload: |


### PR DESCRIPTION
Since our `run-tests` workflow also triggers on pull requests to `main`, we get notifications for test failures for changes that may still be in progress. 

- Set an explicit `github.ref == 'refs/heads/main'` condition to the notification job so it only notifies about failures in `main`. 