### PR TITLE
fix(types): add open-telemetry reporter joi schema

### DIFF
--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -159,7 +159,7 @@ const InfluxReporterSchema = Joi.object({
 
 const OtelCommonOptions = {
   endpoint: Joi.string(),
-  headers: Joi.object()
+  headers: Joi.object().unknown()
 };
 
 const OpenTelemetryReporterSchema = Joi.object({
@@ -172,7 +172,7 @@ const OpenTelemetryReporterSchema = Joi.object({
       .default('otlp-http'),
     includeOnly: Joi.array().items(Joi.string()),
     excluded: Joi.array().items(Joi.string()),
-    attributes: Joi.object()
+    attributes: Joi.object().unknown()
   }),
   traces: Joi.object({
     ...OtelCommonOptions,
@@ -181,7 +181,7 @@ const OpenTelemetryReporterSchema = Joi.object({
       .default('otlp-http'),
     sampleRate: artilleryNumberOrString,
     useRequestNames: artilleryBooleanOrString,
-    attributes: Joi.object()
+    attributes: Joi.object().unknown()
   })
 })
   .unknown(false)

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -157,6 +157,36 @@ const InfluxReporterSchema = Joi.object({
   .unknown(false)
   .meta({ title: 'InfluxDB/Telegraf Reporter' });
 
+const OtelCommonOptions = {
+  endpoint: Joi.string(),
+  headers: Joi.object()
+};
+
+const OpenTelemetryReporterSchema = Joi.object({
+  type: Joi.string().valid('open-telemetry').required(),
+  serviceName: Joi.string(),
+  metrics: Joi.object({
+    ...OtelCommonOptions,
+    exporter: Joi.string()
+      .valid('otlp-http', 'otlp-proto', 'otlp-grpc')
+      .default('otlp-http'),
+    includeOnly: Joi.array().items(Joi.string()),
+    excluded: Joi.array().items(Joi.string()),
+    attributes: Joi.object()
+  }),
+  traces: Joi.object({
+    ...OtelCommonOptions,
+    exporter: Joi.string()
+      .valid('otlp-http', 'otlp-proto', 'otlp-grpc', 'zipkin')
+      .default('otlp-http'),
+    sampleRate: artilleryNumberOrString,
+    useRequestNames: artilleryBooleanOrString,
+    attributes: Joi.object()
+  })
+})
+  .unknown(false)
+  .meta({ title: 'OpenTelemetry Reporter' });
+
 const PublishMetricsPluginConfigSchema = Joi.array().items(
   Joi.alternatives()
     .try(
@@ -170,7 +200,8 @@ const PublishMetricsPluginConfigSchema = Joi.array().items(
       LightstepReporterSchema,
       MixpanelReporterSchema,
       StatsdReporterSchema,
-      InfluxReporterSchema
+      InfluxReporterSchema,
+      OpenTelemetryReporterSchema
     )
     .match('one')
 );


### PR DESCRIPTION
## Why

This newly implemented reporter was missing from the schema.

Descriptions of options to be added later together with all other reporters.