### PR TITLE
fix(schema): allow match joi schema to be an array too

### DIFF
--- a/packages/types/schema/engines/common.js
+++ b/packages/types/schema/engines/common.js
@@ -21,14 +21,19 @@ const JsonCaptureSchema = Joi.object({
   ...SharedCaptureProperties
 }).meta({ title: 'JSON Capture' });
 
-const MatchSchema = Joi.object({
-  json: Joi.any()
+const MatchSchemaObject = Joi.object({
+  json: Joi.string()
     .meta({ title: 'JSON' })
     .description('The part of the response to compare.'),
   value: Joi.string()
     .meta({ title: 'Value' })
     .description('The expected value.')
-}).meta({ title: 'Match' });
+});
+
+const MatchSchema = Joi.alternatives(
+  MatchSchemaObject,
+  Joi.array().items(MatchSchemaObject)
+).meta({ title: 'Match' });
 
 const BaseFlowItemAlternatives = [
   Joi.object({


### PR DESCRIPTION
## Why

Small fix as you can do:

```yaml
          match:
            - json: "$.0"
              value: "something"
            - json: "$.1"
              value: "Hello!"
```

And this was being detected as invalid by the VS Code extension.