### PR TITLE
fix(publish-metrics): warn user when metric name invalid

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -162,15 +162,19 @@ class DynatraceReporter {
   }
 
   warnIfMetricNameNotValid(metric) {
+    // Dynatrace allows only latin letters (both uppercase and lowercase), digits, hyphens, underscores and dots(dots usually divide name into sections).
     const unsupportedCharRegex = /[^\w-.]/g;
     const startsWithDigitRegex = /^[\d-]/;
+
     if (
+      // Sections(parts of metric key/name separated by dots e.g. `first.second.third` is 3 sections) can not start with hyphens
       metric.includes('.-') ||
+      // Metric key/name can not start with a digit
       startsWithDigitRegex.test(metric) ||
       unsupportedCharRegex.test(metric)
     ) {
       debug(
-        `Dynatrace reporter: WARNING Metric key '${metric}' does not meet Dynatrace Ingest API's requirements and will be dropped. More info in the docs (https://docs.art/reference/extensions/publish-metrics#dynatrace). `
+        `Dynatrace reporter: WARNING Metric key '${metric}' does not meet Dynatrace Ingest API's requirements and will be dropped. More info in the docs (https://docs.art/reference/extensions/publish-metrics#dynatrace).`
       );
     }
   }
@@ -185,6 +189,7 @@ class DynatraceReporter {
       }
 
       this.warnIfMetricNameNotValid(name);
+
       const count = `${config.prefix}${name},${config.dimensions.join(
         ','
       )} count,delta=${value} ${timestamp}`;

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -170,7 +170,7 @@ class DynatraceReporter {
       unsupportedCharRegex.test(metric)
     ) {
       debug(
-        `Dynatrace reporter: WARNING Metric key '${metric}' does not fulfill Dynatrace's Ingest API requirements and will be dropped. More info in the docs (https://docs.art/reference/extensions/publish-metrics#dynatrace). `
+        `Dynatrace reporter: WARNING Metric key '${metric}' does not meet Dynatrace Ingest API's requirements and will be dropped. More info in the docs (https://docs.art/reference/extensions/publish-metrics#dynatrace). `
       );
     }
   }


### PR DESCRIPTION
# What
In Dynatrace reporter,  gracefully handle cases in which the metric name does not meet the Dynatrace Ingest API's  [requirements for metric key](https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/metric-ingestion-protocol#metric-key).

One case in which this could be needed is when `metrics-by-endpoint` plugin is used alongside this reporter. `metrics-by-endpoint` plugin by default creates metric names that contain URL strings, and therefore characters that are unsupported by Dynatrace Ingest API. This can be avoided by using `useOnlyRequestNames` setting provided by `metrics-by-endpoint` and setting the `name` value for all requests to a string that meets the Ingest API's requirements.

Another case is user setting custom metrics that do not meet said requirements.

# Why
Currently the metric names that don't meet the requirements are dropped on ingest, and user is not notified or warned. 
# How
Two checks are implemented.First one warns the user if `metrics-by-endpoint` plugin is used without the `useOnlyRequestNames` setting and points to the documentation for more info.  

Second one screens for metric names that do not meet the requirements and, when  `DEBUG` is used, logs the warning for each individual metric that will be dropped and again points to the documentation.

To properly implement this solution docs will be updated in a separate PR. 

# Notes
I've decided on this solution as it seemed the best out of existing ones. If I had implemented a solution that replaces/removes unsupported characters, the outcome could result in unreadable metric names, or too tedious function that would have to try and catch all possible combinations and best ways to replace them for readability.