### PR TITLE
feat(playwright): add step transaction function to user context for custom metrics

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -196,7 +196,7 @@ class PlaywrightEngine {
           self.processor[spec.flowFunction];
 
         initialContext.funcs.step = step;
-        await fn(page, contextWithAdditionalFuncs, events);
+        await fn(page, initialContext, events);
 
         await page.close();
 

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -195,13 +195,7 @@ class PlaywrightEngine {
           self.processor[spec.testFunction] ||
           self.processor[spec.flowFunction];
 
-        const contextWithAdditionalFuncs = {
-          ...initialContext,
-          funcs: {
-            ...initialContext.funcs,
-            step
-          }
-        };
+        initialContext.funcs.step = step;
         await fn(page, contextWithAdditionalFuncs, events);
 
         await page.close();

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -82,7 +82,7 @@ class PlaywrightEngine {
                   name: metric.name,
                   value: metric.value,
                   metric: metric,
-                  url: window.location.href // eslint-disable-line
+                  url: window.location.href // eslint-disable-line  no-undef
                 })
               );
             });
@@ -100,7 +100,7 @@ class PlaywrightEngine {
 
           try {
             const performanceTimingJson = await page.evaluate(
-              () => JSON.stringify(window.performance.timing) // eslint-disable-line
+              () => JSON.stringify(window.performance.timing) // eslint-disable-line  no-undef
             );
             const performanceTiming = JSON.parse(performanceTimingJson);
 
@@ -170,7 +170,7 @@ class PlaywrightEngine {
             const { usedJSHeapSize } = JSON.parse(
               await page.evaluate(() =>
                 JSON.stringify({
-                  usedJSHeapSize: window.performance.memory.usedJSHeapSize // eslint-disable-line
+                  usedJSHeapSize: window.performance.memory.usedJSHeapSize // eslint-disable-line  no-undef
                 })
               )
             );
@@ -195,7 +195,6 @@ class PlaywrightEngine {
           self.processor[spec.testFunction] ||
           self.processor[spec.flowFunction];
 
-        //we inject a test object to allow certain playwright-like functions to be used. only step allowed right now.
         const test = { step };
 
         await fn(page, initialContext, events, test);

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -195,8 +195,10 @@ class PlaywrightEngine {
           self.processor[spec.testFunction] ||
           self.processor[spec.flowFunction];
 
-        initialContext.funcs.step = step;
-        await fn(page, initialContext, events);
+        //we inject a test object to allow certain playwright-like functions to be used. only step allowed right now.
+        const test = { step };
+
+        await fn(page, initialContext, events, test);
 
         await page.close();
 


### PR DESCRIPTION
## What

Gives users an abstraction to facilitate breaking their Playwright scenario into a series of steps and capture transaction timers for each of them, with an API that should be familiar to Playwright users.

### Example (based on real user scenario)
```js
async function loginSearchAndLogout(page, userContext, events, test) {
   //1. simply add this line to your scenario function, or use test.step below instead
  const { step } = test;
  const userid = userContext.vars.userid;
  const recordid = userContext.vars.recordid;

  //2. wrap any logic you have in steps 
  //(sometimes you might already have something like this done from existing playwright tests)
  await step("landing_page", async () => {
    await page.goto('https://internaltesturl.com/landing');
    await page.getByLabel('id-label').fill( `${userid}` );
    await page.getByLabel('Password').fill(`${password}`);
  })

  await step("submit_login", async () => {
    await page.getByRole('button', { name: 'Submit' }).click();
    await page.getByPlaceholder('enter request id').fill(`${recordid}`);
  })

  await step("search_record", async () => {
    await page.getByRole('button', { name: 'Go' }).click();
    await page.locator('css=button.avatar-button').click();
  })

  await step("logout", async () => {
    await page.getByText('Logout').click();
  })
}
```

This will leverage Artillery's custom metrics to create metrics that look like this:
```
browser.step.landing_page:
  min: ......................................................................... 87
  max: ......................................................................... 150
  median: ...................................................................... 89.1
  p95: ......................................................................... 89.1
  p99: ......................................................................... 89.1
browser.step.submit_login:
  min: ......................................................................... 300
  max: ......................................................................... 716
  median: ...................................................................... 561.2
  p95: ......................................................................... 561.2
  p99: ......................................................................... 561.2
browser.step.search_record:
  min: ......................................................................... 287
  max: ......................................................................... 801
  median: ...................................................................... 290.1
  p95: ......................................................................... 290.1
  p99: ......................................................................... 290.1
browser.step.logout:
  min: ......................................................................... 52
  max: ......................................................................... 334
  median: ...................................................................... 140.2
  p95: ......................................................................... 200.4
  p99: ......................................................................... 200.4
```

- Web vital metrics give you a single pane of glass look into performance of individual pages.
- Steps give you control to break it down into the transactions you care about and analyse their performance over time.

## Why

This pattern was already present in the examples, and recently there was demand for it. After abstracting it into a utility function (https://github.com/artilleryio/artillery/issues/2147#issuecomment-1729259684 and https://github.com/artilleryio/artillery/discussions/2164#discussioncomment-7102210), and the received feedback, it became obvious that users could benefit from this.

## Testing

Tested against the examples (which will be updated once this is released into the next version).