### PR TITLE
fix(commons): match regex groups by integer index

### DIFF
--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -609,12 +609,16 @@ function extractRegExp(doc, expr, opts) {
     return '';
   }
 
+  // Captures named group (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)
   if (group && match.groups) {
     return match.groups[group];
+    // Captures integer index defined group since those don't show up in match.groups
   } else if (group && match[group]) {
     return match[group];
+    // Defaults to first match if found and no group defined
   } else if (match[0]) {
     return match[0];
+    // If no match returns empty string
   } else {
     return '';
   }

--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -22,6 +22,8 @@ try {
   xmlCapture = null;
 }
 
+// TODO Write tests
+
 module.exports = {
   createThink: createThink,
   createLoopWithCount: createLoopWithCount,
@@ -609,6 +611,8 @@ function extractRegExp(doc, expr, opts) {
 
   if (group && match.groups) {
     return match.groups[group];
+  } else if (group && match[group]) {
+    return match[group];
   } else if (match[0]) {
     return match[0];
   } else {


### PR DESCRIPTION
# What

Fix for #2125 
The `extractRegExp` function was not considering the integer index of the group in the regular expression as a group identifier, only [named groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group) were considered.

# How
Implemented the integer index consideration.

# Testing
Tested manually. As no tests exists for `engine_util` yet, the tests implementation will be added in a separate PR when created.