### PR TITLE
feat(core): add mean to calculated histogram metrics

### DIFF
--- a/packages/artillery/lib/console-reporter.js
+++ b/packages/artillery/lib/console-reporter.js
@@ -408,6 +408,7 @@ function printSummaries(summaries, report) {
     result.push(`${n}:`);
     result.push(padded('  min:', r.min));
     result.push(padded('  max:', r.max));
+    result.push(padded('  mean:', r.mean));
     result.push(padded('  median:', r.median));
     result.push(padded('  p95:', r.p95));
     result.push(padded('  p99:', r.p99));

--- a/packages/core/lib/ssms.js
+++ b/packages/core/lib/ssms.js
@@ -626,6 +626,7 @@ function summarizeHistogram(h) {
     min: round(h.min, 1),
     max: round(h.max, 1),
     count: h.count,
+    mean: round(h.sum/h.count, 1),
     p50: round(h.getValueAtQuantile(0.5), 1),
     median: round(h.getValueAtQuantile(0.5), 1), // Here for compatibility
     p75: round(h.getValueAtQuantile(0.75), 1),


### PR DESCRIPTION
## Why

Some users may be interested in observing the difference between `mean` and other statistics, as we've received as feedback. As we expose a lot of other statistics, we can easily expose this one too.

---

_Open question: should we change `ensure` to include this in the legacy conditions?_