### PR TITLE
dep(playwright): update playwright version to 1.37.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4533,29 +4533,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.27.1",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
+      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.27.1"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.27.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright": "cli.js"
+        "node": ">=16"
       },
-      "engines": {
-        "node": ">=14"
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -15376,27 +15369,29 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.34.3",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.37.1.tgz",
+      "integrity": "sha512-bgUXRrQKhT48zHdxDYQTpf//0xDfDd5hLeEhjuSw8rXEGoT9YeElpfvs/izonTNY21IQZ7d3s22jLxYaAnubbQ==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.34.3"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.34.3",
-      "license": "Apache-2.0",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/pluralize": {
@@ -22167,10 +22162,10 @@
       "license": "MPL-2.0",
       "dependencies": {
         "debug": "^4.3.2",
-        "playwright": "1.34.3"
+        "playwright": "1.37.1"
       },
       "devDependencies": {
-        "@playwright/test": "1.27.1"
+        "@playwright/test": "1.37.1"
       }
     },
     "packages/artillery-engine-posthog": {
@@ -23828,7 +23823,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.34.3
+FROM mcr.microsoft.com/playwright:v1.37.1
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery artillery-engine-playwright && \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -11,9 +11,9 @@
   "license": "MPL-2.0",
   "dependencies": {
     "debug": "^4.3.2",
-    "playwright": "1.34.3"
+    "playwright": "1.37.1"
   },
   "devDependencies": {
-    "@playwright/test": "1.27.1"
+    "@playwright/test": "1.37.1"
   }
 }


### PR DESCRIPTION
## Context

Updating Playwright version. This will release a canary which can then be used to test and release Fargate.

Release details: https://playwright.dev/docs/release-notes#version-137

## Breaking Changes

Since our previous version (1.34.3), only the following breaking change was released:
- [Playwright Core name change](https://github.com/microsoft/playwright/releases/tag/v1.35.0) - **shouldn't affect us as we don't use this directly**

## Testing

- Tested against all Playwright examples
- Tested against a small script ran against Artillery Cloud