### PR TITLE
feat(publish-metrics): implement otel reporter with tracing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4602,6 +4602,23 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.15.2.tgz",
+      "integrity": "sha512-j9dPe8tyx4KqIqJAfZ/LCYfkF9+ggsT0V1+bVg9ZKTBNcLf5dTsTMdcxUxc/9s599kgcn6UERnti/tozbzwa6Q==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.41.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
@@ -22704,6 +22721,7 @@
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.41.2",
+        "@opentelemetry/exporter-zipkin": "^1.15.2",
         "@opentelemetry/resources": "^1.15.2",
         "@opentelemetry/sdk-trace-base": "^1.15.2",
         "@opentelemetry/semantic-conventions": "^1.15.2",
@@ -23625,11 +23643,6 @@
           "optional": true
         }
       }
-    },
-    "packages/core/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "packages/core/node_modules/ms": {
       "version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4532,6 +4532,196 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
+      "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.41.2.tgz",
+      "integrity": "sha512-Y0fGLipjZXLMelWtlS1/MDtrPxf25oM408KukRdkN31a1MEFo4h/ZkNwS7ZfmqHGUa+4rWRt2bi6JBiqy7Ytgw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.41.2.tgz",
+      "integrity": "sha512-IGZga9IIckqYE3IpRE9FO9G5umabObIrChlXUHYpMJtDgx797dsb3qXCvLeuAwB+HoB8NsEZstlzmLnoa6/HmA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-pfwa6d+Dax3itZcGWiA0AoXeVaCuZbbqUTsCtOysd2re8C2PWXNxDONUfBWsn+KgxAdi+ljwTjJGiaVLDaIEvQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-BxmEMiP6tHiFroe5/dTt9BsxCci7BTLtF7A6d4DKHLiLweWWZxQ9l7hON7qt/IhpKrQcAFD1OzZ1Gq2ZkNzhCw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "protobufjs": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.2.tgz",
+      "integrity": "sha512-jJbPwB0tNu2v+Xi0c/v/R3YBLJKLonw1p+v3RVjT2VfzeUyzSp/tBeVdY7RZtL6dzZpA9XSmp8UEfWIFQo33yA==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.41.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-logs": "0.41.2",
+        "@opentelemetry/sdk-metrics": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.2.tgz",
+      "integrity": "sha512-smqKIw0tTW15waj7BAPHFomii5c3aHnSE4LQYTszGoK5P9nZs8tEAIpu15UBxi3aG31ZfsLmm4EUQkjckdlFrw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz",
+      "integrity": "sha512-9aIlcX8GnhcsAHW/Wl8bzk4ZnWTpNlLtud+fxUfBtFATu6OZ6TrGrF4JkT9EVrnoxwtPIDtjHdEsSjOqisY/iA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.27.1",
       "dev": true,
@@ -12782,7 +12972,6 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.some": {
@@ -12976,6 +13165,11 @@
       "version": "2.7.5",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loupe": {
       "version": "2.3.6",
@@ -15769,6 +15963,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy": {
@@ -22523,6 +22740,12 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.41.2",
+        "@opentelemetry/resources": "^1.15.2",
+        "@opentelemetry/sdk-trace-base": "^1.15.2",
+        "@opentelemetry/semantic-conventions": "^1.15.2",
         "async": "^2.6.1",
         "datadog-metrics": "^0.9.3",
         "debug": "^4.1.1",
@@ -23441,11 +23664,6 @@
         }
       }
     },
