### PR TITLE
fix(schema): implement correct socketio ack and response in json schema

### DIFF
--- a/packages/types/schema/engines/common.js
+++ b/packages/types/schema/engines/common.js
@@ -2,7 +2,29 @@ const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
 
-const { artilleryNumberOrString } = require('../joi.helpers');
+const {
+  artilleryNumberOrString,
+  artilleryBooleanOrString
+} = require('../joi.helpers');
+
+const SharedCaptureProperties = {
+  as: Joi.string().meta({ title: 'Name your capture' }),
+  strict: artilleryBooleanOrString
+    .meta({ title: 'Strict?' })
+    .description(
+      'Captures are strict by default, so if a capture fails (no match), no subsequent request will run. You can configure that behaviour with this option.'
+    )
+};
+
+const JsonCaptureSchema = Joi.object({
+  json: Joi.string().required().meta({ title: 'Jsonpath expression' }),
+  ...SharedCaptureProperties
+}).meta({ title: 'JSON Capture' });
+
+const MatchSchema = Joi.object({
+  json: Joi.any(),
+  value: Joi.string()
+}).meta({ title: 'Match' });
 
 const BaseFlowItemAlternatives = [
   Joi.object({
@@ -42,5 +64,8 @@ const LoopOptions = {
 
 module.exports = {
   BaseFlowItemAlternatives,
-  LoopOptions
+  LoopOptions,
+  SharedCaptureProperties,
+  JsonCaptureSchema,
+  MatchSchema
 };

--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -1,29 +1,20 @@
 const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
-const { BaseFlowItemAlternatives, LoopOptions } = require('./common');
+const {
+  BaseFlowItemAlternatives,
+  LoopOptions,
+  SharedCaptureProperties,
+  JsonCaptureSchema,
+  MatchSchema
+} = require('./common');
 const { ExpectPluginImplementationSchema } = require('../plugins/expect');
 
-const {
-  artilleryNumberOrString,
-  artilleryBooleanOrString
-} = require('../joi.helpers');
-
-const SharedCaptureProperties = {
-  as: Joi.string().meta({ title: 'Name your capture' }),
-  strict: artilleryBooleanOrString
-    .meta({ title: 'Strict?' })
-    .description(
-      'Captures are strict by default, so if a capture fails (no match), no subsequent request will run. You can configure that behaviour with this option.'
-    )
-};
+const { artilleryNumberOrString } = require('../joi.helpers');
 
 const CaptureSchema = Joi.alternatives()
   .try(
-    Joi.object({
-      json: Joi.string().required().meta({ title: 'Jsonpath expression' }),
-      ...SharedCaptureProperties
-    }).meta({ title: 'JSON Capture' }),
+    JsonCaptureSchema,
     Joi.object({
       xpath: Joi.string().meta({ title: 'Xpath expression' }).required(),
       ...SharedCaptureProperties
@@ -91,14 +82,9 @@ const SharedHttpMethodProperties = {
     .description(
       'Capture and reuse parts of a response\nhttps://www.artillery.io/docs/reference/engines/http#extracting-and-re-using-parts-of-a-response-request-chaining'
     ),
-  match: Joi.object({
-    json: Joi.any(),
-    value: Joi.string()
-  })
-    .meta({ title: 'Match' })
-    .description(
-      '(Deprecated) Response validation criteria. Use capture and expect instead'
-    ), //TODO: add proper deprecated when available
+  match: MatchSchema.description(
+    '(Deprecated) Response validation criteria. Use capture and expect instead'
+  ), //TODO: add proper deprecated when available
   auth: Joi.object({
     user: Joi.string().meta({ title: 'Username' }),
     pass: Joi.string().meta({ title: 'Password' })

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -7,6 +7,8 @@ const { BaseWithHttp } = require('./http');
 
 //TODO: add metadata
 
+const SocketioDataSchema = Joi.alternatives(Joi.string(), Joi.object());
+
 const BaseWithSocketio = [
   ...BaseWithHttp,
   //TODO: review this schema and if it should also import base flow item.
@@ -14,18 +16,18 @@ const BaseWithSocketio = [
     emit: Joi.alternatives(
       Joi.object({
         channel: Joi.string(),
-        data: Joi.string()
+        data: SocketioDataSchema
       }),
-      Joi.array().items(Joi.string())
+      Joi.array().items(SocketioDataSchema)
     ),
     response: Joi.object({
       channel: Joi.string(),
-      data: Joi.string(),
+      data: SocketioDataSchema,
       match: MatchSchema,
       capture: JsonCaptureSchema
     }),
     acknowledge: Joi.object({
-      data: Joi.string(),
+      data: SocketioDataSchema,
       match: MatchSchema,
       capture: JsonCaptureSchema
     }),

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -2,7 +2,7 @@ const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
 
-const { LoopOptions } = require('./common');
+const { LoopOptions, MatchSchema, JsonCaptureSchema } = require('./common');
 const { BaseWithHttp } = require('./http');
 
 //TODO: add metadata
@@ -20,15 +20,14 @@ const BaseWithSocketio = [
     ),
     response: Joi.object({
       channel: Joi.string(),
-      data: Joi.string()
-      //TODO add capture and match
+      data: Joi.string(),
+      match: MatchSchema,
+      capture: JsonCaptureSchema
     }),
     acknowledge: Joi.object({
       data: Joi.string(),
-      match: Joi.object({
-        json: Joi.any(),
-        value: Joi.string()
-      })
+      match: MatchSchema,
+      capture: JsonCaptureSchema
     }),
     namespace: Joi.string()
   })

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -11,22 +11,26 @@ const BaseWithSocketio = [
   ...BaseWithHttp,
   //TODO: review this schema and if it should also import base flow item.
   Joi.object({
-    emit: Joi.object({
-      channel: Joi.string(),
-      data: Joi.string(),
-      namespace: Joi.string(),
-      response: Joi.object({
+    emit: Joi.alternatives(
+      Joi.object({
         channel: Joi.string(),
         data: Joi.string()
       }),
-      acknowledge: Joi.object({
-        data: Joi.string(),
-        match: Joi.object({
-          json: Joi.any(),
-          value: Joi.string()
-        })
+      Joi.array().items(Joi.string())
+    ),
+    response: Joi.object({
+      channel: Joi.string(),
+      data: Joi.string()
+      //TODO add capture and match
+    }),
+    acknowledge: Joi.object({
+      data: Joi.string(),
+      match: Joi.object({
+        json: Joi.any(),
+        value: Joi.string()
       })
-    })
+    }),
+    namespace: Joi.string()
   })
 ];
 

--- a/packages/types/test/engine.socketio.test.ts
+++ b/packages/types/test/engine.socketio.test.ts
@@ -17,6 +17,23 @@ scenarios:
   tap.end();
 });
 
+tap.test('supports emit as an array', (tap) => {
+  tap.same(
+    validateTestScript(`
+scenarios:
+  - engine: socketio
+    flow:
+      - emit:
+          - "myChannel"
+          - "hello"
+          - "world"
+    `),
+    []
+  );
+
+  tap.end();
+});
+
 tap.test('allows general flow properties', (tap) => {
   tap.same(
     validateTestScript(`

--- a/packages/types/test/engine.socketio.test.ts
+++ b/packages/types/test/engine.socketio.test.ts
@@ -52,6 +52,57 @@ scenarios:
   tap.end();
 });
 
+tap.test(
+  'supports response with its options at the same level as emit',
+  (tap) => {
+    tap.same(
+      validateTestScript(`
+scenarios:
+  - engine: socketio
+    flow:
+      - namespace: "myOwnNamespace"
+        emit:
+          channel: myChannel
+          data: Hello world
+        response:
+          channel: "myChannel"
+          data: "hello world"
+          match:
+            json: "$.something"
+            value: "abc"
+    `),
+      []
+    );
+
+    tap.end();
+  }
+);
+
+tap.test(
+  'supports acknowledge with its options at the same level as emit',
+  (tap) => {
+    tap.same(
+      validateTestScript(`
+scenarios:
+  - engine: socketio
+    flow:
+      - namespace: "myOwnNamespace"
+        emit:
+          channel: myChannel
+          data: Hello world
+        acknowledge:
+          data: "hello world"
+          capture:
+            json: "$"
+            as: "myJson"
+    `),
+      []
+    );
+
+    tap.end();
+  }
+);
+
 tap.test('allows general flow properties', (tap) => {
   tap.same(
     validateTestScript(`

--- a/packages/types/test/engine.socketio.test.ts
+++ b/packages/types/test/engine.socketio.test.ts
@@ -34,6 +34,24 @@ scenarios:
   tap.end();
 });
 
+tap.test('supports namespace at same level as emit', (tap) => {
+  tap.same(
+    validateTestScript(`
+scenarios:
+  - engine: socketio
+    flow:
+      - namespace: "myOwnNamespace"
+        emit:
+          - "myChannel"
+          - "hello"
+          - "world"
+    `),
+    []
+  );
+
+  tap.end();
+});
+
 tap.test('allows general flow properties', (tap) => {
   tap.same(
     validateTestScript(`


### PR DESCRIPTION
## Why

Follow up of https://github.com/artilleryio/artillery/pull/2149.

Implements the right schema in our JSON schema to be used by the VS Code extension.