### PR TITLE
chore: forward the entire "err" in "execute" helper

### DIFF
--- a/packages/artillery/test/cli/_helpers.js
+++ b/packages/artillery/test/cli/_helpers.js
@@ -13,7 +13,7 @@ async function execute(args, options) {
     const result = await c;
     return [0, result];
   } catch (err) {
-    return [err.code, err.stderr];
+    return [err.code, err];
   }
 }
 async function deleteFile(path) {

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -26,7 +26,7 @@ tap.test(
       '-o',
       'totally/bogus/path'
     ]);
-    t.ok(exitCode !== 0 && output.includes('Path does not exist'));
+    t.ok(exitCode !== 0 && output.stderr.includes('Path does not exist'));
   }
 );
 
@@ -38,7 +38,7 @@ tap.test(
       'test/scripts/environments.yaml'
     ]);
 
-    t.ok(exitCode !== 0 && output.includes('No target specified'));
+    t.ok(exitCode !== 0 && output.stderr.includes('No target specified'));
   }
 );
 

--- a/packages/artillery/test/cli/errors-and-warnings.test.js
+++ b/packages/artillery/test/cli/errors-and-warnings.test.js
@@ -41,7 +41,7 @@ tap.test(
 
 tap.test('Suggest similar commands if unknown command is used', async (t) => {
   const [exitCode, output] = await execute(['helpp']);
-  t.ok(exitCode === 127 && output.includes('Did you mean'));
+  t.ok(exitCode === 127 && output.stderr.includes('Did you mean'));
 });
 
 /*


### PR DESCRIPTION
## Context

Our `execute` helper function for running the CLI in tests only forwards the `err.stderr` to the test. This makes it difficult to use when you wish to assert `stdout`, or other properties in case of error scenarios. 

## Changes

- Forwards the entire `err` object to the consumer.
- Adjusts existing tests asserting on `output` directly. 