### PR TITLE
feat(schema): use joi schema instead of ts

### DIFF
--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -130,7 +130,7 @@ const ConfigSchema = Joi.object({
     .meta({ title: 'Plugins' })
     .description(
       'List of Artillery plugins to use (official or third-party) and their configuration'
-    ), //TODO: add a few like expect here
+    ),
   engines: Joi.object()
     .meta({ title: 'Engines' })
     .description('Configuration for specific engines used'), //TODO: add config for a few engines like Playwright

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -1,0 +1,178 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+const { ExpectPluginConfigSchema } = require('./plugins/expect');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const HttpDefaultsConfig = Joi.object({
+  headers: Joi.object()
+    .meta({ title: 'Request Headers' })
+    .description(
+      'Default headers to be used in all requests.\nhttps://www.artillery.io/docs/reference/engines/http#default-configuration'
+    ),
+  cookie: Joi.object()
+    .meta({ title: 'Request Cookies' })
+    .description('Default cookies to be used in all requests.'),
+  strictCapture: Joi.alternatives(Joi.boolean(), Joi.string())
+    .meta({ title: 'Strict capture' })
+    .description(
+      'Whether to turn on strict capture by default for all captures.\nhttps://www.artillery.io/docs/reference/engines/http#turn-off-strict-capture'
+    ),
+  think: Joi.object({
+    jitter: artilleryStringNumber
+      .meta('Jitter')
+      .description(
+        'Sets jitter to simulate real-world random variance into think time pauses. Accepts both number and percentage.'
+      )
+  }).meta({ title: 'Think Options' })
+});
+
+const HttpConfig = Joi.object({
+  timeout: artilleryStringNumber
+    .meta({ title: 'Request Timeout' })
+    .description('Increase or decrease request timeout'),
+  maxSockets: artilleryStringNumber
+    .meta({ title: 'Maximum Sockets' })
+    .description(
+      'Maximum amount of TCP connections per virtual user.\nhttps://www.artillery.io/docs/reference/engines/http#max-sockets-per-virtual-user'
+    ),
+  extendedMetrics: Joi.boolean()
+    .meta({ title: 'Enable Extended Metrics' })
+    .description(
+      'Enable tracking of additional HTTP metrics.\nhttps://www.artillery.io/docs/reference/engines/http#additional-performance-metrics'
+    ),
+  defaults: HttpDefaultsConfig.meta({
+    title: 'Configure Default Settings for all requests'
+  })
+});
+
+const WsConfig = Joi.object({
+  subprotocols: Joi.array()
+    .items(Joi.alternatives('json', 'soap', 'wamp'))
+    .meta({ title: 'Websocket sub-protocols' }),
+  headers: Joi.object().meta({ title: 'Headers' }),
+  proxy: Joi.object({
+    url: Joi.string().meta({ title: 'URL' })
+  }).meta({ title: 'Proxy' })
+});
+
+const TlsConfig = Joi.object({
+  rejectUnauthorized: Joi.boolean().meta({
+    title:
+      'Set this setting to `false` to tell Artillery to accept self-signed TLS certificates.'
+  })
+});
+
+const TestPhaseWithArrivals = Joi.object({
+  name: Joi.string().meta({ title: 'Test Phase Name' }),
+  duration: artilleryStringNumber
+    .meta({ title: 'Test Phase Duration' })
+    .description(
+      'Test phase duration (in seconds).\nCan also be any valid human-readable duration: https://www.npmjs.com/package/ms .'
+    ),
+  arrivalRate: artilleryStringNumber
+    .meta({ title: 'Arrival Rate' })
+    .description(
+      'Constant arrival rate.\nThe number of virtual users generated every second.'
+    ),
+  arrivalCount: artilleryStringNumber
+    .meta({ title: 'Arrival Count' })
+    .description(
+      'Fixed number of virtual users over that time period.\nhttps://www.artillery.io/docs/reference/test-script#fixed-number-of-arrivals-per-second'
+    ),
+  rampTo: artilleryStringNumber
+    .meta({ title: 'Ramp up rate' })
+    .description(
+      'Ramp from initial arrivalRate to this value over time period.\nhttps://www.artillery.io/docs/reference/test-script#ramp-up-rate'
+    ),
+  maxVusers: artilleryStringNumber
+    .meta({ title: 'Maximum virtual users' })
+    .description(
+      'Cap the number of concurrent virtual users at any given time.'
+    )
+});
+
+const TestPhaseWithPause = Joi.object({
+  name: Joi.string().meta({ title: 'Test Phase Name' }),
+  pause: artilleryStringNumber
+    .meta({ title: 'Pause' })
+    .description(
+      'Pause the test phase execution for given duration (in seconds).\nCan also be any valid human-readable duration: https://www.npmjs.com/package/ms.'
+    )
+});
+
+const TestPhase = Joi.alternatives(
+  TestPhaseWithArrivals,
+  TestPhaseWithPause
+).meta({ title: 'Test Phase' });
+
+//TODO: review this one
+const PayloadConfig = Joi.object({
+  path: Joi.string(),
+  fields: Joi.array().items(Joi.string()),
+  random: Joi.alternatives('random', 'sequence'),
+  skipHeader: Joi.boolean(),
+  delimiter: Joi.string(),
+  cast: Joi.boolean(),
+  skipEmptyLines: Joi.boolean()
+});
+
+const ReplaceableConfig = {
+  target: Joi.string()
+    .meta({ title: 'Target' })
+    .description(
+      'Endpoint of the system under test, such as a hostname, IP address or a URI.\nhttps://www.artillery.io/docs/reference/test-script#target---target-service'
+    )
+    .example('https://example.com')
+    .example('ws://127.0.0.1'),
+  phases: Joi.array()
+    .items(TestPhase)
+    .meta({ title: 'Phases' })
+    .description(
+      'A load phase defines how Artillery generates new virtual users (VUs) in a specified time period.\nhttps://www.artillery.io/docs/reference/test-script#phases---load-phases'
+    )
+};
+
+const ArtilleryBuiltInPlugins = {
+  expect: ExpectPluginConfigSchema
+};
+
+const ConfigSchema = Joi.object({
+  ...ReplaceableConfig,
+  http: HttpConfig.meta({ title: 'HTTP Configuration' }),
+  ws: WsConfig.meta({ title: 'Websocket Configuration' }),
+  environments: Joi.object()
+    // .rename(/\w\d/, 'something')
+    // .pattern(/\w\d/, Joi.object(ReplaceableConfig))//TODO: this isn't working well. Probably a limitation of https://github.com/kenspirit/joi-to-json#known-limitation. Find alternative?
+    .meta({ title: 'Environments' })
+    .description(
+      'Define environments to run your load test against different configs:\nhttps://www.artillery.io/docs/reference/test-script#environments---config-profiles'
+    ), //TODO: type this properly
+
+  processor: Joi.string()
+    .meta({ title: 'Processor Function Path' })
+    .description('Path to a CommonJS module to load for this test run.'),
+  variables: Joi.object()
+    .meta({ title: 'Variables' })
+    .description('Map of variables to expose to the test run.'),
+  payload: Joi.alternatives(PayloadConfig, Joi.array().items(PayloadConfig))
+    .meta({ title: 'CSV Payload' })
+    .description(
+      'Load data from CSV to be used during the test run:\nhttps://www.artillery.io/docs/reference/test-script#payload---loading-data-from-csv-files'
+    ),
+  tls: TlsConfig.meta({ title: 'TLS Settings' }),
+  plugins: Joi.object({ ...ArtilleryBuiltInPlugins })
+    .meta({ title: 'Plugins' })
+    .description(
+      'List of Artillery plugins to use (official or third-party) and their configuration'
+    ), //TODO: add a few like expect here
+  engines: Joi.object()
+    .meta({ title: 'Engines' })
+    .description('Configuration for specific engines used'), //TODO: add config for a few engines like Playwright
+  ...ArtilleryBuiltInPlugins
+});
+
+module.exports = {
+  ConfigSchema
+};

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -3,6 +3,7 @@ const Joi = require('joi').defaults((schema) =>
 );
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
 const { EnsurePluginConfigSchema } = require('./plugins/ensure');
+const { ApdexPluginConfigSchema } = require('./plugins/apdex');
 
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
@@ -137,7 +138,8 @@ const ReplaceableConfig = {
 
 const ArtilleryBuiltInPlugins = {
   expect: ExpectPluginConfigSchema,
-  ensure: EnsurePluginConfigSchema
+  ensure: EnsurePluginConfigSchema,
+  apdex: ApdexPluginConfigSchema
 };
 
 const ConfigSchema = Joi.object({

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -3,6 +3,7 @@ const Joi = require('joi').defaults((schema) =>
 );
 const { HttpConfigSchema } = require('./engines/http');
 const { WsConfigSchema } = require('./engines/websocket');
+const { SocketIoConfigSchema } = require('./engines/socketio');
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
 const { EnsurePluginConfigSchema } = require('./plugins/ensure');
 const { ApdexPluginConfigSchema } = require('./plugins/apdex');
@@ -104,6 +105,7 @@ const ConfigSchema = Joi.object({
   ...ReplaceableConfig,
   http: HttpConfigSchema.meta({ title: 'HTTP Configuration' }),
   ws: WsConfigSchema.meta({ title: 'Websocket Configuration' }),
+  socketio: SocketIoConfigSchema.meta({ title: 'SocketIo Configuration' }),
   environments: Joi.object()
     // .rename(/\w\d/, 'something')
     // .pattern(/\w\d/, Joi.object(ReplaceableConfig))//TODO: this isn't working well. Probably a limitation of https://github.com/kenspirit/joi-to-json#known-limitation. Find alternative?

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -4,6 +4,9 @@ const Joi = require('joi').defaults((schema) =>
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
 const { EnsurePluginConfigSchema } = require('./plugins/ensure');
 const { ApdexPluginConfigSchema } = require('./plugins/apdex');
+const {
+  MetricsByEndpointPluginConfigSchema
+} = require('./plugins/metrics-by-endpoint');
 
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
@@ -139,7 +142,8 @@ const ReplaceableConfig = {
 const ArtilleryBuiltInPlugins = {
   expect: ExpectPluginConfigSchema,
   ensure: EnsurePluginConfigSchema,
-  apdex: ApdexPluginConfigSchema
+  apdex: ApdexPluginConfigSchema,
+  'metrics-by-endpoint': MetricsByEndpointPluginConfigSchema
 };
 
 const ConfigSchema = Joi.object({

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -1,6 +1,8 @@
 const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
+const { HttpConfigSchema } = require('./engines/http');
+const { WsConfigSchema } = require('./engines/websocket');
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
 const { EnsurePluginConfigSchema } = require('./plugins/ensure');
 const { ApdexPluginConfigSchema } = require('./plugins/apdex');
@@ -12,58 +14,6 @@ const {
 } = require('./plugins/publish-metrics');
 
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
-
-const HttpDefaultsConfig = Joi.object({
-  headers: Joi.object()
-    .meta({ title: 'Request Headers' })
-    .description(
-      'Default headers to be used in all requests.\nhttps://www.artillery.io/docs/reference/engines/http#default-configuration'
-    ),
-  cookie: Joi.object()
-    .meta({ title: 'Request Cookies' })
-    .description('Default cookies to be used in all requests.'),
-  strictCapture: Joi.alternatives(Joi.boolean(), Joi.string())
-    .meta({ title: 'Strict capture' })
-    .description(
-      'Whether to turn on strict capture by default for all captures.\nhttps://www.artillery.io/docs/reference/engines/http#turn-off-strict-capture'
-    ),
-  think: Joi.object({
-    jitter: artilleryStringNumber
-      .meta('Jitter')
-      .description(
-        'Sets jitter to simulate real-world random variance into think time pauses. Accepts both number and percentage.'
-      )
-  }).meta({ title: 'Think Options' })
-});
-
-const HttpConfig = Joi.object({
-  timeout: artilleryStringNumber
-    .meta({ title: 'Request Timeout' })
-    .description('Increase or decrease request timeout'),
-  maxSockets: artilleryStringNumber
-    .meta({ title: 'Maximum Sockets' })
-    .description(
-      'Maximum amount of TCP connections per virtual user.\nhttps://www.artillery.io/docs/reference/engines/http#max-sockets-per-virtual-user'
-    ),
-  extendedMetrics: Joi.boolean()
-    .meta({ title: 'Enable Extended Metrics' })
-    .description(
-      'Enable tracking of additional HTTP metrics.\nhttps://www.artillery.io/docs/reference/engines/http#additional-performance-metrics'
-    ),
-  defaults: HttpDefaultsConfig.meta({
-    title: 'Configure Default Settings for all requests'
-  })
-});
-
-const WsConfig = Joi.object({
-  subprotocols: Joi.array()
-    .items(Joi.alternatives('json', 'soap', 'wamp'))
-    .meta({ title: 'Websocket sub-protocols' }),
-  headers: Joi.object().meta({ title: 'Headers' }),
-  proxy: Joi.object({
-    url: Joi.string().meta({ title: 'URL' })
-  }).meta({ title: 'Proxy' })
-});
 
 const TlsConfig = Joi.object({
   rejectUnauthorized: Joi.boolean().meta({
@@ -152,8 +102,8 @@ const ArtilleryBuiltInPlugins = {
 
 const ConfigSchema = Joi.object({
   ...ReplaceableConfig,
-  http: HttpConfig.meta({ title: 'HTTP Configuration' }),
-  ws: WsConfig.meta({ title: 'Websocket Configuration' }),
+  http: HttpConfigSchema.meta({ title: 'HTTP Configuration' }),
+  ws: WsConfigSchema.meta({ title: 'Websocket Configuration' }),
   environments: Joi.object()
     // .rename(/\w\d/, 'something')
     // .pattern(/\w\d/, Joi.object(ReplaceableConfig))//TODO: this isn't working well. Probably a limitation of https://github.com/kenspirit/joi-to-json#known-limitation. Find alternative?

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -4,6 +4,7 @@ const Joi = require('joi').defaults((schema) =>
 const { HttpConfigSchema } = require('./engines/http');
 const { WsConfigSchema } = require('./engines/websocket');
 const { SocketIoConfigSchema } = require('./engines/socketio');
+const { PlaywrightConfigSchema } = require('./engines/playwright');
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
 const { EnsurePluginConfigSchema } = require('./plugins/ensure');
 const { ApdexPluginConfigSchema } = require('./plugins/apdex');
@@ -131,7 +132,9 @@ const ConfigSchema = Joi.object({
     .description(
       'List of Artillery plugins to use (official or third-party) and their configuration'
     ),
-  engines: Joi.object()
+  engines: Joi.object({
+    playwright: PlaywrightConfigSchema
+  })
     .meta({ title: 'Engines' })
     .description('Configuration for specific engines used'), //TODO: add config for a few engines like Playwright
   ...ArtilleryBuiltInPlugins

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -2,6 +2,7 @@ const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
 const { ExpectPluginConfigSchema } = require('./plugins/expect');
+const { EnsurePluginConfigSchema } = require('./plugins/ensure');
 
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
@@ -135,7 +136,8 @@ const ReplaceableConfig = {
 };
 
 const ArtilleryBuiltInPlugins = {
-  expect: ExpectPluginConfigSchema
+  expect: ExpectPluginConfigSchema,
+  ensure: EnsurePluginConfigSchema
 };
 
 const ConfigSchema = Joi.object({

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -7,6 +7,9 @@ const { ApdexPluginConfigSchema } = require('./plugins/apdex');
 const {
   MetricsByEndpointPluginConfigSchema
 } = require('./plugins/metrics-by-endpoint');
+const {
+  PublishMetricsPluginConfigSchema
+} = require('./plugins/publish-metrics');
 
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
@@ -143,7 +146,8 @@ const ArtilleryBuiltInPlugins = {
   expect: ExpectPluginConfigSchema,
   ensure: EnsurePluginConfigSchema,
   apdex: ApdexPluginConfigSchema,
-  'metrics-by-endpoint': MetricsByEndpointPluginConfigSchema
+  'metrics-by-endpoint': MetricsByEndpointPluginConfigSchema,
+  'publish-metrics': PublishMetricsPluginConfigSchema
 };
 
 const ConfigSchema = Joi.object({

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -1,0 +1,104 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+const { ExpectPluginImplementationSchema } = require('../plugins/expect');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const BaseFlowItemAlternatives = [
+  Joi.object({ function: Joi.string() }),
+  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
+    title: 'Logging'
+  }),
+  Joi.object({ think: artilleryStringNumber })
+];
+
+//TODO: add request with body properties
+const HttpMethodProperties = Joi.object({
+  url: Joi.string().required(),
+  headers: Joi.object(),
+  cookie: Joi.object(), //TODO: make them strings only,
+  followRedirect: Joi.boolean(),
+  qs: Joi.object(),
+  gzip: Joi.boolean(),
+  capture: Joi.object(), //TODO: add capture here
+  auth: Joi.object({
+    user: Joi.string(),
+    pass: Joi.string()
+  }),
+  beforeRequest: Joi.alternatives(
+    Joi.string(),
+    Joi.array().items(Joi.string())
+  ), //TODO: this is likely different on a resolved config
+  afterResponse: Joi.alternatives(
+    Joi.string(),
+    Joi.array().items(Joi.string())
+  ), //TODO: this is likely different on a resolved config
+  ifTrue: Joi.string(),
+  //match TODO: add match here (deprecated)
+  expect: Joi.alternatives(
+    ExpectPluginImplementationSchema,
+    Joi.array().items(ExpectPluginImplementationSchema)
+  )
+});
+
+const BaseWithHttp = [
+  ...BaseFlowItemAlternatives,
+  Joi.object({
+    get: HttpMethodProperties.description('hi there still me').meta({
+      title: 'GET REQUEST'
+    })
+  }),
+  Joi.object({ post: HttpMethodProperties }), //TODO: add body options
+  Joi.object({ put: HttpMethodProperties }),
+  Joi.object({ patch: HttpMethodProperties }),
+  Joi.object({ delete: HttpMethodProperties }) //TODO: do we need head and options methods?
+];
+
+const HttpFlowItemSchema = Joi.alternatives()
+  .try(
+    ...BaseWithHttp,
+    // ...BaseFlowItemAlternatives,
+    // Joi.object({get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"})}),
+    // Joi.object({post: HttpMethodProperties}),//TODO: add body options
+    // Joi.object({put: HttpMethodProperties}),
+    // Joi.object({patch: HttpMethodProperties}),
+    // Joi.object({delete: HttpMethodProperties}),//TODO: do we need head and options methods?
+    Joi.object({
+      loop: Joi.array()
+        .items(
+          Joi.alternatives()
+            .try(
+              // Joi.link('#HttpFlowItemSchema')
+              ...BaseWithHttp
+            )
+            .match('all')
+            .required()
+        )
+        .meta({ title: 'Loop (Http)' }),
+      whileTrue: Joi.string(),
+      count: Joi.alternatives(Joi.string(), Joi.number()),
+      over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    })
+  )
+  .match('all')
+  .id('HttpFlowItemSchema');
+
+// const HttpFlowItemSchema2 = Joi.object({
+//     function: Joi.string(),
+//     think: Joi.alternatives(Joi.number(), Joi.string()),
+//     log: Joi.string().meta({title: "Logging"}),
+//     get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"}),
+//     post: HttpMethodProperties
+// })
+
+// const HttpLoopSchema = Joi.object({
+//     loop: Joi.array().items(HttpFlowItemSchema).meta({title: "Http Loop"}),
+//     whileTrue: Joi.string(),
+//     count: Joi.alternatives(Joi.string(), Joi.boolean()),
+//     over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+// })
+
+module.exports = {
+  HttpFlowItemSchema
+};

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -6,53 +6,86 @@ const { ExpectPluginImplementationSchema } = require('../plugins/expect');
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
 const BaseFlowItemAlternatives = [
-  Joi.object({ function: Joi.string() }),
-  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
-    title: 'Logging'
+  Joi.object({
+    function: Joi.string()
+      .meta({ title: 'Function' })
+      .description('Function name to run.')
   }),
-  Joi.object({ think: artilleryStringNumber })
+  Joi.object({
+    log: Joi.string()
+      .meta({ title: 'Log' })
+      .description('Print given message to the console.')
+  }),
+  Joi.object({
+    think: artilleryStringNumber
+      .meta({ title: 'Think time' })
+      .description('Pause virtual user for the given duration (in seconds).')
+  })
 ];
 
 //TODO: add request with body properties
 const HttpMethodProperties = Joi.object({
-  url: Joi.string().required(),
-  headers: Joi.object(),
-  cookie: Joi.object(), //TODO: make them strings only,
-  followRedirect: Joi.boolean(),
-  qs: Joi.object(),
-  gzip: Joi.boolean(),
-  capture: Joi.alternatives(Joi.object(), Joi.array().items(Joi.object())), //TODO: add capture here
+  url: Joi.string().required().meta({ title: 'URL' }),
+  headers: Joi.object().meta({ title: 'Headers' }),
+  cookie: Joi.object() //TODO: maybe make this a [name: string]: string
+    .meta({ title: 'Cookies' }), //TODO: make them strings only,
+  followRedirect: Joi.boolean()
+    .meta({ title: 'Disable redirect following' })
+    .description(
+      'Artillery follows redirects by default.\nSet this option to `false` to stop following redirects.'
+    ),
+  qs: Joi.object().meta({ title: 'Query string object' }),
+  gzip: Joi.boolean()
+    .meta({ title: 'Compression' })
+    .description(
+      "Automatically set the 'Accept-Encoding' request header and decode compressed responses encoded with gzip."
+    ),
+  capture: Joi.alternatives(Joi.object(), Joi.array().items(Joi.object()))
+    .meta({ title: 'Capture' })
+    .description(
+      'Capture and reuse parts of a response\nhttps://www.artillery.io/docs/reference/engines/http#extracting-and-re-using-parts-of-a-response-request-chaining'
+    ), //TODO: add capture here
   auth: Joi.object({
-    user: Joi.string(),
-    pass: Joi.string()
-  }),
-  beforeRequest: Joi.alternatives(
-    Joi.string(),
-    Joi.array().items(Joi.string())
-  ), //TODO: this is likely different on a resolved config
-  afterResponse: Joi.alternatives(
-    Joi.string(),
-    Joi.array().items(Joi.string())
-  ), //TODO: this is likely different on a resolved config
-  ifTrue: Joi.string(),
-  //match TODO: add match here (deprecated)
+    user: Joi.string().meta({ title: 'Username' }),
+    pass: Joi.string().meta({ title: 'Password' })
+  }).meta({ title: 'Basic authentication' }),
+  beforeRequest: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    .meta({ title: 'Before Request' })
+    .description('Functions to run before every request is sent.'), //TODO: this is likely different on a resolved config
+  afterResponse: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    .meta({ title: 'After Response' })
+    .description('Functions to run after every response is received.'), //TODO: this is likely different on a resolved config
+  ifTrue: Joi.string()
+    .meta({ title: 'Request Condition' })
+    .description('Expression that controls when to execute this request.'),
+  //TODO: add match here (deprecated)
   expect: Joi.alternatives(
     ExpectPluginImplementationSchema,
     Joi.array().items(ExpectPluginImplementationSchema)
   )
+    .meta({ title: 'Expect plugin expectations' })
+    .description(
+      'More information: https://www.artillery.io/docs/reference/extensions/expect#expectations'
+    )
 });
 
 const BaseWithHttp = [
   ...BaseFlowItemAlternatives,
   Joi.object({
-    get: HttpMethodProperties.description('hi there still me').meta({
-      title: 'GET REQUEST'
-    })
+    get: HttpMethodProperties.meta({ title: 'Perform a GET request' })
   }),
-  Joi.object({ post: HttpMethodProperties }), //TODO: add body options
-  Joi.object({ put: HttpMethodProperties }),
-  Joi.object({ patch: HttpMethodProperties }),
-  Joi.object({ delete: HttpMethodProperties }) //TODO: do we need head and options methods?
+  Joi.object({
+    post: HttpMethodProperties.meta({ title: 'Perform a POST request' })
+  }), //TODO: add body options
+  Joi.object({
+    put: HttpMethodProperties.meta({ title: 'Perform a PUT request' })
+  }),
+  Joi.object({
+    patch: HttpMethodProperties.meta({ title: 'Perform a PATCH request' })
+  }),
+  Joi.object({
+    delete: HttpMethodProperties.meta({ title: 'Perform a DELETE request' })
+  }) //TODO: do we need head and options methods?
 ];
 
 const HttpFlowItemSchema = Joi.alternatives()

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -99,6 +99,49 @@ const HttpFlowItemSchema = Joi.alternatives()
 //     over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
 // })
 
+const HttpDefaultsConfigSchema = Joi.object({
+  headers: Joi.object()
+    .meta({ title: 'Request Headers' })
+    .description(
+      'Default headers to be used in all requests.\nhttps://www.artillery.io/docs/reference/engines/http#default-configuration'
+    ),
+  cookie: Joi.object()
+    .meta({ title: 'Request Cookies' })
+    .description('Default cookies to be used in all requests.'),
+  strictCapture: Joi.alternatives(Joi.boolean(), Joi.string())
+    .meta({ title: 'Strict capture' })
+    .description(
+      'Whether to turn on strict capture by default for all captures.\nhttps://www.artillery.io/docs/reference/engines/http#turn-off-strict-capture'
+    ),
+  think: Joi.object({
+    jitter: artilleryStringNumber
+      .meta('Jitter')
+      .description(
+        'Sets jitter to simulate real-world random variance into think time pauses. Accepts both number and percentage.'
+      )
+  }).meta({ title: 'Think Options' })
+});
+
+const HttpConfigSchema = Joi.object({
+  timeout: artilleryStringNumber
+    .meta({ title: 'Request Timeout' })
+    .description('Increase or decrease request timeout'),
+  maxSockets: artilleryStringNumber
+    .meta({ title: 'Maximum Sockets' })
+    .description(
+      'Maximum amount of TCP connections per virtual user.\nhttps://www.artillery.io/docs/reference/engines/http#max-sockets-per-virtual-user'
+    ),
+  extendedMetrics: Joi.boolean()
+    .meta({ title: 'Enable Extended Metrics' })
+    .description(
+      'Enable tracking of additional HTTP metrics.\nhttps://www.artillery.io/docs/reference/engines/http#additional-performance-metrics'
+    ),
+  defaults: HttpDefaultsConfigSchema.meta({
+    title: 'Configure Default Settings for all requests'
+  })
+});
+
 module.exports = {
-  HttpFlowItemSchema
+  HttpFlowItemSchema,
+  HttpConfigSchema
 };

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -21,7 +21,7 @@ const HttpMethodProperties = Joi.object({
   followRedirect: Joi.boolean(),
   qs: Joi.object(),
   gzip: Joi.boolean(),
-  capture: Joi.object(), //TODO: add capture here
+  capture: Joi.alternatives(Joi.object(), Joi.array().items(Joi.object())), //TODO: add capture here
   auth: Joi.object({
     user: Joi.string(),
     pass: Joi.string()

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -143,5 +143,6 @@ const HttpConfigSchema = Joi.object({
 
 module.exports = {
   HttpFlowItemSchema,
+  BaseWithHttp,
   HttpConfigSchema
 };

--- a/packages/types/schema/engines/playwright.js
+++ b/packages/types/schema/engines/playwright.js
@@ -1,0 +1,23 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const PlaywrightSchemaObject = {
+  testFunction: Joi.string(),
+  flowFunction: Joi.string()
+};
+
+const PlaywrightConfigSchema = Joi.object({
+  aggregateByName: Joi.alternatives(Joi.boolean(), Joi.string()),
+  defaultTimeout: artilleryStringNumber,
+  defaultNavigationTimeout: artilleryStringNumber,
+  launchOptions: Joi.object(),
+  contextOptions: Joi.object()
+});
+
+module.exports = {
+  PlaywrightSchemaObject,
+  PlaywrightConfigSchema
+};

--- a/packages/types/schema/engines/playwright.js
+++ b/packages/types/schema/engines/playwright.js
@@ -5,16 +5,40 @@ const Joi = require('joi').defaults((schema) =>
 const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
 
 const PlaywrightSchemaObject = {
-  testFunction: Joi.string(),
+  testFunction: Joi.string()
+    .meta({ title: 'Test function' })
+    .description('Equivalent to flowFunction.'),
   flowFunction: Joi.string()
+    .meta({ title: 'Flow function' })
+    .description('Equivalent to testFunction.')
 };
 
 const PlaywrightConfigSchema = Joi.object({
-  aggregateByName: Joi.alternatives(Joi.boolean(), Joi.string()),
-  defaultTimeout: artilleryStringNumber,
-  defaultNavigationTimeout: artilleryStringNumber,
-  launchOptions: Joi.object(),
+  aggregateByName: Joi.alternatives(Joi.boolean(), Joi.string())
+    .meta({ title: 'Aggregate by name' })
+    .description(
+      'Aggregate Artillery metrics by test scenario name.\nhttps://www.artillery.io/docs/reference/engines/playwright#aggregate-metrics-by-scenario-name'
+    ),
+  defaultTimeout: artilleryStringNumber
+    .meta({ title: 'Default timeout' })
+    .description(
+      'Default maximum time (in seconds) for all Playwright methods accepting the `timeout` option.\nhttps://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout'
+    ),
+  defaultNavigationTimeout: artilleryStringNumber
+    .meta({ title: 'Default navigation timeout' })
+    .description(
+      'Default maximum navigation time (in seconds) for Playwright navigation methods, like `page.goto()`.\nhttps://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout'
+    ),
+  launchOptions: Joi.object()
+    .meta({ title: 'Playwright launch options' })
+    .description(
+      'Arguments for the `browser.launch()` call in Playwright.\nhttps://playwright.dev/docs/api/class-browsertype#browser-type-launch'
+    ),
   contextOptions: Joi.object()
+    .meta({ title: 'Playwright context options' })
+    .description(
+      'Arguments for the `browser.newContext()` call in Playwright.\nhttps://playwright.dev/docs/api/class-browser#browser-new-context'
+    )
 });
 
 module.exports = {

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -29,7 +29,10 @@ const BaseWithSocketio = [
       }),
       acknowledge: Joi.object({
         data: Joi.string(),
-        match: Joi.string()
+        match: Joi.object({
+          json: Joi.any(),
+          value: Joi.string()
+        })
       })
     })
   })

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -1,0 +1,68 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+
+const { BaseWithHttp } = require('./http');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const BaseFlowItemAlternatives = [
+  Joi.object({ function: Joi.string() }),
+  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
+    title: 'Logging'
+  }),
+  Joi.object({ think: artilleryStringNumber })
+];
+
+const BaseWithSocketio = [
+  // ...BaseFlowItemAlternatives,
+  ...BaseWithHttp,
+  //TODO: review this schema.
+  Joi.object({
+    emit: Joi.object({
+      channel: Joi.string(),
+      data: Joi.string(),
+      namespace: Joi.string(),
+      response: Joi.object({
+        channel: Joi.string(),
+        data: Joi.string()
+      }),
+      acknowledge: Joi.object({
+        data: Joi.string(),
+        match: Joi.string()
+      })
+    })
+  })
+];
+
+const SocketIoFlowItemSchema = Joi.alternatives()
+  .try(
+    ...BaseWithSocketio,
+    Joi.object({
+      loop: Joi.array()
+        .items(
+          Joi.alternatives()
+            .try(...BaseWithSocketio)
+            .match('all')
+            .required()
+        )
+        .meta({ title: 'Loop (SocketIo)' }),
+      whileTrue: Joi.string(),
+      count: artilleryStringNumber,
+      over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    })
+  )
+  .match('all')
+  .id('SocketIoFlowItemSchema');
+
+const SocketIoConfigSchema = Joi.object({
+  query: Joi.alternatives(Joi.string(), Joi.object()),
+  path: Joi.string(),
+  extraHeaders: Joi.object(),
+  transports: Joi.array().items(Joi.string().valid('websocket')).single() //TODO: review how to make this autofill with the only option
+});
+
+module.exports = {
+  SocketIoFlowItemSchema,
+  SocketIoConfigSchema
+};

--- a/packages/types/schema/engines/websocket.js
+++ b/packages/types/schema/engines/websocket.js
@@ -53,6 +53,18 @@ const WsFlowItemSchema = Joi.alternatives()
   .match('all')
   .id('WsFlowItemSchema');
 
+//TODO: add info here that you can configure underlying ws client
+const WsConfigSchema = Joi.object({
+  subprotocols: Joi.array()
+    .items(Joi.string().valid('json', 'soap', 'wamp', 'xmpp'))
+    .meta({ title: 'Websocket sub-protocols' }),
+  headers: Joi.object().meta({ title: 'Headers' }),
+  proxy: Joi.object({
+    url: Joi.string().required().meta({ title: 'URL' })
+  }).meta({ title: 'Proxy' })
+});
+
 module.exports = {
-  WsFlowItemSchema
+  WsFlowItemSchema,
+  WsConfigSchema
 };

--- a/packages/types/schema/engines/websocket.js
+++ b/packages/types/schema/engines/websocket.js
@@ -1,0 +1,58 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const BaseFlowItemAlternatives = [
+  Joi.object({ function: Joi.string() }),
+  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
+    title: 'Logging'
+  }),
+  Joi.object({ think: artilleryStringNumber })
+];
+
+const BaseWithWs = [
+  ...BaseFlowItemAlternatives,
+  Joi.object({
+    send: Joi.alternatives(Joi.string(), Joi.object())
+  }),
+  Joi.object({
+    connect: Joi.alternatives(
+      Joi.string(),
+      Joi.object({
+        function: Joi.string()
+      }),
+      Joi.object({
+        target: Joi.string(),
+        proxy: Joi.object({
+          url: Joi.string()
+        })
+      })
+    )
+  })
+];
+
+const WsFlowItemSchema = Joi.alternatives()
+  .try(
+    ...BaseWithWs,
+    Joi.object({
+      loop: Joi.array()
+        .items(
+          Joi.alternatives()
+            .try(...BaseWithWs)
+            .match('all')
+            .required()
+        )
+        .meta({ title: 'Loop (Websocket)' }),
+      whileTrue: Joi.string(),
+      count: Joi.alternatives(Joi.string(), Joi.number()),
+      over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    })
+  )
+  .match('all')
+  .id('WsFlowItemSchema');
+
+module.exports = {
+  WsFlowItemSchema
+};

--- a/packages/types/schema/index.js
+++ b/packages/types/schema/index.js
@@ -7,7 +7,7 @@ const Joi = require('joi').defaults((schema) =>
 
 const schema = Joi.object({
   config: ConfigSchema,
-  scenarios: Joi.array().items(ScenarioSchema).required()
+  scenarios: Joi.array().items(ScenarioSchema).required() //TODO make this optional?
   // before: ScenarioSchema
 });
 

--- a/packages/types/schema/index.js
+++ b/packages/types/schema/index.js
@@ -1,0 +1,16 @@
+const { ConfigSchema } = require('./config');
+const { ScenarioSchema } = require('./scenario');
+
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+
+const schema = Joi.object({
+  config: ConfigSchema,
+  scenarios: Joi.array().items(ScenarioSchema).required()
+  // before: ScenarioSchema
+});
+
+module.exports = {
+  schema
+};

--- a/packages/types/schema/plugins/apdex.js
+++ b/packages/types/schema/plugins/apdex.js
@@ -1,0 +1,11 @@
+const Joi = require('joi');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const ApdexPluginConfigSchema = Joi.object({
+  threshold: artilleryStringNumber
+}).unknown(false);
+
+module.exports = {
+  ApdexPluginConfigSchema
+};

--- a/packages/types/schema/plugins/ensure.js
+++ b/packages/types/schema/plugins/ensure.js
@@ -11,13 +11,13 @@ const EnsureLegacyOptions = {
 };
 
 const EnsurePluginConfigSchema = Joi.object({
-  thresholds: Joi.array().items(Joi.object()),
+  thresholds: Joi.array().items(Joi.object()), //TODO: this is typed wrong
   conditions: Joi.array().items(
     Joi.object({
       expression: Joi.string(),
       strict: Joi.boolean()
     })
-  ),
+  ), //TODO: check that conditions are typed right
   ...EnsureLegacyOptions
 }).unknown(false);
 

--- a/packages/types/schema/plugins/ensure.js
+++ b/packages/types/schema/plugins/ensure.js
@@ -1,0 +1,26 @@
+const Joi = require('joi');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+const EnsureLegacyOptions = {
+  min: artilleryStringNumber,
+  max: artilleryStringNumber,
+  median: artilleryStringNumber,
+  p95: artilleryStringNumber,
+  p99: artilleryStringNumber,
+  maxErrorRate: artilleryStringNumber
+};
+
+const EnsurePluginConfigSchema = Joi.object({
+  thresholds: Joi.array().items(Joi.object()),
+  conditions: Joi.array().items(
+    Joi.object({
+      expression: Joi.string(),
+      strict: Joi.boolean()
+    })
+  ),
+  ...EnsureLegacyOptions
+}).unknown(false);
+
+module.exports = {
+  EnsurePluginConfigSchema
+};

--- a/packages/types/schema/plugins/expect.js
+++ b/packages/types/schema/plugins/expect.js
@@ -1,0 +1,88 @@
+// const Joi = require('joi').defaults((schema) =>
+//   schema.options({ allowUnknown: true, abortEarly: true })
+// );
+
+const Joi = require('joi');
+
+const ExpectPluginConfigSchema = Joi.object({
+  outputFormat: Joi.string()
+    .valid('pretty', 'json', 'prettyError', 'silent')
+    .meta({ title: 'Output Format' }),
+  formatter: Joi.string()
+    .valid('pretty', 'json', 'prettyError', 'silent')
+    .meta({ title: '(Deprecated) Formatter' }) //TODO: add deprecated status
+    .description('Please use the `outputFormat` option instead.'),
+  reportFailuresAsErrors: Joi.boolean()
+    .meta({ title: 'Report Failures as Errors' })
+    .description(
+      'Reports failures from expect plugin as errors in Artillery Report'
+    ), //TODO: add default value
+  useOnlyRequestNames: Joi.boolean()
+    .meta({ title: 'Use Only Request Names' })
+    .description(
+      'Use request name instead of the URL path when logging requests in console and report'
+    ),
+  expectDefault200: Joi.boolean()
+    .meta({ title: 'Expect 200 by default' })
+    .description('Sets a 200 OK status code expectation for all requests.') //TODO: add default value
+}).unknown(false);
+
+const ExpectPluginImplementationSchema = {
+  statusCode: Joi.alternatives(Joi.number(), Joi.array().items(Joi.number()))
+    .meta({ title: 'Expectation: Status Code' })
+    .description(
+      'Check the response status code.\nIf a list of status codes is provided, check that the response status code is present in the list.\nhttps://www.artillery.io/docs/reference/extensions/expect#statuscode'
+    ),
+  notStatusCode: Joi.alternatives(Joi.number(), Joi.array().items(Joi.number()))
+    .meta({ title: 'Expectation: Not Status Code' })
+    .description(
+      'Check the response status code does not equal given status code.\nIf a list of status codes is provided, check that the response status code is not present in the list.\nhttps://www.artillery.io/docs/reference/extensions/expect#notstatuscode'
+    ),
+  contentType: Joi.string()
+    .meta({ title: 'Expectation: Content type' })
+    .description(
+      'Check that the value of the `Content-Type` response header.\nhttps://www.artillery.io/docs/reference/extensions/expect#contenttype'
+    ),
+  hasProperty: Joi.string()
+    .meta({ title: 'Expectation: Has Property' })
+    .description(
+      'Check that the response object has the given property.\nhttps://www.artillery.io/docs/reference/extensions/expect#hasproperty-and-nothasproperty'
+    ),
+  notHasProperty: Joi.string()
+    .meta({ title: 'Expectation: Not Has Property' })
+    .description(
+      "Check that the response object doesn't have the given property.\nhttps://www.artillery.io/docs/reference/extensions/expect#hasproperty-and-nothasproperty"
+    ),
+  equals: Joi.array()
+    .items(Joi.string())
+    .meta({ title: 'Expectation: Equals' })
+    .description(
+      'Check that two or more values are the same.\nhttps://www.artillery.io/docs/reference/extensions/expect#hasheader'
+    ),
+  hasHeader: Joi.string()
+    .meta({ title: 'Expectation: Has Header' })
+    .description(
+      'Check that the response contains the given header.\nhttps://www.artillery.io/docs/reference/extensions/expect#hasheader'
+    ),
+  headerEquals: Joi.array()
+    .items(Joi.string())
+    .meta({ title: 'Expectation: Header Equals' })
+    .description(
+      'Check that the response contains a header and its value matches is present in the list.\nhttps://www.artillery.io/docs/reference/extensions/expect#headerequals'
+    ),
+  matchesRegexp: Joi.string()
+    .meta({ title: 'Expectation: Matches Regular Expression' })
+    .description(
+      'Check that the response matches a regular expression.\nhttps://www.artillery.io/docs/reference/extensions/expect#matchesregexp'
+    ),
+  cdnHit: Joi.boolean()
+    .meta({ title: 'Expectation: Is CDN Hit' })
+    .description(
+      'Check the presence of a cache hit/miss header from a CDN.\nhttps://www.artillery.io/docs/reference/extensions/expect#cdnhit'
+    )
+};
+
+module.exports = {
+  ExpectPluginConfigSchema,
+  ExpectPluginImplementationSchema
+};

--- a/packages/types/schema/plugins/expect.js
+++ b/packages/types/schema/plugins/expect.js
@@ -28,12 +28,20 @@ const ExpectPluginConfigSchema = Joi.object({
 }).unknown(false);
 
 const ExpectPluginImplementationSchema = {
-  statusCode: Joi.alternatives(Joi.number(), Joi.array().items(Joi.number()))
+  statusCode: Joi.alternatives(
+    Joi.number(),
+    Joi.string(),
+    Joi.array().items(Joi.alternatives(Joi.number(), Joi.string()))
+  )
     .meta({ title: 'Expectation: Status Code' })
     .description(
       'Check the response status code.\nIf a list of status codes is provided, check that the response status code is present in the list.\nhttps://www.artillery.io/docs/reference/extensions/expect#statuscode'
     ),
-  notStatusCode: Joi.alternatives(Joi.number(), Joi.array().items(Joi.number()))
+  notStatusCode: Joi.alternatives(
+    Joi.number(),
+    Joi.string(),
+    Joi.array().items(Joi.alternatives(Joi.number(), Joi.string()))
+  )
     .meta({ title: 'Expectation: Not Status Code' })
     .description(
       'Check the response status code does not equal given status code.\nIf a list of status codes is provided, check that the response status code is not present in the list.\nhttps://www.artillery.io/docs/reference/extensions/expect#notstatuscode'

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -1,0 +1,12 @@
+const Joi = require('joi');
+
+const MetricsByEndpointPluginConfigSchema = Joi.object({
+  useOnlyRequestNames: Joi.boolean(),
+  stripQueryString: Joi.boolean(),
+  ignoreUnnamedRequests: Joi.boolean(),
+  metricsPrefix: Joi.string()
+}).unknown(false);
+
+module.exports = {
+  MetricsByEndpointPluginConfigSchema
+};

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -77,7 +77,7 @@ const SplunkReporterSchema = Joi.object({
   .unknown(false)
   .meta({ title: 'Splunk Reporter' });
 
-const PrometheusSchema = Joi.object({
+const PrometheusReporterSchema = Joi.object({
   type: Joi.string().valid('prometheus').required(),
   pushgateway: Joi.string().required(),
   tags: Joi.array().items(Joi.string())
@@ -125,14 +125,14 @@ const LightstepReporterSchema = Joi.object({
   .unknown(false)
   .meta({ title: 'Lightstep (Tracing) Reporter' });
 
-const MixpanelSchema = Joi.object({
+const MixpanelReporterSchema = Joi.object({
   type: Joi.string().valid('mixpanel').required(),
   projectToken: Joi.string().required()
 })
   .unknown(false)
   .meta({ title: 'Mixpanel Reporter' });
 
-const StatsDSchema = Joi.object({
+const StatsdReporterSchema = Joi.object({
   type: Joi.string().valid('statsd').required(),
   host: Joi.string(),
   port: artilleryStringNumber,
@@ -141,7 +141,7 @@ const StatsDSchema = Joi.object({
   .unknown(false)
   .meta({ title: 'StatsD Reporter' });
 
-const InfluxStatsDSchema = Joi.object({
+const InfluxReporterSchema = Joi.object({
   type: Joi.string().valid('influxdb-statsd').required(),
   prefix: Joi.string(),
   tags: Joi.array().items(Joi.string()),
@@ -160,13 +160,13 @@ const PublishMetricsPluginConfigSchema = Joi.array().items(
       DatadogReporterSchema,
       NewRelicReporterSchema,
       SplunkReporterSchema,
-      PrometheusSchema,
+      PrometheusReporterSchema,
       DynatraceReporterSchema,
       HoneycombReporterSchema,
       LightstepReporterSchema,
-      MixpanelSchema,
-      StatsDSchema,
-      InfluxStatsDSchema
+      MixpanelReporterSchema,
+      StatsdReporterSchema,
+      InfluxReporterSchema
     )
     .match('one')
 );

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -1,0 +1,176 @@
+const Joi = require('joi');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+const artilleryStringBoolean = Joi.alternatives(Joi.boolean(), Joi.string());
+
+const CloudwatchReporterSchema = Joi.object({
+  type: Joi.string().valid('cloudwatch').required(),
+  region: Joi.string(),
+  namespace: Joi.string(),
+  name: Joi.string(),
+  dimensions: Joi.array().items(
+    Joi.object({
+      name: Joi.string().required(),
+      value: Joi.string().required()
+    })
+  ),
+  includeOnly: Joi.array().items(Joi.string()),
+  excluded: Joi.array().items(Joi.string())
+})
+  .unknown(false)
+  .meta({ title: 'Cloudwatch Reporter' });
+
+const DatadogReporterSchema = Joi.object({
+  type: Joi.string().valid('datadog').required(),
+  apiKey: Joi.string(),
+  appKey: Joi.string(),
+  apiHost: Joi.string(),
+  prefix: Joi.string(),
+  tags: Joi.array().items(Joi.string()),
+  includeOnly: Joi.array().items(Joi.string()),
+  excluded: Joi.array().items(Joi.string()),
+  event: Joi.object({
+    title: Joi.string(),
+    text: Joi.string(),
+    priority: Joi.string().valid('normal', 'low'),
+    tags: Joi.array().items(Joi.string()),
+    alertType: Joi.string().valid('error', 'warning', 'info', 'success'),
+    send: artilleryStringBoolean
+  })
+})
+  .unknown(false)
+  .meta({ title: 'Datadog Reporter' });
+
+const NewRelicReporterSchema = Joi.object({
+  type: Joi.string().valid('newrelic').required(),
+  licenseKey: Joi.string().required(),
+  region: Joi.string(),
+  prefix: Joi.string(),
+  attributes: Joi.array().items(Joi.string()),
+  includeOnly: Joi.array().items(Joi.string()),
+  excluded: Joi.array().items(Joi.string()),
+  event: Joi.object({
+    accountId: Joi.string().required(),
+    eventType: Joi.string(),
+    attributes: Joi.array().items(Joi.string()),
+    send: artilleryStringBoolean
+  })
+})
+  .unknown(false)
+  .meta({ title: 'New Relic Reporter' });
+
+const SplunkReporterSchema = Joi.object({
+  type: Joi.string().valid('splunk').required(),
+  accessToken: Joi.string().required(),
+  realm: Joi.string(),
+  prefix: Joi.string(),
+  dimensions: Joi.array().items(Joi.string()),
+  includeOnly: Joi.array().items(Joi.string()),
+  excluded: Joi.array().items(Joi.string()),
+  event: Joi.object({
+    eventType: Joi.string(),
+    dimensions: Joi.array().items(Joi.string()),
+    properties: Joi.array().items(Joi.string()),
+    send: artilleryStringBoolean
+  })
+})
+  .unknown(false)
+  .meta({ title: 'Splunk Reporter' });
+
+const PrometheusSchema = Joi.object({
+  type: Joi.string().valid('prometheus').required(),
+  pushgateway: Joi.string().required(),
+  tags: Joi.array().items(Joi.string())
+})
+  .unknown(false)
+  .meta({ title: 'Prometheus (Pushgateway) Reporter' });
+
+const DynatraceReporterSchema = Joi.object({
+  type: Joi.string().valid('dynatrace').required(),
+  apiToken: Joi.string().required(),
+  envUrl: Joi.string().required(),
+  prefix: Joi.string(),
+  dimensions: Joi.array().items(Joi.string()),
+  includeOnly: Joi.array().items(Joi.string()),
+  excluded: Joi.array().items(Joi.string()),
+  event: Joi.object({
+    eventType: Joi.string(),
+    title: Joi.string(),
+    properties: Joi.array().items(Joi.string()),
+    entitySelector: artilleryStringBoolean,
+    send: artilleryStringBoolean
+  })
+})
+  .unknown(false)
+  .meta({ title: 'Dynatrace Reporter' });
+
+const HoneycombReporterSchema = Joi.object({
+  type: Joi.string().valid('dynatrace').required(),
+  apiKey: Joi.string(), //TODO: add required between these
+  writeKey: Joi.string(),
+  dataset: Joi.string(),
+  sampleRate: artilleryStringNumber,
+  enabled: artilleryStringBoolean
+})
+  .unknown(false)
+  .meta({ title: 'Honeycomb (Tracing) Reporter' });
+
+const LightstepReporterSchema = Joi.object({
+  type: Joi.string().valid('dynatrace').required(),
+  accessToken: Joi.string().required(),
+  componentName: Joi.string().required(),
+  tags: Joi.object(),
+  enabled: artilleryStringBoolean
+})
+  .unknown(false)
+  .meta({ title: 'Lightstep (Tracing) Reporter' });
+
+const MixpanelSchema = Joi.object({
+  type: Joi.string().valid('mixpanel').required(),
+  projectToken: Joi.string().required()
+})
+  .unknown(false)
+  .meta({ title: 'Mixpanel Reporter' });
+
+const StatsDSchema = Joi.object({
+  type: Joi.string().valid('statsd').required(),
+  host: Joi.string(),
+  port: artilleryStringNumber,
+  prefix: Joi.string()
+})
+  .unknown(false)
+  .meta({ title: 'StatsD Reporter' });
+
+const InfluxStatsDSchema = Joi.object({
+  type: Joi.string().valid('influxdb-statsd').required(),
+  prefix: Joi.string(),
+  tags: Joi.array().items(Joi.string()),
+  event: Joi.object({
+    priority: Joi.string().valid('normal', 'low'),
+    tags: Joi.array().items(Joi.string())
+  })
+})
+  .unknown(false)
+  .meta({ title: 'InfluxDB/Telegraf Reporter' });
+
+const PublishMetricsPluginConfigSchema = Joi.array().items(
+  Joi.alternatives()
+    .try(
+      CloudwatchReporterSchema,
+      DatadogReporterSchema,
+      NewRelicReporterSchema,
+      SplunkReporterSchema,
+      PrometheusSchema,
+      DynatraceReporterSchema,
+      HoneycombReporterSchema,
+      LightstepReporterSchema,
+      MixpanelSchema,
+      StatsDSchema,
+      InfluxStatsDSchema
+    )
+    .match('one')
+);
+
+module.exports = {
+  PublishMetricsPluginConfigSchema
+};

--- a/packages/types/schema/scenario.js
+++ b/packages/types/schema/scenario.js
@@ -3,7 +3,7 @@ const Joi = require('joi').defaults((schema) =>
 );
 
 const { HttpFlowItemSchema } = require('./engines/http');
-// const { WsFlowItemSchema } = require('./engines/websocket');
+const { WsFlowItemSchema } = require('./engines/websocket');
 
 const ScenarioSchema = Joi.object({
   name: Joi.string(),
@@ -48,7 +48,7 @@ const ScenarioSchema = Joi.object({
     then: Joi.object({
       engine: Joi.string().valid('ws', 'websocket'),
       flow: Joi.array()
-        .items(Joi.object())
+        .items(WsFlowItemSchema)
         .required()
         .meta({ title: 'Websocket Engine Flow' })
     })

--- a/packages/types/schema/scenario.js
+++ b/packages/types/schema/scenario.js
@@ -1,0 +1,182 @@
+const Joi = require('joi').defaults((schema) =>
+  schema.options({ allowUnknown: true, abortEarly: true })
+);
+
+const { ExpectPluginImplementationSchema } = require('./plugins/expect');
+
+const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
+
+const HttpMethodProperties = Joi.object({
+  url: Joi.string().required(),
+  headers: Joi.object(),
+  cookie: Joi.object(), //TODO: make them strings only,
+  followRedirect: Joi.boolean(),
+  qs: Joi.object(),
+  gzip: Joi.boolean(),
+  capture: Joi.object(), //TODO: add capture here
+  auth: Joi.object({
+    user: Joi.string(),
+    pass: Joi.string()
+  }),
+  beforeRequest: Joi.alternatives(
+    Joi.string(),
+    Joi.array().items(Joi.string())
+  ), //TODO: this is likely different on a resolved config
+  afterResponse: Joi.alternatives(
+    Joi.string(),
+    Joi.array().items(Joi.string())
+  ), //TODO: this is likely different on a resolved config
+  ifTrue: Joi.string(),
+  //match TODO: add match here (deprecated)
+  expect: Joi.alternatives(
+    ExpectPluginImplementationSchema,
+    Joi.array().items(ExpectPluginImplementationSchema)
+  )
+});
+
+// const HttpMethodWithBodyProperties = HttpMethodProperties.
+
+const BaseFlowItemAlternatives = [
+  Joi.object({ function: Joi.string() }),
+  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
+    title: 'Logging'
+  }),
+  Joi.object({ think: artilleryStringNumber })
+];
+
+const BaseWithHttp = [
+  ...BaseFlowItemAlternatives,
+  Joi.object({
+    get: HttpMethodProperties.description('hi there still me').meta({
+      title: 'GET REQUEST'
+    })
+  }),
+  Joi.object({ post: HttpMethodProperties }), //TODO: add body options
+  Joi.object({ put: HttpMethodProperties }),
+  Joi.object({ patch: HttpMethodProperties }),
+  Joi.object({ delete: HttpMethodProperties }) //TODO: do we need head and options methods?
+];
+
+const HttpFlowItemSchema = Joi.alternatives()
+  .try(
+    ...BaseWithHttp,
+    // ...BaseFlowItemAlternatives,
+    // Joi.object({get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"})}),
+    // Joi.object({post: HttpMethodProperties}),//TODO: add body options
+    // Joi.object({put: HttpMethodProperties}),
+    // Joi.object({patch: HttpMethodProperties}),
+    // Joi.object({delete: HttpMethodProperties}),//TODO: do we need head and options methods?
+    Joi.object({
+      loop: Joi.array()
+        .items(
+          Joi.alternatives()
+            .try(
+              // Joi.link('#HttpFlowItemSchema')
+              ...BaseWithHttp
+            )
+            .match('all')
+            .required()
+        )
+        .meta({ title: 'Loop' }),
+      whileTrue: Joi.string(),
+      count: Joi.alternatives(Joi.string(), Joi.number()),
+      over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+    })
+  )
+  .match('all')
+  .id('HttpFlowItemSchema');
+
+// const HttpFlowItemSchema2 = Joi.object({
+//     function: Joi.string(),
+//     think: Joi.alternatives(Joi.number(), Joi.string()),
+//     log: Joi.string().meta({title: "Logging"}),
+//     get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"}),
+//     post: HttpMethodProperties
+// })
+
+// const HttpLoopSchema = Joi.object({
+//     loop: Joi.array().items(HttpFlowItemSchema).meta({title: "Http Loop"}),
+//     whileTrue: Joi.string(),
+//     count: Joi.alternatives(Joi.string(), Joi.boolean()),
+//     over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+// })
+
+const ScenarioSchema = Joi.object({
+  name: Joi.string(),
+  // engine: Joi.alternatives().conditional('engine', { is: Joi.alternatives('socketio', 'ws', 'http'), then: Joi.alternatives('socketio', 'ws', 'http'), otherwise: Joi.string().invalid('socketio', 'ws', 'http')}),//TODO:maybe improve this?
+  // flow: Joi.array().items(Joi.object()),
+  engine: Joi.alternatives('http', 'ws', 'socketio', Joi.string()),
+  beforeScenario: Joi.array().items(Joi.string()).single(), //TODO:review this
+  afterScenario: Joi.array().items(Joi.string()).single() //TODO:review this
+})
+  // .when('engine', {
+  //     is: 'http',
+  //     then: Joi.object({
+  //         engine: Joi.string().valid('http'),
+  //         flow: Joi.array().items(HttpFlowItemSchema).required().meta({title: 'HTTP Engine Flow'})
+  //     })
+  // })
+  // .when('engine', {
+  //     is: Joi.any().valid(null, ""),
+  //     then: Joi.object({
+  //         engine: Joi.any().valid(null, ""),
+  //         flow: Joi.array().items(HttpFlowItemSchema).required().meta({title: 'HTTP Engine Flow (Default)'})
+  //     })
+  // })
+  .when(Joi.object({ engine: Joi.string().valid('http') }), {
+    then: Joi.object({
+      engine: Joi.string().valid('http'),
+      flow: Joi.array()
+        .items(HttpFlowItemSchema)
+        .required()
+        .meta({ title: 'HTTP Engine Flow' })
+    })
+    // then: Joi.object({
+    //     engine: Joi.alternatives('http'),
+    //     flow: Joi.array().items(Joi.alternatives(HttpFlowItemSchema, HttpLoopSchema)).required().meta({title: "HTTP Flow"})
+    // }),
+    // then: Joi.object({
+
+    // })
+    // then: Joi.when(Joi.object({}))
+  })
+  .when(Joi.object({ engine: Joi.string().valid('ws', 'websocket') }), {
+    then: Joi.object({
+      engine: Joi.string().valid('ws', 'websocket'),
+      flow: Joi.array()
+        .items(Joi.object())
+        .required()
+        .meta({ title: 'Websocket Engine Flow' })
+    })
+  })
+  .when(Joi.object({ engine: Joi.any().valid(null, '') }), {
+    then: Joi.object({
+      engine: Joi.any().valid(null, ''),
+      flow: Joi.array()
+        .items(HttpFlowItemSchema)
+        .required()
+        .meta({ title: 'HTTP Engine Flow (Default)' })
+    })
+    // then: Joi.object({
+    //     engine: Joi.any().valid(null, ""),
+    //     flow: Joi.array().items(Joi.alternatives(HttpFlowItemSchema, HttpLoopSchema)).required().meta({title: "HTTP Flow"})
+    // }),
+  })
+  .when(Joi.object({ engine: Joi.string().not('ws', 'http') }), {
+    then: Joi.object({
+      engine: Joi.string(),
+      // flow: Joi.array().items(Joi.any()).required().meta({title: 'Generic Engine Flow'})
+      flow: Joi.any().required().meta({ title: 'Generic Engine Flow' })
+    })
+  });
+
+// TODO: PR in joi-to-json repo for converting deprecated and default
+
+//TODO: loops are still not working well. I am not sure why it doesnt detect things correctly
+//TODO: Lets do all the descriptions
+//TODO: check why it doesnt accuse  when you do get: url: number
+//TODO: type socketio and ws
+
+module.exports = {
+  ScenarioSchema
+};

--- a/packages/types/schema/scenario.js
+++ b/packages/types/schema/scenario.js
@@ -84,7 +84,7 @@ const ScenarioSchema = Joi.object({
       then: Joi.object({
         engine: Joi.string(),
         // flow: Joi.array().items(Joi.any()).required().meta({title: 'Generic Engine Flow'})
-        flow: Joi.any().required().meta({ title: 'Generic Engine Flow' })
+        flow: Joi.any().meta({ title: 'Generic Engine Flow' }) //TODO: decide if flow should be required here? probably not
       })
     }
   );

--- a/packages/types/schema/scenario.js
+++ b/packages/types/schema/scenario.js
@@ -2,104 +2,8 @@ const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
 
-const { ExpectPluginImplementationSchema } = require('./plugins/expect');
-
-const artilleryStringNumber = Joi.alternatives(Joi.number(), Joi.string());
-
-const HttpMethodProperties = Joi.object({
-  url: Joi.string().required(),
-  headers: Joi.object(),
-  cookie: Joi.object(), //TODO: make them strings only,
-  followRedirect: Joi.boolean(),
-  qs: Joi.object(),
-  gzip: Joi.boolean(),
-  capture: Joi.object(), //TODO: add capture here
-  auth: Joi.object({
-    user: Joi.string(),
-    pass: Joi.string()
-  }),
-  beforeRequest: Joi.alternatives(
-    Joi.string(),
-    Joi.array().items(Joi.string())
-  ), //TODO: this is likely different on a resolved config
-  afterResponse: Joi.alternatives(
-    Joi.string(),
-    Joi.array().items(Joi.string())
-  ), //TODO: this is likely different on a resolved config
-  ifTrue: Joi.string(),
-  //match TODO: add match here (deprecated)
-  expect: Joi.alternatives(
-    ExpectPluginImplementationSchema,
-    Joi.array().items(ExpectPluginImplementationSchema)
-  )
-});
-
-// const HttpMethodWithBodyProperties = HttpMethodProperties.
-
-const BaseFlowItemAlternatives = [
-  Joi.object({ function: Joi.string() }),
-  Joi.object({ log: Joi.string().meta({ title: 'Log from inside' }) }).meta({
-    title: 'Logging'
-  }),
-  Joi.object({ think: artilleryStringNumber })
-];
-
-const BaseWithHttp = [
-  ...BaseFlowItemAlternatives,
-  Joi.object({
-    get: HttpMethodProperties.description('hi there still me').meta({
-      title: 'GET REQUEST'
-    })
-  }),
-  Joi.object({ post: HttpMethodProperties }), //TODO: add body options
-  Joi.object({ put: HttpMethodProperties }),
-  Joi.object({ patch: HttpMethodProperties }),
-  Joi.object({ delete: HttpMethodProperties }) //TODO: do we need head and options methods?
-];
-
-const HttpFlowItemSchema = Joi.alternatives()
-  .try(
-    ...BaseWithHttp,
-    // ...BaseFlowItemAlternatives,
-    // Joi.object({get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"})}),
-    // Joi.object({post: HttpMethodProperties}),//TODO: add body options
-    // Joi.object({put: HttpMethodProperties}),
-    // Joi.object({patch: HttpMethodProperties}),
-    // Joi.object({delete: HttpMethodProperties}),//TODO: do we need head and options methods?
-    Joi.object({
-      loop: Joi.array()
-        .items(
-          Joi.alternatives()
-            .try(
-              // Joi.link('#HttpFlowItemSchema')
-              ...BaseWithHttp
-            )
-            .match('all')
-            .required()
-        )
-        .meta({ title: 'Loop' }),
-      whileTrue: Joi.string(),
-      count: Joi.alternatives(Joi.string(), Joi.number()),
-      over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
-    })
-  )
-  .match('all')
-  .id('HttpFlowItemSchema');
-
-// const HttpFlowItemSchema2 = Joi.object({
-//     function: Joi.string(),
-//     think: Joi.alternatives(Joi.number(), Joi.string()),
-//     log: Joi.string().meta({title: "Logging"}),
-//     get: HttpMethodProperties.description("hi there still me").meta({title: "GET REQUEST"}),
-//     post: HttpMethodProperties
-// })
-
-// const HttpLoopSchema = Joi.object({
-//     loop: Joi.array().items(HttpFlowItemSchema).meta({title: "Http Loop"}),
-//     whileTrue: Joi.string(),
-//     count: Joi.alternatives(Joi.string(), Joi.boolean()),
-//     over: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
-// })
+const { HttpFlowItemSchema } = require('./engines/http');
+// const { WsFlowItemSchema } = require('./engines/websocket');
 
 const ScenarioSchema = Joi.object({
   name: Joi.string(),
@@ -162,7 +66,7 @@ const ScenarioSchema = Joi.object({
     //     flow: Joi.array().items(Joi.alternatives(HttpFlowItemSchema, HttpLoopSchema)).required().meta({title: "HTTP Flow"})
     // }),
   })
-  .when(Joi.object({ engine: Joi.string().not('ws', 'http') }), {
+  .when(Joi.object({ engine: Joi.string().not('ws', 'websocket', 'http') }), {
     then: Joi.object({
       engine: Joi.string(),
       // flow: Joi.array().items(Joi.any()).required().meta({title: 'Generic Engine Flow'})


### PR DESCRIPTION
## Why

TS had limitations when it came to discriminated unions that prevented us from generating the correct JSON schema. 

This PR introduces an equivalent Joi schema. I haven't removed the Typescript schema yet, but can do this either as part of this PR or in another one. 

As far as reconciling this schema with the existing one already in `artillery` package, that can be done at a later time. That schema is used in the critical path (and it is after everything has been merged into a single JSON/YAML), so there are some differences. 

## Roadmap

- [x] All built-in engines are working in the schema
- [x] Custom engines and plugins work
- [x] Loops are working
- [x] All examples are working
- [x] All main built-in plugins
- [ ] Before/After 
- [ ] Default Engine is HTTP (this is only partly working - it does autocomplete but it also displays autocomplete from other engines - however this is an acceptable compromise for now)

_Note: this is still in final stages of development. Comments and other things will be removed before moving this from Draft to Review._