### PR TITLE
fix(types): support array of expectation metrics

### DIFF
--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -545,7 +545,7 @@ export type DefaultHttpRequest = {
    * https://www.artillery.io/docs/reference/extensions/expect#expectations
    * @title Expect plugin expectations
    */
-  expect?: ExpectPluginMetrics;
+  expect?: ExpectPluginMetrics | Array<ExpectPluginMetrics>;
 };
 
 export type HttpRequestWithBody = DefaultHttpRequest &

--- a/packages/types/test/plugin.expect.test.ts
+++ b/packages/types/test/plugin.expect.test.ts
@@ -41,3 +41,24 @@ scenarios:
 
   tap.end();
 });
+
+tap.test('supports array of expectations', (tap) => {
+  tap.same(
+    validateTestScript(`
+scenarios:
+  - flow:
+      - post:
+          url: /resource
+          expect:
+            - statusCode: 200
+            - contentType: json
+            - hasProperty: title
+            - equals:
+                - "From Dusk Till Dawn"
+                - "{{ title }}"
+  `),
+    []
+  );
+
+  tap.end();
+});


### PR DESCRIPTION
- Fixes an issue that errored when an array of expectation metrics is provided to the `expect` property on individual requests. 