### PR TITLE
fix(schema): correct the plugins allowed in root config

### DIFF
--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -132,6 +132,11 @@ const ArtilleryBuiltInPlugins = {
   'publish-metrics': PublishMetricsPluginConfigSchema
 };
 
+const ArtilleryBuiltInPluginsInRootConfig = (({ ensure, apdex }) => ({
+  ensure,
+  apdex
+}))(ArtilleryBuiltInPlugins);
+
 const ConfigSchema = Joi.object({
   ...ReplaceableConfig,
   http: HttpConfigSchema.meta({ title: 'HTTP Configuration' }),
@@ -167,7 +172,7 @@ const ConfigSchema = Joi.object({
   })
     .meta({ title: 'Engines' })
     .description('Configuration for specific engines used'),
-  ...ArtilleryBuiltInPlugins
+  ...ArtilleryBuiltInPluginsInRootConfig
 });
 
 module.exports = {

--- a/packages/types/schema/plugins/apdex.js
+++ b/packages/types/schema/plugins/apdex.js
@@ -6,7 +6,9 @@ const { artilleryNumberOrString } = require('../joi.helpers');
 
 const ApdexPluginConfigSchema = Joi.object({
   threshold: artilleryNumberOrString
-}).unknown(false);
+})
+  .unknown(false)
+  .meta({ title: 'Apdex Plugin' });
 
 module.exports = {
   ApdexPluginConfigSchema

--- a/packages/types/schema/plugins/ensure.js
+++ b/packages/types/schema/plugins/ensure.js
@@ -57,7 +57,9 @@ const EnsurePluginConfigSchema = Joi.object({
       'Set more complex expressions for additional checks.\nhttps://www.artillery.io/docs/reference/extensions/ensure#advanced-conditional-checks'
     ),
   ...EnsureLegacyOptions
-}).unknown(false);
+})
+  .unknown(false)
+  .meta({ title: 'Ensure Plugin' });
 
 module.exports = {
   EnsurePluginConfigSchema

--- a/packages/types/schema/plugins/expect.js
+++ b/packages/types/schema/plugins/expect.js
@@ -27,7 +27,9 @@ const ExpectPluginConfigSchema = Joi.object({
   expectDefault200: artilleryBooleanOrString
     .meta({ title: 'Expect 200 by default' })
     .description('Sets a 200 OK status code expectation for all requests.') //TODO: add default value
-}).unknown(false);
+})
+  .unknown(false)
+  .meta({ title: 'Expect Plugin' });
 
 const ExpectPluginImplementationSchema = {
   statusCode: Joi.alternatives(

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -9,7 +9,9 @@ const MetricsByEndpointPluginConfigSchema = Joi.object({
   stripQueryString: artilleryBooleanOrString,
   ignoreUnnamedRequests: artilleryBooleanOrString,
   metricsPrefix: Joi.string()
-}).unknown(false);
+})
+  .unknown(false)
+  .meta({ title: 'Metrics by Endpoint Plugin' });
 
 module.exports = {
   MetricsByEndpointPluginConfigSchema

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -187,24 +187,26 @@ const OpenTelemetryReporterSchema = Joi.object({
   .unknown(false)
   .meta({ title: 'OpenTelemetry Reporter' });
 
-const PublishMetricsPluginConfigSchema = Joi.array().items(
-  Joi.alternatives()
-    .try(
-      CloudwatchReporterSchema,
-      DatadogReporterSchema,
-      NewRelicReporterSchema,
-      SplunkReporterSchema,
-      PrometheusReporterSchema,
-      DynatraceReporterSchema,
-      HoneycombReporterSchema,
-      LightstepReporterSchema,
-      MixpanelReporterSchema,
-      StatsdReporterSchema,
-      InfluxReporterSchema,
-      OpenTelemetryReporterSchema
-    )
-    .match('one')
-);
+const PublishMetricsPluginConfigSchema = Joi.array()
+  .items(
+    Joi.alternatives()
+      .try(
+        CloudwatchReporterSchema,
+        DatadogReporterSchema,
+        NewRelicReporterSchema,
+        SplunkReporterSchema,
+        PrometheusReporterSchema,
+        DynatraceReporterSchema,
+        HoneycombReporterSchema,
+        LightstepReporterSchema,
+        MixpanelReporterSchema,
+        StatsdReporterSchema,
+        InfluxReporterSchema,
+        OpenTelemetryReporterSchema
+      )
+      .match('one')
+  )
+  .meta({ title: 'Publish Metrics Plugin' });
 
 module.exports = {
   PublishMetricsPluginConfigSchema


### PR DESCRIPTION
## Why

Not all built-in plugins allow you to use `config.<plugin-name>` to set config options. As far as I know, only `ensure` and `apdex` do. The schema assumed that all of them did.