### PR TITLE
dep(publish-metrics): update Honeycomb client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5176,10 +5176,16 @@
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -6044,7 +6050,8 @@
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6225,6 +6232,14 @@
     },
     "node_modules/basic-auth-parser": {
       "version": "0.0.2"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
+      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -6621,6 +6636,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7353,7 +7369,8 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "node_modules/compress-brotli": {
       "version": "1.3.6",
@@ -7642,7 +7659,8 @@
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-js": {
       "version": "3.22.2",
@@ -7872,10 +7890,11 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
+      "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/datadog-metrics": {
@@ -8020,6 +8039,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/default-require-extensions": {
@@ -8055,16 +8075,16 @@
       }
     },
     "node_modules/degenerator": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.8"
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -8162,35 +8182,6 @@
       },
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/detective-amd/node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/detective-amd/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/detective-cjs": {
@@ -8688,84 +8679,32 @@
       }
     },
     "node_modules/escodegen": {
-      "version": "1.14.3",
-      "license": "BSD-2-Clause",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dependencies": {
         "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
         "esgenerate": "bin/esgenerate.js"
       },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=6.0"
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "4.3.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "license": "MIT"
-    },
-    "node_modules/escodegen/node_modules/levn": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/optionator": {
-      "version": "0.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/escodegen/node_modules/source-map": {
       "version": "0.6.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/type-check": {
-      "version": "0.3.2",
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -9990,7 +9929,8 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -10071,13 +10011,6 @@
       "integrity": "sha512-r70c72ln2YHzQINNfxDp02hAhbGkt1HffZ+Du8oetWDLjDtFja/Lm10lUaSh9e+wD+7VDvPee0b0C9SAy8pWZg==",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/filelist": {
@@ -10385,8 +10318,9 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.1",
-      "license": "MIT",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
+      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
@@ -10501,34 +10435,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/ftp": {
-      "version": "0.3.10",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "xregexp": "2.0.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ftp/node_modules/isarray": {
-      "version": "0.0.1",
-      "license": "MIT"
-    },
-    "node_modules/ftp/node_modules/readable-stream": {
-      "version": "1.1.14",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/ftp/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -10660,23 +10566,23 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "3.0.2",
-      "license": "MIT",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.1.tgz",
+      "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "data-uri-to-buffer": "3",
-        "debug": "4",
-        "file-uri-to-path": "2",
-        "fs-extra": "^8.1.0",
-        "ftp": "^0.3.10"
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^5.0.1",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/get-uri/node_modules/fs-extra": {
       "version": "8.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -11129,7 +11035,8 @@
     },
     "node_modules/hexoid": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "engines": {
         "node": ">=8"
       }
@@ -11240,6 +11147,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -11254,6 +11162,7 @@
     },
     "node_modules/http-errors/node_modules/depd": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11261,6 +11170,7 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "1",
@@ -11338,6 +11248,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -12330,12 +12241,12 @@
       }
     },
     "node_modules/libhoney": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.0.1.tgz",
-      "integrity": "sha512-8qiWJqDPfXpAVEoUv+8jVl6IgWwTYr+RKuPYh+Rf7aRZdXUo4t2N5JbGchrkGH0pI46RhFkwZ4BBeNm07R3w7A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/libhoney/-/libhoney-4.1.0.tgz",
+      "integrity": "sha512-U8oCouZXzjlO67wAhDyvnskn9MJFIzTWkxpzsAawUU4nQLMSdISgaGL64eqAeElLRnjlA4hhREr8zOz1So0+yg==",
       "dependencies": {
+        "proxy-agent": "^6.3.0",
         "superagent": "^8.0.0",
-        "superagent-proxy": "^3.0.0",
         "url-join": "^5.0.0"
       },
       "engines": {
@@ -13257,7 +13168,8 @@
     },
     "node_modules/mime": {
       "version": "2.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "bin": {
         "mime": "cli.js"
       },
@@ -13880,7 +13792,8 @@
     },
     "node_modules/netmask": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -15044,33 +14957,69 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
       "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4",
