### PR TITLE
feat(memory-inspector): allow memory units to be specified

### DIFF
--- a/packages/artillery-plugin-memory-inspector/README.md
+++ b/packages/artillery-plugin-memory-inspector/README.md
@@ -23,6 +23,10 @@ You can set more than one `pid` to be watched by the plugin, so that you can wat
 
 _Optional_. The name of the process to display in the custom metrics report. It is the name that will show up in the custom metrics, otherwise defaults to `process_${pid}`.
 
+### `unit`
+
+_Optional_. The unit to convert memory metrics to. Accepts `mb`/`megabyte` or `kb`/`kilobyte`. Defaults to `mb` if not specified.
+
 ### Example Usage
 
 ```yaml
@@ -60,3 +64,5 @@ This will emit the following additional metrics from [`process.memoryUsage`](htt
 - artillery_internal.external
 - artillery_internal.heap_total
 - artillery_internal.heap_used
+
+__Note: These extended Artillery metrics cannot have their unit configured and default to using mb as the unit.__

--- a/packages/artillery-plugin-memory-inspector/package.json
+++ b/packages/artillery-plugin-memory-inspector/package.json
@@ -4,7 +4,7 @@
   "description": "Inspect the memory of processes running together with your load tests!",
   "main": "index.js",
   "scripts": {
-    "test": "tap ./test/*.spec.mjs --no-coverage --color --timeout 300"
+    "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap ./test/*.spec.mjs --no-coverage --color --timeout 300"
   },
   "author": "",
   "license": "MPL-2.0",

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -612,7 +612,8 @@ async function sendTelemetry(script, flags, extraProps) {
         'metrics-by-endpoint',
         'hls',
         'fuzzer',
-        'ensure'
+        'ensure',
+        'memory-inspector'
       ];
       for (const p of OFFICIAL_PLUGINS) {
         if (script.config.plugins[p]) {


### PR DESCRIPTION
## Why

Currently, this defaults to bytes, which makes it very hard to read the data. This gives more control over it.

Also sends telemetry data for the plugin, so we can see if there's interest in it.