### PR TITLE
feat(ensure): add colored output to checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6840,7 +6840,8 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -22104,7 +22105,7 @@
       }
     },
     "packages/artillery": {
-      "version": "2.0.0-35",
+      "version": "2.0.0-36",
       "license": "MPL-2.0",
       "dependencies": {
         "@artilleryio/int-commons": "*",
@@ -22241,9 +22242,10 @@
       "license": "MPL-2.0"
     },
     "packages/artillery-plugin-ensure": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MPL-2.0",
       "dependencies": {
+        "chalk": "^2.4.2",
         "debug": "^4.3.3",
         "filtrex": "^2.2.3"
       },
@@ -22257,7 +22259,7 @@
       "license": "MIT"
     },
     "packages/artillery-plugin-expect": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -22519,7 +22521,7 @@
       }
     },
     "packages/artillery-plugin-publish-metrics": {
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
@@ -23331,7 +23333,7 @@
     },
     "packages/commons": {
       "name": "@artilleryio/int-commons",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "async": "^2.6.4",
         "cheerio": "^1.0.0-rc.10",
@@ -23344,7 +23346,7 @@
     },
     "packages/core": {
       "name": "@artilleryio/int-core",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "dependencies": {
         "@artilleryio/int-commons": "*",
         "@artilleryio/sketches-js": "^2.1.1",
@@ -23856,7 +23858,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-plugin-ensure/index.js
+++ b/packages/artillery-plugin-ensure/index.js
@@ -6,6 +6,7 @@
 
 const debug = require('debug')('plugin:ensure');
 const filtrex = require('filtrex').compileExpression;
+const chalk = require('chalk');
 
 class EnsurePlugin {
   constructor(script, events) {
@@ -63,16 +64,18 @@ class EnsurePlugin {
 
         global.artillery.globalEvents.emit('checks', checkTests);
 
-        checkTests.forEach((check) => {
+        checkTests
+          .sort((a, b) => (a.result < b.result) ? 1 : -1)
+          .forEach((check) => {
           if (check.result !== 1) {
             global.artillery.log(
-              `fail: ${check.original}${check.strict ? '' : ' (optional)'}`
+              `${chalk.red('fail')}: ${check.original}${check.strict ? '' : ' (optional)'}`
             );
             if (check.strict) {
               global.artillery.suggestedExitCode = 1;
             }
           } else {
-            global.artillery.log(`ok: ${check.original}`);
+            global.artillery.log(`${chalk.green('ok')}: ${check.original}`);
           }
         });
       }

--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -10,6 +10,7 @@
   "author": "Artillery.io <team@artillery.io>",
   "license": "MPL-2.0",
   "dependencies": {
+    "chalk": "^2.4.2",
     "debug": "^4.3.3",
     "filtrex": "^2.2.3"
   },


### PR DESCRIPTION
## What

- Sets coloured output on `fail`/`ok` messages in checks
- Fixes ordering of checks so that they are grouped: passing checks are displayed first, and failing checks after (before they could alternate, depending on the type of check, for example)

Example:
<img width="248" alt="Screenshot 2023-08-21 at 14 59 20" src="https://github.com/artilleryio/artillery/assets/39738771/be11d1ef-c6b3-4106-960d-23670e4d8f0a">
