### PR TITLE
test(artillery): increase timeout of suite

### DIFF
--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -43,7 +43,7 @@
     }
   },
   "scripts": {
-    "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=300 --color test/unit/*.test.js test/cli/*.test.js && bash test/lib/run.sh && tap --no-coverage --color test/testcases/plugins/*.test.js",
+    "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 --color test/unit/*.test.js test/cli/*.test.js && bash test/lib/run.sh && tap --no-coverage --color test/testcases/plugins/*.test.js",
     "test:cloud": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=300 test/cloud-e2e/*.test.js",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "lint-fix": "npm run lint -- --fix"


### PR DESCRIPTION
## Why

There's a particular test in the suite that keeps failing due to a timeout. Now that I've changed its title to distinguish which one, I can see it's the last test in the suite to run. My theory is that maybe the problem is not the test at all, but sometimes the runtime of the suite is being pushed beyond 5 minutes in CI (and happens to always fall on that test because it's the last one to run).