### PR TITLE
fix(types): rename "followRedirects" to "followRedirect"

### DIFF
--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -491,7 +491,7 @@ export type DefaultHttpRequest = {
    * Set this option to `false` to stop following redirects.
    * @title Disable redirect following
    */
-  followRedirects?: false;
+  followRedirect?: false;
   /**
    * @title Capture
    */


### PR DESCRIPTION
During testing I've discovered a typo in one of the request properties: `followRedirects` doesn't exist, the property must be `followRedirect`. This fixes the issue. 