### PR TITLE
feat(socketio): add args+on for event validation of any amount of args

### DIFF
--- a/packages/core/lib/engine_socketio.js
+++ b/packages/core/lib/engine_socketio.js
@@ -52,7 +52,9 @@ function markEndTime(ee, _, startedAt) {
 }
 
 function isResponseRequired(spec) {
-  return spec.emit && spec.response && spec.response.channel;
+  return (
+    spec.emit && spec.response && (spec.response.channel || spec.response.on)
+  );
 }
 
 function isAcknowledgeRequired(spec) {
@@ -60,8 +62,15 @@ function isAcknowledgeRequired(spec) {
 }
 
 function processResponse(ee, data, response, context, callback) {
+  function isValid() {
+    if (!Array.isArray(response.data)) {
+      return deepEqual(data[0], response.data);
+    }
+
+    return deepEqual(data, response.data);
+  }
   // Do we have supplied data to validate?
-  if (response.data && !deepEqual(data, response.data)) {
+  if (response.data && !isValid()) {
     debug('data is not valid:');
     debug(data);
     debug(response);
@@ -186,9 +195,12 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       }
 
       if (isAcknowledgeRequired(requestSpec)) {
-        const ackCallback = function () {
+        const ackCallback = function (...args) {
           const response = {
-            data: template(requestSpec.acknowledge.data, context),
+            data: template(
+              requestSpec.acknowledge.data || requestSpec.acknowledge.args,
+              context
+            ),
             capture: template(requestSpec.acknowledge.capture, context),
             match: template(requestSpec.acknowledge.match, context)
           };
@@ -198,8 +210,9 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
               r.json = '$.0'; // Default to the first callback argument
             }
           });
+
           // Acknowledge data can take up multiple arguments of the emit callback
-          processResponse(ee, arguments, response, context, function (err) {
+          processResponse(ee, args, response, context, function (err) {
             if (!err) {
               markEndTime(ee, context, startedAt);
             }
@@ -225,8 +238,14 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
 
     if (isResponseRequired(requestSpec)) {
       const response = {
-        channel: template(requestSpec.response.channel, context),
-        data: template(requestSpec.response.data, context),
+        channel: template(
+          requestSpec.response.channel || requestSpec.response.on,
+          context
+        ),
+        data: template(
+          requestSpec.response.data || requestSpec.response.args,
+          context
+        ),
         capture: template(requestSpec.response.capture, context),
         match: template(requestSpec.response.match, context)
       };
@@ -234,9 +253,9 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       // Listen for the socket.io response on the specified channel
       let done = false;
 
-      socketio.on(response.channel, function receive(data) {
+      socketio.on(response.channel, function receive(...args) {
         done = true;
-        processResponse(ee, data, response, context, function (err) {
+        processResponse(ee, args, response, context, function (err) {
           if (!err) {
             markEndTime(ee, context, startedAt);
           }

--- a/packages/core/lib/engine_socketio.js
+++ b/packages/core/lib/engine_socketio.js
@@ -62,15 +62,20 @@ function isAcknowledgeRequired(spec) {
 }
 
 function processResponse(ee, data, response, context, callback) {
-  function isValid() {
+  function isValid(data, response) {
     if (!Array.isArray(response.data)) {
-      return deepEqual(data[0], response.data);
+      //`json` key is added at some point to the response.data object, to use with `captureOrMatch` function
+      //we should omit it when comparing the response to the data
+      const responseDataWithoutJson = _.isObject(response.data)
+        ? _.omit(response.data, 'json')
+        : response.data;
+      return deepEqual(data[0], responseDataWithoutJson);
     }
 
     return deepEqual(data, response.data);
   }
   // Do we have supplied data to validate?
-  if (response.data && !isValid()) {
+  if (response.data && !isValid(data, response)) {
     debug('data is not valid:');
     debug(data);
     debug(response);

--- a/packages/core/test/core/run.sh
+++ b/packages/core/test/core/run.sh
@@ -8,6 +8,7 @@ SILENT=true node $DIR/targets/simple.js &
 node $DIR/targets/simple_ws.js &
 node $DIR/targets/simple_socketio.js &
 node $DIR/targets/express_socketio.js &
+node $DIR/targets/socketio_args.js &
 node $DIR/targets/ws_tls.js &
 node $DIR/targets/ws_proxy.js &
 
@@ -16,6 +17,7 @@ cleanup() {
     kill $(ps aux|grep simple_ws.js|grep node|awk '{print $2}') || true
     kill $(ps aux|grep simple_socketio.js|grep node|awk '{print $2}') || true
     kill $(ps aux|grep express_socketio.js|grep node|awk '{print $2}') || true
+    kill $(ps aux|grep socketio_args.js|grep node|awk '{print $2}') || true
     kill $(ps aux|grep ws_tls.js|grep node|awk '{print $2}') || true
     kill $(ps aux|grep ws_proxy.js|grep node|awk '{print $2}') || true
 }

--- a/packages/core/test/core/scripts/hello_socketio_with_args.json
+++ b/packages/core/test/core/scripts/hello_socketio_with_args.json
@@ -1,0 +1,40 @@
+{
+  "config": {
+    "target": "http://127.0.0.1:9096",
+    "tls": {
+      "rejectUnauthorized": true
+    },
+    "phases": [{ "duration": 1, "arrivalRate": 1 }]
+  },
+  "scenarios": [
+    {
+      "engine": "socketio",
+      "flow": [
+        {
+          "emit": ["join", "chat_room_1"],
+          "response": {
+            "on": "new_user_join",
+            "args": ["Welcome to chat_room_1"]
+          }
+        },
+        {
+          "emit": ["message", "chat_room_1", "I", "am", "a test runner!"],
+          "response": {
+            "on": "message_response",
+            "args": ["chat_room_1", "I", "am", "a test runner!"],
+            "match": [
+              { "json": "$.0", "value": "chat_room_1" },
+              { "json": "$.3", "value": "a test runner!" }
+            ]
+          }
+        },
+        {
+          "emit": ["new_server_version", "version", "1.2.4"],
+          "acknowledge": {
+            "args": ["version", "1.2.4"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/core/scripts/hello_socketio_with_args.json
+++ b/packages/core/test/core/scripts/hello_socketio_with_args.json
@@ -33,6 +33,14 @@
           "acknowledge": {
             "args": ["version", "1.2.4"]
           }
+        },
+        {
+          "emit": ["new_server_version_as_object", "1.2.4"],
+          "acknowledge": {
+            "args": {
+              "version": "1.2.4"
+            }
+          }
         }
       ]
     }

--- a/packages/core/test/core/targets/socketio_args.js
+++ b/packages/core/test/core/targets/socketio_args.js
@@ -20,6 +20,12 @@ io.on('connection', function (socket) {
   socket.on('new_server_version', (message1, message2, callback) => {
     callback(message1, message2);
   });
+
+  socket.on('new_server_version_as_object', (message1, callback) => {
+    callback({
+      version: message1
+    });
+  });
 });
 
 function handler(req, res) {

--- a/packages/core/test/core/targets/socketio_args.js
+++ b/packages/core/test/core/targets/socketio_args.js
@@ -1,0 +1,28 @@
+const httpServer = require('http').createServer(handler);
+const io = require('socket.io')(httpServer);
+const PORT = 9096;
+httpServer.listen(PORT, function () {
+  console.log('Socket.io Args Server listening on %s', PORT);
+});
+
+io.on('connection', function (socket) {
+  socket.on('join', (channel) => {
+    socket.join(channel);
+    socket.emit('new_user_join', `Welcome to ${channel}`);
+  });
+
+  socket.on('message', (channel, ...message) => {
+    console.log(channel);
+    console.log(message);
+    io.in(channel).emit('message_response', channel, ...message);
+  });
+
+  socket.on('new_server_version', (message1, message2, callback) => {
+    callback(message1, message2);
+  });
+});
+
+function handler(req, res) {
+  res.writeHead(404);
+  res.end('No http pages here');
+}

--- a/packages/core/test/core/test_misc.js
+++ b/packages/core/test/core/test_misc.js
@@ -9,6 +9,7 @@ var SCRIPTS = [
   'hello.json',
   'hello_ws.json',
   'hello_socketio.json',
+  'hello_socketio_with_args.json',
   'express_socketio.json',
   'multiple_phases.json',
   'large_payload.json',

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -33,12 +33,18 @@ const BaseWithSocketio = [
         'Supports emitting action as an array, or by providing channel and data.\nMore information: https://www.artillery.io/docs/reference/engines/socketio#scenario-actions-and-configuration'
       ),
     response: Joi.object({
+      on: Joi.string()
+        .meta({ title: 'Event Name' })
+        .description('The name of the event to listen to.'),
       channel: Joi.string()
         .meta({ title: 'Channel' })
         .description('The name of the channel where the response is received.'),
       data: SocketioDataSchema.meta({ title: 'Data' }).description(
         'The data to verify is in the response.'
       ),
+      args: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+        .meta({ title: 'Response Arguments' })
+        .description('Assert that the response emits these arguments.'),
       match: MatchSchema.meta({ title: 'Match' }).description(
         'Match the response exactly to the value provided.'
       ),
@@ -48,6 +54,11 @@ const BaseWithSocketio = [
       data: SocketioDataSchema.meta({ title: 'Data' }).description(
         'The data to verify is in the acknowledge.'
       ),
+      args: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+        .meta({ title: 'Acknowledge Arguments' })
+        .description(
+          'Assert that the acknowledge callback was sent with these arguments.'
+        ),
       match: MatchSchema.meta({ title: 'Match' }).description(
         'Match the response exactly to the value provided.'
       ),

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -5,7 +5,11 @@ const Joi = require('joi').defaults((schema) =>
 const { LoopOptions, MatchSchema, JsonCaptureSchema } = require('./common');
 const { BaseWithHttp } = require('./http');
 
-const SocketioDataSchema = Joi.alternatives(Joi.string(), Joi.object());
+const SocketioDataSchema = Joi.alternatives(
+  Joi.string(),
+  Joi.object(),
+  Joi.array().items(Joi.string())
+);
 
 const BaseWithSocketio = [
   ...BaseWithHttp,
@@ -42,7 +46,11 @@ const BaseWithSocketio = [
       data: SocketioDataSchema.meta({ title: 'Data' }).description(
         'The data to verify is in the response.'
       ),
-      args: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+      args: Joi.alternatives(
+        Joi.string(),
+        Joi.object(),
+        Joi.array().items(Joi.string())
+      )
         .meta({ title: 'Response Arguments' })
         .description('Assert that the response emits these arguments.'),
       match: MatchSchema.meta({ title: 'Match' }).description(
@@ -54,7 +62,11 @@ const BaseWithSocketio = [
       data: SocketioDataSchema.meta({ title: 'Data' }).description(
         'The data to verify is in the acknowledge.'
       ),
-      args: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string()))
+      args: Joi.alternatives(
+        Joi.string(),
+        Joi.object(),
+        Joi.array().items(Joi.string())
+      )
         .meta({ title: 'Acknowledge Arguments' })
         .description(
           'Assert that the acknowledge callback was sent with these arguments.'


### PR DESCRIPTION
## Description

A porting of the popular (and really good) third-party engine (https://github.com/ptejada/artillery-engine-socketio-v3) to Artillery Core was done back in July 2021 in https://github.com/artilleryio/artillery/pull/1112.

However, shortly after that, updates were done to the engine that were never ported over to Artillery, which left the job incomplete. This update in particular makes a lot of sense, because it gives support for multiple arguments to be easily asserted on, which is something that can be done when emitting SocketIO events.

Essentially, it gives the ability to do things like:

```yaml
      - emit: ["message", "chat_room_1", "Hey there!"]
        response:
          on: message
          args:
            - chat_room_1
            - Hey there!
```

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [] Does this require an update to the docs? _**Yes**_
- [] Does this require a changelog entry? _**Yes**_