### PR TITLE
fix(validate-script): socketio runtime schema max value

### DIFF
--- a/examples/socket-io/app.js
+++ b/examples/socket-io/app.js
@@ -3,7 +3,9 @@ const io = require('socket.io')(8080, {
   serveClient: false
 });
 
-io.on('connection', (socket) => {
+const personalisedNamespace = io.of('/personalised');
+
+personalisedNamespace.on('connection', (socket) => {
   socket.on('echo', (msg) => {
     socket.emit('echoResponse', msg);
   });

--- a/examples/socket-io/socket-io.yml
+++ b/examples/socket-io/socket-io.yml
@@ -1,8 +1,8 @@
 config:
   target: "http://localhost:8080"
   phases:
-    - duration: 30
-      arrivalRate: 5
+    - duration: 60
+      arrivalRate: 25
 
 scenarios:
   - name: "Emit and validate response"

--- a/examples/socket-io/socket-io.yml
+++ b/examples/socket-io/socket-io.yml
@@ -1,14 +1,15 @@
 config:
-  target: "http://localhost:8080/"
+  target: "http://localhost:8080"
   phases:
-    - duration: 60
-      arrivalRate: 25
+    - duration: 30
+      arrivalRate: 5
 
 scenarios:
   - name: "Emit and validate response"
     engine: socketio
     flow:
-      - emit:
+      - namespace: /personalised
+        emit:
           channel: "echo"
           data: "Hello from Artillery"
         response:
@@ -18,7 +19,8 @@ scenarios:
   - name: "Emit and validate acknowledgement"
     engine: socketio
     flow:
-      - emit:
+      - namespace: /personalised
+        emit:
           channel: "userDetails"
         acknowledge:
           match:

--- a/packages/artillery/lib/util/validate-script.js
+++ b/packages/artillery/lib/util/validate-script.js
@@ -83,7 +83,7 @@ const flowItemSchema = Joi.object({
   }),
   otherwise: Joi.when('...engine', {
     is: Joi.exist().valid('socketio'),
-    then: Joi.object().max(2),
+    then: Joi.object().max(3),
     otherwise: Joi.object().length(1)
   })
 });


### PR DESCRIPTION
## Why

With `namespace` being a valid option too, there are a max of 3 keys in this object, not 2.

I also updated the example to include this, which also helps users understand how to use `namespace`.