### PR TITLE
feat(artillery): add ability to specify scenario to run by name

### DIFF
--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -115,6 +115,9 @@ RunLambdaCommand.flags = {
   key: Flags.string({
     description: 'API key for Artillery Cloud'
   }),
+  'scenario-name': Flags.string({
+    description: 'Name of the specific scenario to run'
+  }),
   architecture: Flags.string({
     description: 'Architecture of the Lambda function',
     default: 'arm64'

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -157,7 +157,7 @@ RunCommand.flags = {
     description: 'API key for Artillery Cloud'
   }),
   name: Flags.string({
-    description: 'Name of the test to run',
+    description: 'Name of the specific scenario to run',
     char: 'n'
   })
 };

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -156,9 +156,8 @@ RunCommand.flags = {
   key: Flags.string({
     description: 'API key for Artillery Cloud'
   }),
-  name: Flags.string({
-    description: 'Name of the specific scenario to run',
-    char: 'n'
+  'scenario-name': Flags.string({
+    description: 'Name of the specific scenario to run'
   })
 };
 

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -155,6 +155,10 @@ RunCommand.flags = {
   }),
   key: Flags.string({
     description: 'API key for Artillery Cloud'
+  }),
+  name: Flags.string({
+    description: 'Name of the test to run',
+    char: 'n'
   })
 };
 
@@ -207,7 +211,8 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       scriptPath: args.script,
       // TODO: This should be an array of files, like inputFiles above
       absoluteScriptPath: path.resolve(process.cwd(), args.script),
-      plugins: []
+      plugins: [],
+      scenarioName: flags.name
     };
 
     // Set "name" tag if not set explicitly

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -211,7 +211,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       // TODO: This should be an array of files, like inputFiles above
       absoluteScriptPath: path.resolve(process.cwd(), args.script),
       plugins: [],
-      scenarioName: flags.name
+      scenarioName: flags['scenario-name']
     };
 
     // Set "name" tag if not set explicitly

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -189,6 +189,11 @@ class PlatformLambda {
       this.artilleryArgs.push(path.basename(this.platformOpts.cliArgs.dotenv));
     }
 
