### PR TITLE
Add application key property to artillery publish-metrics type datadog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22104,7 +22104,7 @@
       }
     },
     "packages/artillery": {
-      "version": "2.0.0-35",
+      "version": "2.0.0-36",
       "license": "MPL-2.0",
       "dependencies": {
         "@artilleryio/int-commons": "*",
@@ -22241,7 +22241,7 @@
       "license": "MPL-2.0"
     },
     "packages/artillery-plugin-ensure": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "debug": "^4.3.3",
@@ -22257,7 +22257,7 @@
       "license": "MIT"
     },
     "packages/artillery-plugin-expect": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -22519,7 +22519,7 @@
       }
     },
     "packages/artillery-plugin-publish-metrics": {
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
@@ -23331,7 +23331,7 @@
     },
     "packages/commons": {
       "name": "@artilleryio/int-commons",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "async": "^2.6.4",
         "cheerio": "^1.0.0-rc.10",
@@ -23344,7 +23344,7 @@
     },
     "packages/core": {
       "name": "@artilleryio/int-core",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "dependencies": {
         "@artilleryio/int-commons": "*",
         "@artilleryio/sketches-js": "^2.1.1",
@@ -23856,7 +23856,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-plugin-publish-metrics/lib/datadog.js
+++ b/packages/artillery-plugin-publish-metrics/lib/datadog.js
@@ -85,7 +85,7 @@ function DatadogReporter(config, events, script) {
     if (this.reportingType === 'api') {
       this.dogapi.initialize({
         api_key: config.apiKey,
-        app_Key: config.appKey
+        app_key: config.appKey
       });
     }
 

--- a/packages/artillery-plugin-publish-metrics/lib/datadog.js
+++ b/packages/artillery-plugin-publish-metrics/lib/datadog.js
@@ -39,8 +39,11 @@ function DatadogReporter(config, events, script) {
 
   debug('creating DatadogReporter with config');
   debug(
-    config.apiKey
-      ? Object.assign({ apiKey: sanitize(config.apiKey) }, config)
+    (config.apiKey || config.appKey)
+      ? Object.assign(
+        { apiKey: sanitize(config.apiKey),
+          appKey: sanitize(config.appKey)
+        }, config)
       : config
   );
 
@@ -50,6 +53,7 @@ function DatadogReporter(config, events, script) {
 
     this.metrics = new datadogMetrics.BufferedMetricsLogger({
       apiKey: config.apiKey,
+      appKey: config.appKey,
       apiHost: config.apiHost,
       prefix: config.prefix,
       defaultTags: config.tags,
@@ -80,7 +84,8 @@ function DatadogReporter(config, events, script) {
   if (config.event && String(config.event.send) !== 'false') {
     if (this.reportingType === 'api') {
       this.dogapi.initialize({
-        api_key: config.apiKey
+        api_key: config.apiKey,
+        app_Key: config.appKey
       });
     }
 
@@ -236,6 +241,9 @@ function createDatadogReporter(config, events, script) {
 }
 
 function sanitize(str) {
+  if(!str){
+    return str;
+  }
   return `${str.substring(0, 3)}********************${str.substring(
     str.length - 3,
     str.length

--- a/packages/artillery-plugin-publish-metrics/test/config-api.yaml
+++ b/packages/artillery-plugin-publish-metrics/test/config-api.yaml
@@ -7,6 +7,7 @@ config:
     publish-metrics:
       - type: datadog
         apiKey: "{{ $processEnvironment.DD_API_KEY }}"
+        appKey: "{{ $processEnvironment.DD_APP_KEY }}"
         prefix: 'artillery.publish_metrics_plugin.'
         tags:
           - "testId:{{ $processEnvironment.TEST_ID }}"

--- a/packages/artillery-plugin-publish-metrics/test/index.js
+++ b/packages/artillery-plugin-publish-metrics/test/index.js
@@ -21,7 +21,8 @@ test('Basic interface checks', async (t) => {
         'publish-metrics': [
           {
             type: 'datadog',
-            apiKey: '123'
+            apiKey: '123',
+            appKey: '456'
           }
         ]
       }


### PR DESCRIPTION
This new feature is related to this opened issue: https://github.com/artilleryio/artillery/issues/2066. Thx ;)