### PR TITLE
fix(socketio): allow emit to be array of strings in validate-script

### DIFF
--- a/packages/artillery/lib/util/validate-script.js
+++ b/packages/artillery/lib/util/validate-script.js
@@ -50,10 +50,13 @@ const httpItems = {
 const socketioItems = {
   emit: Joi.any().when(Joi.ref('....engine'), {
     is: 'socketio',
-    then: Joi.object({
-      channel: Joi.string(),
-      data: Joi.any()
-    }),
+    then: Joi.alternatives(
+      Joi.object({
+        channel: Joi.string(),
+        data: Joi.any()
+      }),
+      Joi.array().items(Joi.string())
+    ),
     otherwise: Joi.any()
   })
 };


### PR DESCRIPTION
## Why

When running this valid `Socketio` interface (since this PR: https://github.com/artilleryio/artillery/pull/1112):

```yaml
flow:
   - emit:
       - "join"
       - "lobby"
```

You would get this error `Scenario validation error: "scenarios[0].flow[0].emit" must be of type object`.

## Testing

Tested with a scenario locally. Automated tests for this will be added as part of another PR, as I'm adding tests for socketio in `artillery` package soon (only exist in `core`, which makes things like this fall through the cracks).