### PR TITLE
refactor(examples): make playwright smoke example have more interaction

### DIFF
--- a/examples/browser-load-testing-playwright/browser-smoke-test.yml
+++ b/examples/browser-load-testing-playwright/browser-smoke-test.yml
@@ -2,7 +2,9 @@ config:
   target: "https://www.artillery.io"
   payload:
     - path: ./pages.csv
-      fields: ["url"]
+      fields:
+        - "url"
+        - "title"
   engines:
     playwright: {}
   processor: ./flows.js

--- a/examples/browser-load-testing-playwright/flows.js
+++ b/examples/browser-load-testing-playwright/flows.js
@@ -19,12 +19,21 @@ async function cloudWaitlistSignupFlow(page) {
 //
 async function checkPage(page, userContext, events) {
   const url = userContext.vars.url;
+  const title = userContext.vars.title;
   const response = await page.goto(url);
   if (response.status() !== 200) {
     events.emit('counter', `user.status_check_failed.${url}`, 1);
   } else {
     events.emit('counter', `user.status_check_ok.${url}`, 1);
   }
+
+  const isElementVisible = await page.getByText(title).isVisible();
+
+  if (!isElementVisible) {
+    events.emit('counter', `user.element_check_failed.${title}`, 1);
+  }
+
+  await page.reload();
 }
 
 async function multistepWithCustomMetrics(page, userContext, events) {

--- a/examples/browser-load-testing-playwright/pages.csv
+++ b/examples/browser-load-testing-playwright/pages.csv
@@ -1,3 +1,3 @@
-https://www.artillery.io/
-https://www.artillery.io/docs
-https://www.artillery.io/pro
+https://www.artillery.io/,The Artillery Manifesto
+https://www.artillery.io/docs,What's different about Artillery?
+https://www.artillery.io/cloud,Test more effectively & fix issues faster


### PR DESCRIPTION
## Why

As per https://github.com/GoogleChrome/web-vitals/issues/180, very simple scenarios can sometimes be too fast for certain metrics like `LCP` and `CLS` to be able to be caught in time. For this reason, I've added the `page.reload()` function (instead of adding additional things like clicks that go to other pages).

In our case, even `TTFB` and `FCP` weren't consistently showing, which is why I also added waiting for an element beforehand.