-    "packages/core/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
     "packages/core/node_modules/nock": {
       "version": "11.8.2",
       "dev": true,
@@ -23459,29 +23677,6 @@
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "packages/core/node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "packages/core/node_modules/socket.io": {
@@ -23856,7 +24051,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -48,6 +48,9 @@ function Plugin(script, events) {
     } else if (config.type === 'dynatrace') {
       const { createDynatraceReporter } = require('./lib/dynatrace');
       this.reporters.push(createDynatraceReporter(config, events, script));
+    } else if (config.type === 'open-telemetry') {
+      const { createOTelReporter } = require('./lib/open-telemetry');
+      this.reporters.push(createOTelReporter(config, events, script));
     } else {
       events.emit(
         'userWarning',

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const debug = require('debug')('plugin:publish-metrics:otel');
+const { attachScenarioHooks } = require('../util');
+
+const { trace } = require('@opentelemetry/api');
+
+const { Resource } = require('@opentelemetry/resources');
+const {
+  SemanticResourceAttributes
+} = require('@opentelemetry/semantic-conventions');
+
+class OTelReporter {
+  constructor(config, events, script) {
+    this.script = script;
+    this.events = events;
+    this.protocols = [
+      ['http-proto', 'proto'],
+      ['http-json', 'http']
+    ];
+
+    this.resource = Resource.default().merge(
+      new Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]:
+          config.serviceName || 'Artillery-test'
+      })
+    );
+
+    if (config.traces) {
+      this.tracing = true;
+      this.traceConfig = config.traces;
+
+      this.configureTrace(this.traceConfig);
+
+      attachScenarioHooks(script, [
+        {
+          type: 'beforeRequest',
+          name: 'startOTelSpan',
+          hook: this.startOTelSpan.bind(this)
+        }
+      ]);
+
+      attachScenarioHooks(script, [
+        {
+          type: 'afterResponse',
+          name: 'exportOTelSpan',
+          hook: this.exportOTelSpan.bind(this)
+        }
+      ]);
+    }
+  }
+
+  configureTrace(config) {
+    debug('Configuring Tracer Provider');
+    const {
+      BasicTracerProvider,
+      TraceIdRatioBasedSampler,
+      ParentBasedSampler,
+      BatchSpanProcessor
+    } = require('@opentelemetry/sdk-trace-base');
+
+    this.tracerOpts = {
+      resource: this.resource
+    };
+    if (config.sampleRate) {
+      this.tracerOpts.sampler = new ParentBasedSampler({
+        root: new TraceIdRatioBasedSampler(config.sampleRate)
+      });
+    }
+
+    this.tracerProvider = new BasicTracerProvider(this.tracerOpts);
+
+    debug('Configuring Exporter');
+    this.traceExporterOpts = {};
+    if (config.endpoint) {
+      this.traceExporterOpts.url = config.endpoint;
+    }
+
+    if (config.headers) {
+      this.traceExporterOpts.headers = config.headers;
+    }
+
+    const protocol = !config.protocol
+      ? 'http'
+      : this.protocols.filter((p) => p[0] === config.protocol)[0][1];
+    const {
+      OTLPTraceExporter
+    } = require(`@opentelemetry/exporter-trace-otlp-${protocol}`);
+    this.exporter = new OTLPTraceExporter(this.traceExporterOpts);
+
+    this.tracerProvider.addSpanProcessor(
+      new BatchSpanProcessor(this.exporter, {
+        scheduledDelayMillis: 1000
+      })
+    );
+    this.tracerProvider.register();
+  }
+
+  startOTelSpan(req, userContext, events, done) {
+    debug('Starting span');
+    const startTime = Date.now();
+    userContext.vars['__otlStartTime'] = startTime;
+    const span = trace
+      .getTracer('artillery-tracer')
+      .startSpan('http_request', { startTime });
+    span.setAttribute('kind', 'client');
+    span.addEvent('http_request_started', startTime);
+    userContext.vars['__otlpSpan'] = span;
+
+    return done();
+  }
+
+  exportOTelSpan(req, res, userContext, events, done) {
+    if (!userContext.vars['__otlpSpan']) {
+      return done();
+    }
+
+    const span = userContext.vars['__otlpSpan'];
+    let endTime;
+    if (res.timings && res.timings.phases) {
+      span.setAttribute('timeToFirstByte', res.timings.phases.firstByte);
+      endTime =
+        userContext.vars['__otlStartTime'] + res.timings.phases.firstByte;
+      span.addEvent('http_request_ended', endTime);
+    } else {
+      span.addEvent('http_request_ended');
+    }
+
+    const url = new URL(req.url);
+    span.setAttributes({
+      url: url.href,
+      'url.host': url.host,
+      'http.request.method': req.method,
+      'http.response.status_code': res.statusCode
+    });
+
+    if (this.tracesConfig?.attributes) {
+      try {
+        span.setAttributes(this.tracesConfig.attributes);
+      } catch (err) {
+        debug('There has been an error in setting attributes:\n', err);
+      }
+    }
+    span.end(endTime || Date.now);
+
+    debug('Span finished');
+    return done();
+  }
+
+  async shutDown() {
+    debug('Initiating TracerProvider shutdown');
+    try {
+      await this.tracerProvider.shutdown();
+    } catch (err) {
+      debug(err);
+    }
+    return true;
+  }
+
+  cleanup(done) {
+    debug('Cleaning up');
+    return this.shutDown().then(done);
+  }
+}
+
+function createOTelReporter(config, events, script) {
+  return new OTelReporter(config, events, script);
+}
+
+module.exports = {
+  createOTelReporter
+};

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -25,6 +25,10 @@ class OTelReporter {
           OTLPTraceExporter
         } = require('@opentelemetry/exporter-trace-otlp-http');
         return new OTLPTraceExporter(options);
