### PR TITLE
fix(publish-metrics): use path.join to append path to endpoints

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -2,6 +2,7 @@
 
 const got = require('got');
 const debug = require('debug')('plugin:publish-metrics:dynatrace');
+const path = require('path');
 
 class DynatraceReporter {
   constructor(config, events, script) {
@@ -44,14 +45,12 @@ class DynatraceReporter {
       }
 
       this.ingestEventsEndpoint = new URL(
-        '/api/v2/events/ingest',
-        this.config.envUrl
+        path.join(this.config.envUrl, '/api/v2/events/ingest')
       );
     }
 
     this.ingestMetricsEndpoint = new URL(
-      '/api/v2/metrics/ingest',
-      this.config.envUrl
+      path.join(this.config.envUrl, '/api/v2/metrics/ingest')
     );
 
     this.pendingRequests = 0;


### PR DESCRIPTION
Related to this [discussion](https://github.com/artilleryio/artillery/discussions/2064#discussioncomment-6968472)
In Dynatrace reporter, `endpoint` that had an existing path (e.g. in managed instances) wasn't being joined correctly. 

Changed to using `path.join()` within creating the URL's to resolve this

