### PR TITLE
fix(publish-metrics): change operator in honeycomb reporter

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
+++ b/packages/artillery-plugin-publish-metrics/lib/honeycomb.js
@@ -10,7 +10,7 @@ const { URL } = require('url');
 
 class HoneycombReporter {
   constructor(config, events, script) {
-    if (!config.apiKey || !config.writeKey) {
+    if (!config.apiKey && !config.writeKey) {
       throw new Error(
         'Honeycomb reporter: apiKey or writeKey must be provided. More info in the docs (https://docs.art/reference/extensions/publish-metrics#honeycomb)'
       );


### PR DESCRIPTION
Fixing a wrong operator in Honeycomb reporter's check for required settings.
Either `apiKey` or `writeKey` are required, not both. 