+      },
+      zipkin(options) {
+        const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
+        return new ZipkinExporter(options);
       }
     };
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -14,10 +14,10 @@ class OTelReporter {
   constructor(config, events, script) {
     this.script = script;
     this.events = events;
-    this.protocols = [
-      ['http-proto', 'proto'],
-      ['http-json', 'http']
-    ];
+    this.protocols = {
+      'http-proto': 'proto',
+      'http-json': 'http'
+    };
 
     this.resource = Resource.default().merge(
       new Resource({
@@ -82,7 +82,8 @@ class OTelReporter {
 
     const protocol = !config.protocol
       ? 'http'
-      : this.protocols.filter((p) => p[0] === config.protocol)[0][1];
+      : this.protocols[config.protocol];
+
     const {
       OTLPTraceExporter
     } = require(`@opentelemetry/exporter-trace-otlp-${protocol}`);
@@ -154,6 +155,7 @@ class OTelReporter {
     } catch (err) {
       debug(err);
     }
+    debug('TracerProvider shutdown completed');
     return true;
   }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('plugin:publish-metrics:otel');
+const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const { attachScenarioHooks } = require('../util');
 
 const { SpanKind, SpanStatusCode, trace } = require('@opentelemetry/api');
@@ -101,12 +101,14 @@ class OTelReporter {
     debug('Starting span');
     const startTime = Date.now();
     userContext.vars['__otlStartTime'] = startTime;
-    const span = trace
-      .getTracer('artillery-tracer')
-      .startSpan(req.method.toLowerCase(), {
-        startTime,
-        kind: SpanKind.CLIENT
-      });
+    const spanName =
+      this.traceConfig.useRequestNames && req.name
+        ? req.name
+        : req.method.toLowerCase();
+    const span = trace.getTracer('artillery-tracer').startSpan(spanName, {
+      startTime,
+      kind: SpanKind.CLIENT
+    });
 
     span.addEvent('http_request_started', startTime);
     userContext.vars['__otlpSpan'] = span;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -98,7 +98,6 @@ class OTelReporter {
   }
 
   startOTelSpan(req, userContext, events, done) {
-    debug('Starting span');
     const startTime = Date.now();
     userContext.vars['__otlStartTime'] = startTime;
     const spanName =
@@ -120,7 +119,6 @@ class OTelReporter {
       });
       debug('Span status set as error due to the following error: \n', err);
       span.end(Date.now);
-      debug('Span finished');
     });
 
     return done();
@@ -162,7 +160,6 @@ class OTelReporter {
 
     span.end(endTime || Date.now);
 
-    debug('Span finished');
     return done();
   }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -118,8 +118,9 @@ class OTelReporter {
 
     const span = userContext.vars['__otlpSpan'];
     let endTime;
+
     if (res.timings && res.timings.phases) {
-      span.setAttribute('timeToFirstByte', res.timings.phases.firstByte);
+      span.setAttribute('responseTimeMs', res.timings.phases.firstByte);
       endTime =
         userContext.vars['__otlStartTime'] + res.timings.phases.firstByte;
       span.addEvent('http_request_ended', endTime);
@@ -136,12 +137,9 @@ class OTelReporter {
     });
 
     if (this.tracesConfig?.attributes) {
-      try {
-        span.setAttributes(this.tracesConfig.attributes);
-      } catch (err) {
-        debug('There has been an error in setting attributes:\n', err);
-      }
+      span.setAttributes(this.tracesConfig.attributes);
     }
+
     span.end(endTime || Date.now);
 
     debug('Span finished');

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -15,6 +15,12 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.370.0",
+    "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.41.2",
+    "@opentelemetry/resources": "^1.15.2",
+    "@opentelemetry/sdk-trace-base": "^1.15.2",
+    "@opentelemetry/semantic-conventions": "^1.15.2",
     "async": "^2.6.1",
     "datadog-metrics": "^0.9.3",
     "debug": "^4.1.1",

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -18,6 +18,7 @@
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.41.2",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.41.2",
+    "@opentelemetry/exporter-zipkin": "^1.15.2",
     "@opentelemetry/resources": "^1.15.2",
     "@opentelemetry/sdk-trace-base": "^1.15.2",
     "@opentelemetry/semantic-conventions": "^1.15.2",


### PR DESCRIPTION
## What

Open Telemetry reporter that supports sending traces from Artillery to external monitoring and observability systems using Open Telemetry Protocol (OTLP) implemented over HTTP transport system. It uses the following Open Telemetry JS exporters [http/json](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http) and [http/protobuf](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto)

**Configuration:**

- In `publish-metrics` config set `type` to `open-telemetry`.
- `serviceName` -- **required** the name of service that data belongs to, defaults to `Artillery-test`
- `tracing` -- set to configure and send traces
  - `endpoint` -- OTLP ingest endpoint (exporters  default to `http://localhost:4318/v1/traces`)
  - `headers` -- headers in `key: value` pairs that are set for each request
  - `protocol` -- set to `http-proto` to send data over HTTP in `protobuf` format, defaults to `http-json` (data sent over HTTP in `JSON` format)
  - `sampleRate` -- sample rate (defaults to 1 i.e. send all spans)
  - `attributes` -- attributes `key: value` pairs to add to each span before export

```yaml
publish-metrics:
  - type: 'open-telemetry'
    serviceName: '{{ $processEnvironment.SERVICE_NAME }}'
    traces:
      protocol: 'http-proto'
      endpoint: '{{ $processEnvironment.OTLP_ENDPOINT}}'
      headers:
        Authorization: '{{ $processEnvironment.API_KEY}}'
      attributes:
        environment: 'test'
        tool: 'Artillery'
```

## Note

Both exporters are experimental packages and new releases may include breaking changes. Despite this, they are still widely adopted and a standard in the industry.