### PR TITLE
fix(schema): add extendedMetrics to playwright engine schema

### DIFF
--- a/packages/types/schema/engines/playwright.js
+++ b/packages/types/schema/engines/playwright.js
@@ -2,7 +2,10 @@ const Joi = require('joi').defaults((schema) =>
   schema.options({ allowUnknown: true, abortEarly: true })
 );
 
-const { artilleryNumberOrString } = require('../joi.helpers');
+const {
+  artilleryNumberOrString,
+  artilleryBooleanOrString
+} = require('../joi.helpers');
 
 const PlaywrightSchemaObject = {
   testFunction: Joi.string()
@@ -14,7 +17,7 @@ const PlaywrightSchemaObject = {
 };
 
 const PlaywrightConfigSchema = Joi.object({
-  aggregateByName: Joi.alternatives(Joi.boolean(), Joi.string())
+  aggregateByName: artilleryBooleanOrString
     .meta({ title: 'Aggregate by name' })
     .description(
       'Aggregate Artillery metrics by test scenario name.\nhttps://www.artillery.io/docs/reference/engines/playwright#aggregate-metrics-by-scenario-name'
@@ -28,6 +31,11 @@ const PlaywrightConfigSchema = Joi.object({
     .meta({ title: 'Default navigation timeout' })
     .description(
       'Default maximum navigation time (in seconds) for Playwright navigation methods, like `page.goto()`.\nhttps://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout'
+    ),
+  extendedMetrics: artilleryBooleanOrString
+    .meta({ title: 'Playwright Extended Metrics' })
+    .description(
+      'If enabled, Artillery will collect additional metrics from Playwright.\nCheck more information here: https://www.artillery.io/docs/reference/engines/playwright#extended-metrics'
     ),
   launchOptions: Joi.object()
     .meta({ title: 'Playwright launch options' })


### PR DESCRIPTION
Quick fix, as I forgot to add this before. Noticed it when using the extension.