### PR TITLE
ci(test): change to better formatted slack notification github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,21 +28,9 @@ jobs:
           FORCE_COLOR: 1
       - name: Notify about failures
         if: failure() && github.ref == 'refs/heads/main'
-        uses: slackapi/slack-github-action@v1
+        uses: 8398a7/action-slack@v3.15.1
         with:
-          payload: |
-            {
-              "text": "",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Workflow \"${{ github.workflow }}\" failed: https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,eventName,job,took,pullRequest
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Why

This Github Action gives out a lot more information for free, so we don't have to format it all ourselves.

Pinned to a specific version so we can control version increases better, for security, since it's a third party action.