### PR TITLE
chore(artillery): change repeated test names

### DIFF
--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -348,7 +348,7 @@ tap.test(
 );
 
 tap.test(
-  'Ramp to script throughput behaves as expected running on multiple workers',
+  'Ramp to script throughput behaves as expected running on multiple workers vs single worker',
   async (t) => {
     // This would cause older versions of artillery to generate much more traffic than expected
     // We compare them to the max amount of arrivals we expect from the script # Note: v2.0.0-22 generates 20+ arrivals, almost double
@@ -387,7 +387,7 @@ tap.test(
 );
 
 tap.test(
-  'Ramp to script throughput behaves as expected running on multiple workers 1s duration',
+  'Ramp to script throughput behaves as expected running on multiple workers vs single worker (1s duration)',
   async (t) => {
     // amount of workers was still affecting ramps with duration = 1s
     // check single worker and multiple workers now generate same throughput
@@ -431,7 +431,7 @@ tap.test(
 );
 
 tap.test(
-  'Ramp to script throughput behaves as expected running on multiple workers',
+  'Ramp to script throughput behaves as expected running on multiple workers (1s duration)',
   async (t) => {
     // Ramp to 2.0.0-24 regression #1682
     // This would cause older versions of artillery to use Infinity as tick duration


### PR DESCRIPTION
## Why

There's a flaky test in CI that fails occasionally. I believe this will be hard enough to debug, but what doesn't help is that it shares its name with another test, making it impossible to pinpoint the culprit, since the TAP stack trace is not pointing to the exact file when there's a timeout.

Changing this first so we can have a better chance to isolate the problem and fix it.