### PR TITLE
ci(examples): make gh action examples report to artillery cloud

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   ARTILLERY_BINARY_PATH: ${{ github.workspace }}/packages/artillery/bin/run
+  CLI_TAGS: repo:${{ github.repository }},actor:${{ github.actor }},type:smoke,owner:artilleryio/dev
 
 jobs:
   http-metrics-by-endpoint:
@@ -28,10 +29,12 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./endpoint-metrics.yml
+          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags $CLI_TAGS
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          CLOUD_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
 
   multiple-scenarios-spec:
     runs-on: ubuntu-latest
@@ -51,7 +54,7 @@ jobs:
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record
+          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags $CLI_TAGS
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -61,7 +64,7 @@ jobs:
       - name: Run dino scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/dino.yml --record
+          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags $CLI_TAGS
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -86,7 +89,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./website-test.yml --record
+          command: run ./website-test.yml --record --tags $CLI_TAGS
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,7 @@ on:
 env:
   ARTILLERY_BINARY_PATH: ${{ github.workspace }}/packages/artillery/bin/run
   CLI_TAGS: repo:${{ github.repository }},actor:${{ github.actor }},type:smoke,owner:artilleryio/dev
+  CLI_NOTE: Running&nbsp;from&nbsp;the&nbsp;Official&nbsp;Artillery&nbsp;Github&nbsp;Action!&nbsp;😀
 
 jobs:
   http-metrics-by-endpoint:
@@ -29,7 +30,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags ${{ env.CLI_TAGS }}
+          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -54,7 +55,7 @@ jobs:
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags ${{ env.CLI_TAGS }}
+          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -64,7 +65,7 @@ jobs:
       - name: Run dino scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags ${{ env.CLI_TAGS }}
+          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -89,7 +90,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./website-test.yml --record --tags ${{ env.CLI_TAGS }}
+          command: run ./website-test.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   ARTILLERY_BINARY_PATH: ${{ github.workspace }}/packages/artillery/bin/run
-  CLI_TAGS: repo:${{ github.repository }},actor:${{ github.actor }},type:smoke,owner:artilleryio/dev
+  CLI_TAGS: repo:${{ github.repository }},actor:${{ github.actor }},type:smoke,ci:true
   CLI_NOTE: Running&nbsp;from&nbsp;the&nbsp;Official&nbsp;Artillery&nbsp;Github&nbsp;Action!&nbsp;😀
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
+          command: run ./endpoint-metrics.yml --record --key ${{ env.CLOUD_KEY }} --tags ${{ env.CLI_TAGS }},group:http-metrics-by-endpoint --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -55,7 +55,7 @@ jobs:
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
+          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags ${{ env.CLI_TAGS }},group:multiple-scenario-specs --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -65,7 +65,7 @@ jobs:
       - name: Run dino scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
+          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags ${{ env.CLI_TAGS }},group:multiple-scenario-specs --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -90,7 +90,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./website-test.yml --record --tags ${{ env.CLI_TAGS }} --note ${{ env.CLI_NOTE }}
+          command: run ./website-test.yml --record --tags ${{ env.CLI_TAGS }},group:using-data-from-csv --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -51,18 +51,22 @@ jobs:
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/armadillo.yml
+          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
 
       - name: Run dino scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/dino.yml
+          command: run --config ./common-config.yml ./scenarios/dino.yml --record
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
 
   using-data-from-csv:
     runs-on: ubuntu-latest
@@ -82,7 +86,9 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./website-test.yml
+          command: run ./website-test.yml --record
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags $CLI_TAGS
+          command: run ./endpoint-metrics.yml --record --key $CLOUD_KEY --tags ${{ env.CLI_TAGS }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -54,7 +54,7 @@ jobs:
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags $CLI_TAGS
+          command: run --config ./common-config.yml ./scenarios/armadillo.yml --record --tags ${{ env.CLI_TAGS }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -64,7 +64,7 @@ jobs:
       - name: Run dino scenario
         uses: artilleryio/action-cli@v1
         with:
-          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags $CLI_TAGS
+          command: run --config ./common-config.yml ./scenarios/dino.yml --record --tags ${{ env.CLI_TAGS }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
@@ -89,7 +89,7 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./website-test.yml --record --tags $CLI_TAGS
+          command: run ./website-test.yml --record --tags ${{ env.CLI_TAGS }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}


### PR DESCRIPTION
## Why

This will serve as a small acceptance test for our Artillery Cloud integration, while also giving us more tests to test against the Dashboard. Win-win.

I added tags and notes so we get a couple of features of the dashboard used in there too.

_Note: the note has markdown space escape character to prevent it from into an issue when sending an initial note with the GH action + workflow combo. We can investigate later if there's something we need to do differently in the GH action to account for this, as it's not the best experience when sending this sort of user input that contains spaces from the Action._