### PR TITLE
fix(examples): artillery cli using data from csv example

### DIFF
--- a/examples/using-data-from-csv/csv/urls.csv
+++ b/examples/using-data-from-csv/csv/urls.csv
@@ -1,4 +1,4 @@
 /
-/docs/
-/pro/
-/contact/
+/dino
+/pony
+/armadillo

--- a/examples/using-data-from-csv/website-test.yml
+++ b/examples/using-data-from-csv/website-test.yml
@@ -1,8 +1,8 @@
 config:
   target: http://asciiart.artillery.io:8080
   phases:
-    - arrivalCount: 40
-      duration: 20
+    - arrivalCount: 300
+      duration: 300
   payload:
     - path: "./csv/urls.csv"
       fields:
@@ -12,7 +12,7 @@ config:
       maxErrorRate: 0
     expect:
       reportFailuresAsErrors: true
-      
+
 scenarios:
   - flow:
       - loop:
@@ -21,4 +21,4 @@ scenarios:
             expect:
               statusCode: 200
         - think: 1
-        count: 5
+        count: 100

--- a/examples/using-data-from-csv/website-test.yml
+++ b/examples/using-data-from-csv/website-test.yml
@@ -1,16 +1,24 @@
 config:
-  target: https://artillery.io
+  target: http://asciiart.artillery.io:8080
   phases:
-    - arrivalCount: 300
-      duration: 300
+    - arrivalCount: 40
+      duration: 20
   payload:
     - path: "./csv/urls.csv"
       fields:
         - url
+  plugins:
+    ensure:
+      maxErrorRate: 0
+    expect:
+      reportFailuresAsErrors: true
+      
 scenarios:
   - flow:
       - loop:
         - get:
             url: "{{ url }}"
+            expect:
+              statusCode: 200
         - think: 1
-        count: 100
+        count: 5


### PR DESCRIPTION
## Why

This example was broken due to redirects from the `https://artillery.io` website:

```
--------------------------------
Summary report @ 14:15:27(+0000)
--------------------------------

errors.ERR_TOO_MANY_REDIRECTS: ................................................. 300
(...)
vusers.created: ................................................................ 300
vusers.failed: ................................................................. 300
```

- Moved it to the asciiart website to keep it more inline with other examples, as it also has 3 paths we can demonstrate the same thing with. 
- Added ensure and expect checks so that this will fail CI if something is wrong, as the example was currently being used in CI, but failing without warning.