-        "get-uri": "3",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "5",
-        "pac-resolver": "^5.0.0",
-        "raw-body": "^2.2.0",
-        "socks-proxy-agent": "5"
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "pac-resolver": "^7.0.0",
+        "socks-proxy-agent": "^8.0.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/pac-resolver": {
-      "version": "5.0.1",
-      "license": "MIT",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
+      "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
       "dependencies": {
-        "degenerator": "^3.0.2",
-        "ip": "^1.1.5",
+        "degenerator": "^5.0.0",
+        "ip": "^1.1.8",
         "netmask": "^2.0.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
       }
     },
     "node_modules/package-hash": {
@@ -15796,36 +15745,70 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
+      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
       "dependencies": {
-        "agent-base": "^6.0.0",
-        "debug": "4",
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "pac-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.0.0",
-        "socks-proxy-agent": "^5.0.0"
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
       }
-    },
-    "node_modules/proxy-agent/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -15982,6 +15965,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -16617,6 +16601,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/samsam": {
@@ -16764,6 +16749,7 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sha.js": {
@@ -16971,15 +16957,27 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "5.0.1",
-      "license": "MIT",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
+      "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "agent-base": "^7.0.1",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/socks/node_modules/ip": {
@@ -17189,6 +17187,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -17407,15 +17406,16 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/superagent": {
-      "version": "8.0.6",
-      "license": "MIT",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
       "dependencies": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
+        "cookiejar": "^2.1.4",
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.1",
+        "formidable": "^2.1.2",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",
@@ -17425,23 +17425,10 @@
         "node": ">=6.4.0 <13 || >=14"
       }
     },
-    "node_modules/superagent-proxy": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.2",
-        "proxy-agent": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "superagent": ">= 0.15.4 || 1 || 2 || 3"
-      }
-    },
     "node_modules/superagent/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -19966,6 +19953,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -20788,6 +20776,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -20969,20 +20958,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vm2": {
-      "version": "3.9.19",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/walk-sync": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
@@ -21115,13 +21090,6 @@
         "wipe-node-cache": "^2.1.0"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "license": "MIT"
@@ -21230,10 +21198,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/xregexp": {
-      "version": "2.0.0",
-      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -22104,7 +22068,7 @@
       }
     },
     "packages/artillery": {
-      "version": "2.0.0-35",
+      "version": "2.0.0-36",
       "license": "MPL-2.0",
       "dependencies": {
         "@artilleryio/int-commons": "*",
@@ -22241,7 +22205,7 @@
       "license": "MPL-2.0"
     },
     "packages/artillery-plugin-ensure": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "debug": "^4.3.3",
@@ -22257,7 +22221,7 @@
       "license": "MIT"
     },
     "packages/artillery-plugin-expect": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -22519,7 +22483,7 @@
       }
     },
     "packages/artillery-plugin-publish-metrics": {
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
@@ -22528,7 +22492,7 @@
         "debug": "^4.1.1",
         "dogapi": "^2.8.4",
         "hot-shots": "^6.0.1",
-        "libhoney": "^4.0.1",
+        "libhoney": "^4.1.0",
         "lightstep-tracer": "^0.31.0",
         "mixpanel": "^0.13.0",
         "opentracing": "^0.14.5",
@@ -23331,7 +23295,7 @@
     },
     "packages/commons": {
       "name": "@artilleryio/int-commons",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "async": "^2.6.4",
         "cheerio": "^1.0.0-rc.10",
@@ -23344,7 +23308,7 @@
     },
     "packages/core": {
       "name": "@artilleryio/int-core",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "dependencies": {
         "@artilleryio/int-commons": "*",
         "@artilleryio/sketches-js": "^2.1.1",
@@ -23856,7 +23820,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -20,7 +20,7 @@
     "debug": "^4.1.1",
     "dogapi": "^2.8.4",
     "hot-shots": "^6.0.1",
-    "libhoney": "^4.0.1",
+    "libhoney": "^4.1.0",
     "lightstep-tracer": "^0.31.0",
     "mixpanel": "^0.13.0",
     "opentracing": "^0.14.5",


### PR DESCRIPTION
## Why

`libhoney` was using a dependency that included a security vulnerability, which was causing `npm audit` to report several Critical vulnerabilities in our repo. They've now removed that dependency and released a version with the fix, so we can upgrade ourselves, so we don't have any critical vulnerabilities in the repo.

## Testing

- [x] `npm audit --omit dev` doesn't show any more critical (or high) vulnerabilities:
<img width="259" alt="Screenshot 2023-08-22 at 15 29 20" src="https://github.com/artilleryio/artillery/assets/39635558/e8bf742b-aba0-43ba-970e-079b965875fd">

- [x]  Honeycomb reporter is working as expected (sends data to Honeycomb as before)