+    if (this.platformOpts.cliArgs['scenario-name']) {
+      this.artilleryArgs.push('--scenario-name');
+      this.artilleryArgs.push(this.platformOpts.cliArgs['scenario-name']);
+    }
+
     if (this.platformOpts.cliArgs.config) {
       this.artilleryArgs.push('--config');
       const p = bom.files.filter(

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -108,7 +108,10 @@ tap.test('Can specify scenario to run by name', async (t) => {
 
   t.ok(
     deleteFile(reportFilePath) &&
-      json.aggregate.counters['vusers.created_by_name.Test Scenario 2'] === 6
+      json.aggregate.counters['vusers.created_by_name.Test Scenario 2'] === 6 &&
+      typeof json.aggregate.counters[
+        'vusers.created_by_name.Test Scenario 1'
+      ] === 'undefined'
   );
 });
 

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -88,6 +88,32 @@ tap.test('Environment specified with -e should be used', async (t) => {
   t.ok(exitCode === 0 && !output.stdout.includes('ECONNREFUSED'));
 });
 
+tap.test('Can specify scenario to run by name', async (t) => {
+  const reportFile = 'report-with-scenario-by-name.json';
+  const reportFilePath = await getRootPath(reportFile);
+
+  const [exitCode, output] = await execute([
+    'run',
+    '-n',
+    'Test Scenario 2',
+    '-o',
+    `${reportFilePath}`,
+    'test/scripts/scenario-named/scenario.yml'
+  ]);
+  console.log(output.stdout);
+
+  // Here if the right environment is not picked up, we'll get ECONNREFUSED errors in the report
+  t.ok(
+    exitCode === 0 && output.stdout.includes('Successfully running scenario 2')
+  );
+  const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  t.ok(
+    deleteFile(reportFilePath) &&
+      json.aggregate.counters['vusers.created_by_name.Test Scenario 2'] === 6
+  );
+});
+
 tap.test('Run a script with one payload command line', async (t) => {
   const [, output] = await execute([
     'run',

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -101,7 +101,6 @@ tap.test('Can specify scenario to run by name', async (t) => {
     'test/scripts/scenario-named/scenario.yml'
   ]);
 
-  // Here if the right environment is not picked up, we'll get ECONNREFUSED errors in the report
   t.ok(
     exitCode === 0 && output.stdout.includes('Successfully running scenario 2')
   );

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -100,7 +100,6 @@ tap.test('Can specify scenario to run by name', async (t) => {
     `${reportFilePath}`,
     'test/scripts/scenario-named/scenario.yml'
   ]);
-  console.log(output.stdout);
 
   // Here if the right environment is not picked up, we'll get ECONNREFUSED errors in the report
   t.ok(

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -94,7 +94,7 @@ tap.test('Can specify scenario to run by name', async (t) => {
 
   const [exitCode, output] = await execute([
     'run',
-    '-n',
+    '--scenario-name',
     'Test Scenario 2',
     '-o',
     `${reportFilePath}`,

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -112,6 +112,25 @@ tap.test('Can specify scenario to run by name', async (t) => {
   );
 });
 
+tap.test(
+  'Errors correctly when specifying a non-existing scenario by name',
+  async (t) => {
+    const [exitCode, output] = await execute([
+      'run',
+      '--scenario-name',
+      'Test Scenario 3',
+      'test/scripts/scenario-named/scenario.yml'
+    ]);
+
+    t.equal(exitCode, 11);
+    t.ok(
+      output.stdout.includes(
+        'Error: Scenario Test Scenario 3 not found in script. Make sure your chosen scenario matches the one in your script exactly.'
+      )
+    );
+  }
+);
+
 tap.test('Run a script with one payload command line', async (t) => {
   const [, output] = await execute([
     'run',

--- a/packages/artillery/test/scripts/scenario-named/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-named/scenario.yml
@@ -1,0 +1,13 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 3
+      arrivalRate: 2
+
+scenarios:
+  - name: Test Scenario 1
+    flow:
+      - log: "Successfully running scenario 1"
+  - name: Test Scenario 2
+    flow:
+      - log: "Successfully running scenario 2"

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -313,7 +313,7 @@ function runScenario(script, metrics, runState, contextVars, options) {
     );
   }
 
-  //default to randomly picked scenario
+  //default to weighted picked scenario
   let i = runState.picker()[0];
 
   if (options.scenarioName) {
@@ -325,11 +325,11 @@ function runScenario(script, metrics, runState, contextVars, options) {
 
     if (!foundScenario) {
       debug(
-        `scenario ${options.scenarioName} not found in script. Choosing random scenario instead.`
+        `scenario ${options.scenarioName} not found in script. Choosing scenario by weight instead (at random).`
       );
     } else if (foundScenario.length > 1) {
       debug(
-        `multiple scenarios found for ${options.scenarioName}. Choosing random scenario instead.`
+        `multiple scenarios found for ${options.scenarioName}. Choosing scenario by weight instead (at random).`
       );
     } else {
       debug(`scenario ${options.scenarioName} found in script. running it!`);

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -331,16 +331,16 @@ function runScenario(script, metrics, runState, contextVars, options) {
       return new RegExp(options.scenarioName).test(scenario.name);
     });
 
-    if (!foundScenario) {
-      debug(
-        `scenario ${options.scenarioName} not found in script. Choosing scenario by weight instead (at random).`
+    if (foundScenario?.length === 0) {
+      throw new Error(
+        `Scenario ${options.scenarioName} not found in script. Make sure your chosen scenario matches the one in your script exactly.`
       );
     } else if (foundScenario.length > 1) {
-      debug(
-        `multiple scenarios found for ${options.scenarioName}. Choosing scenario by weight instead (at random).`
+      throw new Error(
+        `Multiple scenarios for ${options.scenarioName} found in script. Make sure you give unique names to your scenarios in your script.`
       );
     } else {
-      debug(`scenario ${options.scenarioName} found in script. running it!`);
+      debug(`Scenario ${options.scenarioName} found in script. running it!`);
       i = foundIndex;
     }
   }


### PR DESCRIPTION
## Why

Originally requested here https://github.com/artilleryio/artillery/discussions/1929, this is a useful feature for people who are saving multiple scenarios in the same file. Especially useful once you start having complex scenarios with weights, but still want the ability to run them individually on demand, a requirement I've had myself in the past.

~Note: CLI flag name (`--name`) could be changed to something else, like `--byName`. Please suggest something else if you think it makes more sense.~
_Note: Flag name is now --scenario-name after some internal discussions. Please make other suggestions if other ideas pop up._