### PR TITLE
fix(publish-metrics): set headers as metadata for otel-grpc

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const { attachScenarioHooks } = require('../util');
+const grpc = require('@grpc/grpc-js');
 
 const {
   diag,
@@ -166,7 +167,13 @@ class OTelReporter {
     }
 
     if (config.headers) {
-      this.metricsExporterOpts.headers = config.headers;
+      if (config.exporter === 'otlp-grpc') {
+        const metadata = new grpc.Metadata();
+        Object.entries(config.headers).forEach(([k, v]) => metadata.set(k, v));
+        this.metricsExporterOpts.metadata = metadata;
+      } else {
+        this.metricsExporterOpts.headers = config.headers;
+      }
     }
 
     this.metricsExporter = this.metricExporters[


### PR DESCRIPTION
# Issue
`otlp-grpc` exporter does not support `headers` as its config option. So currently when `headers` are set in combination with `otlp-grpc` exporter for `metrics` it will throw an error, and headers can be set only through environment variables. 

# Fix
When `headers` are set in test script along with `otlp-grpc` exporter for `metrics`, they will be passed to the exporter as `metadata` rather than `headers` as `otlp-grpc` exporter supports `metadata`  which can basically serve the same purpose as headers - API keys and such can be set with it.