### PR TITLE
Socket.io engine fixes + more flexible `response.data` behavior

### DIFF
--- a/packages/artillery/lib/util/validate-script.js
+++ b/packages/artillery/lib/util/validate-script.js
@@ -53,6 +53,7 @@ const socketioItems = {
     then: Joi.alternatives(
       Joi.object({
         channel: Joi.string(),
+        concat: Joi.boolean(),
         data: Joi.any()
       }),
       Joi.array().items(Joi.string())
@@ -86,7 +87,7 @@ const flowItemSchema = Joi.object({
   }),
   otherwise: Joi.when('...engine', {
     is: Joi.exist().valid('socketio'),
-    then: Joi.object().max(3),
+    then: Joi.object().max(4),
     otherwise: Joi.object().length(1)
   })
 });

--- a/packages/core/lib/engine_socketio.js
+++ b/packages/core/lib/engine_socketio.js
@@ -78,7 +78,13 @@ function isValid(data, response) {
 
   if (_.isString(response.data)) {
     const expectedResponse = response.data;
-    const actualResponse = data[data.length - 1]; // if response.data is not an array, we compare it to the last element of the actual response
+    let actualResponse = data[data.length - 1]; // if response.data is not an array, we compare it to the last element of the actual response
+
+    // unless the user wants to test against the entire response
+    if (response.concat) {
+      actualResponse = data.join('');
+    }
+
     debug(
       `checking if string ${expectedResponse} is a partial match for string ${actualResponse}`
     );
@@ -263,6 +269,7 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
           requestSpec.response.channel || requestSpec.response.on,
           context
         ),
+        concat: template(requestSpec.response.concat, context),
         data: template(
           requestSpec.response.data || requestSpec.response.args,
           context


### PR DESCRIPTION
The commits give more details, but in summary this PR fixes a couple of bugs around response matching so the tool behaves as the schema/docs indicate it should.

I've also broadened what `response.data` will accept (https://github.com/artilleryio/artillery/commit/22f1e569654230b47a8cde15390697e69a571aea), because:
- This currently wasn't supported
- As this feature was broken, it's unlikely anyone's depending on the current strict behavior
- IMO it's a good compromise between simplicity (no change to config) and additional functionality (matching multiple responses + substring instead of exhaustive match). Alternatives would include allow regular expressions + a specific setting for multiple messages, but I think this is a good starting point 😄 

Please let me know if I can provide more info, and thanks for this excellent tool!