### PR TITLE
feat(core): support multiple time formats in artillery cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23370,6 +23370,7 @@
         "hpagent": "^0.1.1",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.19",
+        "ms": "^2.1.3",
         "protobufjs": "^7.2.4",
         "proxy": "^1.0.2",
         "socket.io-client": "^4.5.1",
@@ -23447,6 +23448,11 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "packages/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "packages/core/node_modules/nock": {
       "version": "11.8.2",
@@ -23858,7 +23864,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "hpagent": "^0.1.1",
     "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.19",
+    "ms": "^2.1.3",
     "protobufjs": "^7.2.4",
     "proxy": "^1.0.2",
     "socket.io-client": "^4.5.1",
@@ -37,7 +38,9 @@
   "scripts": {
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "lint-fix": "npm run lint -- --fix",
-    "test": "tap --no-coverage --color --timeout=300 test/core/unit/*.test.js && bash test/core/run.sh"
+    "test": "npm run test:unit && npm run test:acceptance",
+    "test:unit": "tap --no-coverage --color --timeout=300 test/core/unit/*.test.js",
+    "test:acceptance": "bash test/core/run.sh"
   },
   "devDependencies": {
     "@hapi/basic": "^6.0.0",

--- a/packages/core/test/core/scripts/arrival_phases_time_format.json
+++ b/packages/core/test/core/scripts/arrival_phases_time_format.json
@@ -1,0 +1,33 @@
+{
+  "config": {
+    "target": "http://127.0.0.1:3003",
+    "phases": [
+      {
+        "duration": "10s",
+        "arrivalCount": 10
+      },
+      {
+        "pause": "0.5 min"
+      },
+      {
+        "duration": "1",
+        "arrivalCount": 1
+      },
+      {
+        "duration": "9 seconds",
+        "arrivalCount": 50
+      }
+    ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "get": {
+            "url": "/"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/core/test_arrivals.js
+++ b/packages/core/test/core/test_arrivals.js
@@ -3,9 +3,10 @@
 const { test } = require('tap');
 const runner = require('../..').runner.runner;
 const { SSMS } = require('../../lib/ssms');
+const { init } = require('../../../artillery/lib/telemetry');
 
 test('arrival phases', function (t) {
-  var script = require('./scripts/arrival_phases.json');
+  const script = require('./scripts/arrival_phases.json');
 
   runner(script).then(function (ee) {
     ee.on('phaseStarted', function (info) {
@@ -19,6 +20,38 @@ test('arrival phases', function (t) {
       const report = SSMS.legacyReport(nr).report();
 
       t.ok(report.codes[200] === 60, 'Got 60 status 200 responses');
+
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('arrival phases - with modified time format', function (t) {
+  const script = require('./scripts/arrival_phases_time_format.json');
+  const initialTime = Date.now();
+
+  runner(script).then(function (ee) {
+    ee.on('phaseStarted', function (info) {
+      console.log('Starting phase: %j - %s', info, new Date());
+    });
+    ee.on('phaseCompleted', function () {
+      console.log('Phase completed - %s', new Date());
+    });
+
+    ee.on('done', function (nr) {
+      const finalTime = Date.now();
+      const report = SSMS.legacyReport(nr).report();
+
+      t.ok(report.codes[200] === 61, 'Did not get 61 status 200 responses');
+      t.ok(
+        finalTime - initialTime >= 50 * 1000,
+        `Took ${
+          finalTime - initialTime
+        }ms. Did not take at least 50 seconds (to account for pause time)`
+      );
 
       ee.stop().then(() => {
         t.end();

--- a/packages/core/test/core/unit/phases.test.js
+++ b/packages/core/test/core/unit/phases.test.js
@@ -80,6 +80,43 @@ test('arrivalRate set to 0 stays at 0', function (t) {
   phaser.run();
 });
 
+test('modifies duration in phase as expected', async function (t) {
+  const phaseSpec = { duration: '5s', arrivalRate: 3 };
+
+  const phaser = createPhaser([phaseSpec]);
+
+  phaser.on('phaseStarted', function (spec) {
+    t.ok(spec.duration == 5, 'duration should be 5');
+  });
+
+  phaser.run();
+});
+
+test('modifies pause in phase as expected', async function (t) {
+  const phaseSpec = { pause: '2s' };
+
+  const phaser = createPhaser([phaseSpec]);
+
+  phaser.on('phaseStarted', function (spec) {
+    t.ok(spec.pause == 2, 'pause should be 2');
+  });
+
+  phaser.run();
+});
+
+test('throws when duration is invalid', async function (t) {
+  const phaseSpec = { duration: '5 potatoes', arrivalRate: 3 };
+
+  let phaserError;
+  try {
+    createPhaser([phaseSpec]);
+  } catch (error) {
+    phaserError = error;
+  }
+
+  t.equal(phaserError.message, 'Invalid duration for phase: 5 potatoes');
+});
+
 test('arrivalCount', function (t) {
   const phaseSpec = {
     duration: 10,
@@ -229,7 +266,7 @@ function testRamp(t, phaseSpec) {
 
     t.ok(
       Math.abs(arrivals - expected) <= expected * 0.2, // large allowance
-      'seen arrivals within expected bounds'
+      `seen arrivals within expected bounds: ${arrivals} vs ${expected}`
     );
 
     t.end();

--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -230,34 +230,34 @@ export type TestPhase = {
        * Test phase duration (in seconds).
        * @title Duration
        */
-      duration: number;
+      duration: number | string;
       /**
        * Constant arrival rate.
        * The number of virtual users generated every second.
        * @title Arrival rate
        */
-      arrivalRate?: number;
+      arrivalRate?: number | string;
       /**
        * Fixed number of virtual users.
        * @title Arrival count
        */
-      arrivalCount?: number;
+      arrivalCount?: number | string;
       /**
        * @title Ramp rate
        */
-      rampTo?: number;
+      rampTo?: number | string;
       /**
        * Maximum number of virtual users generated at any given time.
        * @title Maximum virtual users
        */
-      maxVusers?: number;
+      maxVusers?: number | string;
     }
   | {
       /**
        * Pause the test phase execution for given duration (in seconds).
        * @title Pause
        */
-      pause: number;
+      pause: number | string;
     }
 );
 

--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -228,6 +228,7 @@ export type TestPhase = {
   | {
       /**
        * Test phase duration (in seconds).
+       * Can also be any valid [human-readable duration](https://www.npmjs.com/package/ms).
        * @title Duration
        */
       duration: number | string;
@@ -255,6 +256,7 @@ export type TestPhase = {
   | {
       /**
        * Pause the test phase execution for given duration (in seconds).
+       * Can also be any valid [human-readable duration](https://www.npmjs.com/package/ms).
        * @title Pause
        */
       pause: number | string;


### PR DESCRIPTION
## Why

### New Functionality
This will allow users to specify all time formats supported by https://www.npmjs.com/package/ms, bringing us more in line with other Load test frameworks. This is quite useful especially in load test scripts that have long durations

e.g. instead of:
```yaml
phases:
    - duration: 1800
      arrivalRate: 1
      rampTo: 50
      name: "Phase 1"
    - duration: 10800
      arrivalRate: 50
```

users can now specify:
```yaml
phases:
    - duration: 30m
      arrivalRate: 1
      rampTo: 50
      name: "Phase 1"
    - duration: 3h
      arrivalRate: 50
```

which is much more readable.

Note: this also addresses https://github.com/artilleryio/artillery/issues/2065.

### Fixing Endless Test Bug

Previously, when a test was started with an invalid duration, it would run endlessly. That is now caught as well, and errors:
<img width="442" alt="Screenshot 2023-08-24 at 15 53 04" src="https://github.com/artilleryio/artillery/assets/39738771/2a9189a5-2712-4bec-8f14-b1479810fa62">
(there's a stack trace below it too)

I didn't spend too much time on the error handling itself, because changing that would require deeper changes into how workers interact with core, but this already satisfies the problem.

If wanted, we could also add validation for other invalid properties at this point in the future (e.g. negative numbers, non valid arrivals, etc).

## Testing

- [x] For Artillery local, this is well tested manually and with the automated tests added
- [ ] For Fargate, this will require a canary release, and then pointing `platform-fargate` to that canary to test it. However, as Fargate simply runs the Artillery CLI, it should just work.
- [ ] For Lambda, this will require a release of `core`, since it installs latest. Once again, since Lambda simply runs Artillery CLI, it should just work after that.

After this has been merged to master, I will test Fargate and Lambda after.