### PR TITLE
chore: change mockingjay port to 9099

### DIFF
--- a/packages/artillery-plugin-expect/test/pets-fail-test.yaml
+++ b/packages/artillery-plugin-expect/test/pets-fail-test.yaml
@@ -1,5 +1,5 @@
 config:
-  target: http://localhost:9090
+  target: http://localhost:9099
   phases:
     - duration: 1
       arrivalCount: 1
@@ -10,7 +10,7 @@ config:
 scenarios:
   - flow:
       - get:
-          name: 'unicorns'
-          url: '/pets/2'
+          name: "unicorns"
+          url: "/pets/2"
           expect:
             - statusCode: 200

--- a/packages/artillery-plugin-expect/test/pets-test.yaml
+++ b/packages/artillery-plugin-expect/test/pets-test.yaml
@@ -1,5 +1,5 @@
 config:
-  target: http://localhost:9090
+  target: http://localhost:9099
   phases:
     - duration: 1
       arrivalCount: 1

--- a/packages/artillery-plugin-expect/test/run.sh
+++ b/packages/artillery-plugin-expect/test/run.sh
@@ -17,7 +17,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-docker run --name mockingjay -p 9090:9099 -v "$DIR":/data "quii/mockingjay-server:$MOCKINGJAY_VERSION" --config /data/mock-pets-server.yaml &
+docker run --name mockingjay -p 9099:9090 -v "$DIR":/data "quii/mockingjay-server:$MOCKINGJAY_VERSION" --config /data/mock-pets-server.yaml &
 
 sleep 10
 

--- a/packages/artillery-plugin-expect/test/run.sh
+++ b/packages/artillery-plugin-expect/test/run.sh
@@ -17,7 +17,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-docker run --name mockingjay -p 9090:9090 -v "$DIR":/data "quii/mockingjay-server:$MOCKINGJAY_VERSION" --config /data/mock-pets-server.yaml &
+docker run --name mockingjay -p 9090:9099 -v "$DIR":/data "quii/mockingjay-server:$MOCKINGJAY_VERSION" --config /data/mock-pets-server.yaml &
 
 sleep 10
 


### PR DESCRIPTION
- Discovered in https://github.com/artilleryio/artillery/actions/runs/5925989155/job/16066519224

## Changes

- Sets `9099` as the new port for Mockingjay in tests.

## Motivation

We seem to encounter a flaky test behavior due to multiple tests attempting to establish a connection to the same port. When that happens, the test fails since the port is already in use. 