### PR TITLE
fix(publish-metrics): enable diag logger for debug

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -4,6 +4,9 @@ const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const { attachScenarioHooks } = require('../util');
 
 const {
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
   SpanKind,
   SpanStatusCode,
   trace,
@@ -18,7 +21,12 @@ class OTelReporter {
   constructor(config, events, script) {
     this.script = script;
     this.events = events;
-
+    if (
+      process.env.DEBUG &&
+      process.env.DEBUG === 'plugin:publish-metrics:open-telemetry'
+    ) {
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+    }
     this.metricExporters = {
       'otlp-proto'(options) {
         const {


### PR DESCRIPTION
Currently the OTel reporter does not print out errors if any occur due to OpenTelemetry catching them internally with their `DiagAPI`.

This PR implements the `DiagConsoleLogger` which gets activated and set on `debug` log level when `DEBUG` is used for OTel reporter.

Related to #2128 discussion