### PR TITLE
fix(ensure): improve handling of metric names with special chars

### DIFF
--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "tap ./test/*.spec.js --timeout 300 --no-coverage --color"
+    "test:unit": "tap ./test/*.unit.js --timeout 300 --no-coverage --color",
+    "test:acceptance": "tap ./test/*.spec.js --timeout 300 --no-coverage --color",
+    "test": "npm run test:unit && npm run test:acceptance"
   },
   "keywords": [],
   "author": "Artillery.io <team@artillery.io>",

--- a/packages/artillery-plugin-ensure/test/fixtures/processor.js
+++ b/packages/artillery-plugin-ensure/test/fixtures/processor.js
@@ -9,7 +9,7 @@ function runFibonacci(req, context, ee, next) {
   const difference = Date.now() - time;
   ee.emit(
     'histogram',
-    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-',
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-',
     difference
   );
   next();

--- a/packages/artillery-plugin-ensure/test/fixtures/processor.js
+++ b/packages/artillery-plugin-ensure/test/fixtures/processor.js
@@ -1,0 +1,20 @@
+function runFibonacci(req, context, ee, next) {
+  function fibonacci(num) {
+    if (num == 1) return 0;
+    if (num == 2) return 1;
+    return fibonacci(num - 1) + fibonacci(num - 2);
+  }
+  const time = Date.now();
+  fibonacci(35);
+  const difference = Date.now() - time;
+  ee.emit(
+    'histogram',
+    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-',
+    difference
+  );
+  next();
+}
+
+module.exports = {
+  runFibonacci
+};

--- a/packages/artillery-plugin-ensure/test/fixtures/scenario-custom-metrics.yml
+++ b/packages/artillery-plugin-ensure/test/fixtures/scenario-custom-metrics.yml
@@ -1,0 +1,14 @@
+config:
+  target: "http://asciiart.artillery.io:8080"
+  phases:
+    - duration: 2
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: processor.js
+
+scenarios:
+  - name: ensurePluginTestWithCustomMetrics
+    flow:
+      - get:
+          beforeRequest: runFibonacci
+          url: "/"

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -326,16 +326,16 @@ test('checks are grouped in the correct order (ok first, fail after)', async (t)
 test('works with custom metrics including weird characters like urls', async (t) => {
   //Arrange: Plugin overrides
   const failingExpression =
-    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.min < 1 and vusers.created == 2';
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.min < 1 and vusers.created == 2';
   const passingExpression =
-    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 20 or browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.max < 200';
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 20 or browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.max < 200';
   const override = JSON.stringify({
     config: {
       plugins: { ensure: {} },
       ensure: {
         thresholds: [
           {
-            'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 100
+            'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 100
           }
         ],
         conditions: [
@@ -357,9 +357,9 @@ test('works with custom metrics including weird characters like urls', async (t)
       output.stdout.includes(
         `${chalk.green(
           'ok'
-        )}: browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 100`
+        )}: browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 100`
       ),
-      'Console did not include browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
+      'Console did not include browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
     );
     t.ok(
       output.stdout.includes(`${chalk.red('fail')}: ${failingExpression}`),

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -31,7 +31,9 @@ test('works with multiple thresholds set', async (t) => {
     'Console did not include vusers.created check'
   );
   t.ok(
-    output.stdout.includes(`${chalk.green('ok')}: http.response_time.p99 < 10000`),
+    output.stdout.includes(
+      `${chalk.green('ok')}: http.response_time.p99 < 10000`
+    ),
     'Console did not include http.response_time.p99 check'
   );
 });
@@ -62,7 +64,9 @@ test('works with config under config.plugins.ensure instead', async (t) => {
     'Console did not include vusers.created check'
   );
   t.ok(
-    output.stdout.includes(`${chalk.green('ok')}: http.response_time.p99 < 10000`),
+    output.stdout.includes(
+      `${chalk.green('ok')}: http.response_time.p99 < 10000`
+    ),
     'Console did not include http.response_time.p99 check'
   );
 });
@@ -90,7 +94,9 @@ test('fails thresholds correctly', async (t) => {
       'Console did not include vusers.created check'
     );
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p99 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p99 < 1`
+      ),
       'Console did not include http.response_time.p99 failed check'
     );
   }
@@ -151,7 +157,9 @@ test('passes and fails correctly multiple conditions and thresholds', async (t) 
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p99 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p99 < 1`
+      ),
       'Console did not include http.response_time.p99 threshold check'
     );
     t.ok(
@@ -190,7 +198,9 @@ test('strict set to false correctly does not fail conditions', async (t) => {
   t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
 
   t.ok(
-    output.stdout.includes(`${chalk.red('fail')}: ${failingExpression} (optional)`),
+    output.stdout.includes(
+      `${chalk.red('fail')}: ${failingExpression} (optional)`
+    ),
     'Console did not include failing expression check with optional from strict'
   );
   t.ok(
@@ -224,7 +234,9 @@ test('works with legacy thresholds (passing and failing) together with new thres
       'Console did not p99 check'
     );
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p95 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p95 < 1`
+      ),
       'Console did not include p95 check'
     );
     t.ok(
@@ -280,22 +292,82 @@ test('checks are grouped in the correct order (ok first, fail after)', async (t)
   } catch (output) {
     const startIndex = output.stdout.indexOf('Checks:');
     // Get the relevant logs (the first 4 lines after the Checks: line)
-    const relevantLogs = output.stdout.slice(startIndex).split('\n').slice(1, 5)
+    const relevantLogs = output.stdout
+      .slice(startIndex)
+      .split('\n')
+      .slice(1, 5);
 
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
-    t.ok(relevantLogs[0] == `${chalk.green('ok')}: maxErrorRate < 0` || relevantLogs[0] == `${chalk.green('ok')}: p99 < 10000`,
+    t.ok(
+      relevantLogs[0] == `${chalk.green('ok')}: maxErrorRate < 0` ||
+        relevantLogs[0] == `${chalk.green('ok')}: p99 < 10000`,
       'First check should be a passed expectation'
     );
-    t.ok(relevantLogs[1] == `${chalk.green('ok')}: maxErrorRate < 0` || relevantLogs[1] == `${chalk.green('ok')}: p99 < 10000`,
+    t.ok(
+      relevantLogs[1] == `${chalk.green('ok')}: maxErrorRate < 0` ||
+        relevantLogs[1] == `${chalk.green('ok')}: p99 < 10000`,
       'Second check should be a passed expectation'
     );
-    t.ok(relevantLogs[2] == `${chalk.red('fail')}: max < 1` || relevantLogs[2] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
+    t.ok(
+      relevantLogs[2] == `${chalk.red('fail')}: max < 1` ||
+        relevantLogs[2] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
       'Third check should be a failed expectation'
     );
-    t.ok(relevantLogs[3] == `${chalk.red('fail')}: max < 1` || relevantLogs[3] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
+    t.ok(
+      relevantLogs[3] == `${chalk.red('fail')}: max < 1` ||
+        relevantLogs[3] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
       'Fourth check should be a failed expectation'
+    );
+  }
+});
+
+test('works with custom metrics including weird characters like urls', async (t) => {
+  //Arrange: Plugin overrides
+  const failingExpression =
+    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.min < 1 and vusers.created == 2';
+  const passingExpression =
+    'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 20 or browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.max < 200';
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [
+          {
+            'browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 100
+          }
+        ],
+        conditions: [
+          { expression: failingExpression },
+          { expression: passingExpression }
+        ]
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario-custom-metrics.yml --overrides ${override}`;
+  } catch (output) {
+    //Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+    t.ok(
+      output.stdout.includes(
+        `${chalk.green(
+          'ok'
+        )}: browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 100`
+      ),
+      'Console did not include browser.page.browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
+    );
+    t.ok(
+      output.stdout.includes(`${chalk.red('fail')}: ${failingExpression}`),
+      'Console did not include failing expression check'
+    );
+    t.ok(
+      output.stdout.includes(`${chalk.green('ok')}: ${passingExpression}`),
+      'Console did not include passing expression check'
     );
   }
 });

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -328,14 +328,14 @@ test('works with custom metrics including weird characters like urls', async (t)
   const failingExpression =
     'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.min < 1 and vusers.created == 2';
   const passingExpression =
-    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 20 or browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.max < 200';
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 20 or browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.max < 2000';
   const override = JSON.stringify({
     config: {
       plugins: { ensure: {} },
       ensure: {
         thresholds: [
           {
-            'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 100
+            'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 1000
           }
         ],
         conditions: [
@@ -357,7 +357,7 @@ test('works with custom metrics including weird characters like urls', async (t)
       output.stdout.includes(
         `${chalk.green(
           'ok'
-        )}: browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 100`
+        )}: browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 1000`
       ),
       'Console did not include browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
     );

--- a/packages/artillery-plugin-ensure/test/utils.unit.js
+++ b/packages/artillery-plugin-ensure/test/utils.unit.js
@@ -1,0 +1,113 @@
+const { test } = require('tap');
+const { returnExpressionWithHashes, hashString } = require('../utils');
+
+test('works with boolean operators', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'someMetricB';
+  const originalExpression = `${metricA} < 20 and ${metricB} < 30`;
+  const modifiedExpression = `'${hashString(metricA)}' < 20 and '${hashString(
+    metricB
+  )}' < 30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with built-in functions', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'someMetricB';
+  const originalExpression = `ceil(${metricA}) < 20 or random(${metricB}) == 30`;
+  const modifiedExpression = `ceil('${hashString(
+    metricA
+  )}') < 20 or random('${hashString(metricB)}') == 30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with boolean operators without spaces', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'someMetricB';
+  const originalExpression = `${metricA}<20 and ${metricB}<30`;
+  const modifiedExpression = `'${hashString(metricA)}'<20 and '${hashString(
+    metricB
+  )}'<30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with ternary boolean operator', async (t) => {
+  const metricA = 'someMetricA';
+  const originalExpression = `${metricA}<20 ? 30 : 40`;
+  const modifiedExpression = `'${hashString(metricA)}'<20 ? 30 : 40`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with explicit operator precedence (parentheses) with spaces', async (t) => {
+  const metricA = 'vusers.created';
+  const metricB = 'vusers.completed';
+  const metricC = 'vusers.created';
+  const metricD = 'vusers.skipped';
+  const metricE = 'http.request_rate';
+  const originalExpression = `( ( ( ${metricA} - ${metricB}) / floor(${metricC}) * 100 ) + ${metricD} ) <= 0 or ${metricE} > 0`;
+  const modifiedExpression = `( ( ( '${hashString(metricA)}' - '${hashString(
+    metricB
+  )}') / floor('${hashString(metricC)}') * 100 ) + '${hashString(
+    metricD
+  )}' ) <= 0 or '${hashString(metricE)}' > 0`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with explicit operator precedence (parentheses) without spaces', async (t) => {
+  const metricA = 'vusers.created';
+  const metricB = 'vusers.completed';
+  const metricC = 'vusers.created';
+  const metricD = 'vusers.skipped';
+  const metricE = 'http.request_rate';
+  const originalExpression = `(((${metricA}-${metricB})/floor(${metricC})*100)+${metricD})<= 0 or ${metricE}>0`;
+  const modifiedExpression = `((('${hashString(metricA)}'-'${hashString(
+    metricB
+  )}')/floor('${hashString(metricC)}')*100)+'${hashString(
+    metricD
+  )}')<= 0 or '${hashString(metricE)}'>0`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with complex url expressions', async (t) => {
+  const metricA = 'browser.page.FCP.https://www.artillery.io/abc.p99';
+  const metricB = 'browser.page.TTFB.https://www.artillery.io/docs.min';
+  const originalExpression = `${metricA} < 20 and ${metricB} < 30`;
+  const modifiedExpression = `'${hashString(metricA)}' < 20 and '${hashString(
+    metricB
+  )}' < 30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with space in name', async (t) => {
+  const metricA = 'vusers.created_by_name.Scenario with some space';
+  const metricB = 'vusers.created_by_name.Other named scenario';
+  const originalExpression = `${metricA} /${metricB} > 20 or ${metricB}>= 30`;
+  const modifiedExpression = `'${hashString(metricA)}' /'${hashString(
+    metricB
+  )}' > 20 or '${hashString(metricB)}'>= 30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});

--- a/packages/artillery-plugin-ensure/test/utils.unit.js
+++ b/packages/artillery-plugin-ensure/test/utils.unit.js
@@ -14,13 +14,13 @@ test('works with boolean operators', async (t) => {
   t.equal(result, modifiedExpression);
 });
 
-test('works with built-in functions', async (t) => {
+test('works with built-in functions, even if a metric name includes it', async (t) => {
   const metricA = 'someMetricA';
-  const metricB = 'someMetricB';
-  const originalExpression = `ceil(${metricA}) < 20 or random(${metricB}) == 30`;
-  const modifiedExpression = `ceil('${hashString(
+  const metricB = 'vusers.random.ceil';
+  const originalExpression = `(ceil(${metricA}) < 20) or random(${metricB}) == 30`;
+  const modifiedExpression = `(ceil('${hashString(
     metricA
-  )}') < 20 or random('${hashString(metricB)}') == 30`;
+  )}') < 20) or random('${hashString(metricB)}') == 30`;
 
   const result = returnExpressionWithHashes(originalExpression);
 
@@ -106,6 +106,23 @@ test('works with space in name', async (t) => {
   const modifiedExpression = `'${hashString(metricA)}' /'${hashString(
     metricB
   )}' > 20 or '${hashString(metricB)}'>= 30`;
+
+  const result = returnExpressionWithHashes(originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works when metric names include special named operators and we use those special operators', async (t) => {
+  const metricA = 'vusers.created_by_name.andy'; //relevant because andy includes "and" in the name
+  const metricB = 'vusers.created_by_name.nottinghill'; //relevant because nottinghill includes "not" in the name
+  const metricC = 'custom.orders'; //relevant because orders includes "or" in the name
+
+  const originalExpression = `(not ${metricA} < 100 and not ${metricB} < 100) or ${metricC} >= 300`;
+  const modifiedExpression = `(not '${hashString(
+    metricA
+  )}' < 100 and not '${hashString(metricB)}' < 100) or '${hashString(
+    metricC
+  )}' >= 300`;
 
   const result = returnExpressionWithHashes(originalExpression);
 

--- a/packages/artillery-plugin-ensure/utils.js
+++ b/packages/artillery-plugin-ensure/utils.js
@@ -1,16 +1,18 @@
 const crypto = require('crypto');
+const debug = require('debug')('plugin:ensure');
 
 const numericOperators = ['+', '-', '*', '/', '%', '^'];
 const comparisonOperators = ['==', '<=', '>=', '<', '>'];
-const booleanOperators = ['or', 'and', 'not', '?', ':', '(', ')'];
+const booleanOperators = ['?', ':', '(', ')'];
 const builtInFunctions = ['ceil', 'floor', 'random', 'round'];
+//these are boolean operators, but have to be treated specially because they can appear in words
+const specialTextOperators = ['or', 'and', 'not'];
 
 // List of known operators
-const operators = [
+const baseOperators = [
   ...numericOperators,
   ...comparisonOperators,
-  ...booleanOperators,
-  ...builtInFunctions
+  ...booleanOperators
 ];
 
 const hashString = (str) => {
@@ -21,30 +23,48 @@ const hashString = (str) => {
 
 const getOperatorRegularExp = () => {
   // Escape any characters that have special meaning in regex
-  const escapedOperators = operators.map((char) =>
+  const escapedOperators = baseOperators.map((char) =>
     ['+', '*', '.', '(', ')', '[', ']', '{', '}', '|', '\\', '?'].includes(char)
       ? `\\${char}`
       : char
   );
   // Join the array into a string, with each character separated by a pipe (|)
   const operatorsPattern = escapedOperators.join('|');
+  //check for special operators being enclosed in word boundaries
+  const specialOperatorsPattern = '\\band\\b|\\bor\\b|\\bnot\\b';
 
-  // Now create a new RegExp object
-  return new RegExp(`(${operatorsPattern})`);
+  // Now create a new RegExp object, with the special operators first as order matters
+  return RegExp(`(${specialOperatorsPattern}|${operatorsPattern})`);
 };
 
 const returnMetricNamesAfterFilters = (expression) => {
   const operatorPattern = getOperatorRegularExp();
 
-  let tokens = expression.split(operatorPattern);
+  //split by function calls regex first in case of built-in functions (e.g. ceil, floor, etc)
+  let tokens = expression.split(/(\w+)\(([^)]+)\)/g);
 
+  //split further by the remaining operators, and flatten the array
+  tokens = tokens.flatMap((part) => {
+    return part.split(operatorPattern);
+  });
+
+  //filter our undefineds and empty strings
   tokens = tokens.filter(Boolean);
 
+  //trim empty spaces from tokens (e.g. " 20")
   tokens = tokens.map((token) => token.trim());
 
+  //filter out the operators included in the tokens, now including the specially handled operators, as well as numbers.
+  //everything remaining should be metric names
   tokens = tokens.filter(Boolean).filter((el) => {
     //exclude operators and numbers, and the remaining should be metric names
-    return !operators.includes(el) && isNaN(el);
+    return (
+      ![
+        ...baseOperators,
+        ...specialTextOperators,
+        ...builtInFunctions
+      ].includes(el) && isNaN(el)
+    );
   });
 
   return tokens;
@@ -80,6 +100,7 @@ function getMetricNames(expression) {
   }
 
   const metricNames = returnMetricNamesAfterFilters(tmpExpression);
+  debug(`Parsed Metric Names: ${JSON.stringify(metricNames)}`);
 
   return { metricNames, urlPlaceholders };
 }

--- a/packages/artillery-plugin-ensure/utils.js
+++ b/packages/artillery-plugin-ensure/utils.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
 const numericOperators = ['+', '-', '*', '/', '%', '^'];
-const comparisonOperators = ['==', '<', '<=', '>', '>='];
+const comparisonOperators = ['==', '<=', '>=', '<', '>'];
 const booleanOperators = ['or', 'and', 'not', '?', ':', '(', ')'];
 const builtInFunctions = ['ceil', 'floor', 'random', 'round'];
 
@@ -13,42 +13,91 @@ const operators = [
   ...builtInFunctions
 ];
 
-function hashString(str) {
+const hashString = (str) => {
   const hash = crypto.createHash('sha256'); // sha256 is a good choice for uniqueness and speed
   hash.update(str);
   return hash.digest('hex'); // returns the hash as a string of hexadecimal numbers
+};
+
+const getOperatorRegularExp = () => {
+  // Escape any characters that have special meaning in regex
+  const escapedOperators = operators.map((char) =>
+    ['+', '*', '.', '(', ')', '[', ']', '{', '}', '|', '\\', '?'].includes(char)
+      ? `\\${char}`
+      : char
+  );
+  // Join the array into a string, with each character separated by a pipe (|)
+  const operatorsPattern = escapedOperators.join('|');
+
+  // Now create a new RegExp object
+  return new RegExp(`(${operatorsPattern})`);
+};
+
+const returnMetricNamesAfterFilters = (expression) => {
+  const operatorPattern = getOperatorRegularExp();
+
+  let tokens = expression.split(operatorPattern);
+
+  tokens = tokens.filter(Boolean);
+
+  tokens = tokens.map((token) => token.trim());
+
+  tokens = tokens.filter(Boolean).filter((el) => {
+    //exclude operators and numbers, and the remaining should be metric names
+    return !operators.includes(el) && isNaN(el);
+  });
+
+  return tokens;
+};
+
+function getMetricNames(expression) {
+  let tmpExpression = expression;
+
+  // Treat URLs as a special case
+  const urlPlaceholders = {};
+  const urlPattern = /(\w+:\/\/[^\s]+)/g;
+  tmpExpression.match(urlPattern)?.forEach((match) => {
+    const replacementString = `URL_PLACEHOLDER_${
+      Object.keys(urlPlaceholders).length
+    }`;
+    tmpExpression = tmpExpression.replaceAll(match, replacementString);
+    urlPlaceholders[replacementString] = match;
+  });
+
+  // Treat ternary operator as a special case
+  const ternaryPattern = /(.*?)\?(.*?):(.*)/;
+  const ternaryMatch = tmpExpression.match(ternaryPattern);
+  if (ternaryMatch) {
+    return {
+      metricNames: [
+        //if ternary is found, we call the filter function on each of the filtered parts of the ternary
+        ...returnMetricNamesAfterFilters(ternaryMatch[1]),
+        ...returnMetricNamesAfterFilters(ternaryMatch[2]),
+        ...returnMetricNamesAfterFilters(ternaryMatch[3])
+      ],
+      urlPlaceholders
+    };
+  }
+
+  const metricNames = returnMetricNamesAfterFilters(tmpExpression);
+  console.log(metricNames);
+
+  return { metricNames, urlPlaceholders };
 }
 
 function returnExpressionWithHashes(expression) {
-  let metricNames = expression
-    //1. split by spaces first to divide into chunks
-    .split(/\s+/)
-    .filter(Boolean)
-    //2. check for potential builtInFunction usage and flatten arguments
-    .flatMap((part) => {
-      const functionPattern = /(\w+)\(([^)]+)\)/;
-
-      if (functionPattern.test(part)) {
-        // Handle function calls by splitting arguments further
-        const [, functionName, args] = part.match(functionPattern);
-        const bleh = [functionName, ...args.split(/, */)];
-        return bleh;
-      }
-
-      return part.split();
-    })
-    //3. filter out operators and user input numbers
-    .filter((el) => {
-      return !operators.includes(el) && isNaN(el);
-    });
-
+  let { metricNames, urlPlaceholders } = getMetricNames(expression);
   let finalExpression = expression;
 
-  metricNames.forEach((metricString) => {
-    finalExpression = finalExpression.replaceAll(
-      metricString,
-      `'${hashString(metricString)}'` //include quotes '' in string due to filtrex
-    );
+  metricNames = metricNames.map((str) => {
+    //return all url placeholders to original form
+    for (let placeholder of Object.keys(urlPlaceholders)) {
+      str = str.replace(placeholder, urlPlaceholders[placeholder]);
+    }
+
+    //hash only the metric names in the expression
+    finalExpression = finalExpression.replaceAll(str, `'${hashString(str)}'`);
+    return str;
   });
 
   return finalExpression;

--- a/packages/artillery-plugin-ensure/utils.js
+++ b/packages/artillery-plugin-ensure/utils.js
@@ -80,7 +80,6 @@ function getMetricNames(expression) {
   }
 
   const metricNames = returnMetricNamesAfterFilters(tmpExpression);
-  console.log(metricNames);
 
   return { metricNames, urlPlaceholders };
 }

--- a/packages/artillery-plugin-ensure/utils.js
+++ b/packages/artillery-plugin-ensure/utils.js
@@ -1,0 +1,60 @@
+const crypto = require('crypto');
+
+const numericOperators = ['+', '-', '*', '/', '%', '^'];
+const comparisonOperators = ['==', '<', '<=', '>', '>='];
+const booleanOperators = ['or', 'and', 'not', '?', ':', '(', ')'];
+const builtInFunctions = ['ceil', 'floor', 'random', 'round'];
+
+// List of known operators
+const operators = [
+  ...numericOperators,
+  ...comparisonOperators,
+  ...booleanOperators,
+  ...builtInFunctions
+];
+
+function hashString(str) {
+  const hash = crypto.createHash('sha256'); // sha256 is a good choice for uniqueness and speed
+  hash.update(str);
+  return hash.digest('hex'); // returns the hash as a string of hexadecimal numbers
+}
+
+function returnExpressionWithHashes(expression) {
+  let metricNames = expression
+    //1. split by spaces first to divide into chunks
+    .split(/\s+/)
+    .filter(Boolean)
+    //2. check for potential builtInFunction usage and flatten arguments
+    .flatMap((part) => {
+      const functionPattern = /(\w+)\(([^)]+)\)/;
+
+      if (functionPattern.test(part)) {
+        // Handle function calls by splitting arguments further
+        const [, functionName, args] = part.match(functionPattern);
+        const bleh = [functionName, ...args.split(/, */)];
+        return bleh;
+      }
+
+      return part.split();
+    })
+    //3. filter out operators and user input numbers
+    .filter((el) => {
+      return !operators.includes(el) && isNaN(el);
+    });
+
+  let finalExpression = expression;
+
+  metricNames.forEach((metricString) => {
+    finalExpression = finalExpression.replaceAll(
+      metricString,
+      `'${hashString(metricString)}'` //include quotes '' in string due to filtrex
+    );
+  });
+
+  return finalExpression;
+}
+
+module.exports = {
+  returnExpressionWithHashes,
+  hashString
+};


### PR DESCRIPTION
## Why

Originally reported here: https://github.com/artilleryio/artillery/discussions/2166#discussioncomment-7110325, `ensure` is currently broken with most Playwright test assertions on web vital metrics.

The problem is more general though - any custom metric that includes special characters can hit this.

## Approach

As it's hard to predict what patterns can fall into this (as it depends on how the package `filtrex` is handling it), rather than going with an approach of replacing specific patterns, we try to identify the `metricNames` in the expression and apply a hash to them, so that `filtrex` can run without issues. Otherwise we'd have to deal with finding all possible patterns that might have an issue with `filtrex` - this way we only have to concern ourselves with being able to correctly isolate metricNames.

## Breaking Change

~~I am not sure if this is a behaviour we currently support or not, as all examples we have don't use it, but in order to use this approach, the code assumes that there will be spacing used between any operators used. This is consistent with what we've documented here: https://www.artillery.io/docs/reference/extensions/ensure.~~

I have been able to change the approach to be able to support spacing, so that the following is now possible:

```
(((vusers.created-vusers.completed)/ceil(vusers.created) * 100) + vusers.slept)<= 0
```

However, this comes with the following downside: **all operators listed [here](https://www.artillery.io/docs/reference/extensions/ensure#expression-syntax) are now reserved keywords** for the purposes of asserting using `conditions`, which means that metric names should not include them if you want to use `ensure`. This potentially includes Scenario Name, if you're asserting on `vusers.created_by_name`.

This was the best trade-off I could find.

_Note: The exception to the above is that keywords like and, not, random etc can all be used within metric names (as long as they are used within words, as they were specially handled - otherwise it would not be possible to have custom metrics with words that included those._

## Testing

Since I implemented automated acceptance tests here back in August, these were actually helping me spot mistakes along the way 👍. That being said, I thought this logic was the perfect candidate for unit tests too, so I actually wrote the unit tests before part of the refactor (half-TDD), so it's now well covered by that too.

Hopefully between these two, we are making sure all cases are covered. Please let me know if I might have missed something 🙇‍♂️!