### PR TITLE
feat(playwright): trace user flow through performance api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4620,6 +4620,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.17.0.tgz",
+      "integrity": "sha512-bDIRCgpKniSyhORU0fTL9ISW6ucU9nruKyXKwYrEBep/2f3uLz8LFyF51ZUK9QxIwBHw6WJudK/2UqttWzER4w==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
+      }
+    },
     "node_modules/@opentelemetry/core": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
@@ -23025,6 +23036,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
         "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/context-async-hooks": "^1.17.0",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.2",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.41.2",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.2",
@@ -24347,7 +24359,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -207,10 +207,12 @@ class PlaywrightEngine {
         await fn(page, initialContext, events);
 
         // After the user flow function has finished we will have all the performance entries needed to set the spans
-        const tracePerformanceEntries = self.processor[spec.traceFlowFunction]
-        tracePerformanceEntries(entries, spec.name)
-        await page.close();
+        if (self.tracing){
+          const tracePerformanceEntries = self.processor[spec.traceFlowFunction]
+          tracePerformanceEntries(entries, spec.name)
+        }
 
+        await page.close();
 
         if (cb) {
           cb(null, initialContext);

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -88,14 +88,17 @@ class PlaywrightEngine {
         debug('page created');
         // For tracing we need the performance entry array from the last frame navigated (when all the performanceEntry objects have been added)
         // The 'entries' variable is set outside the emitter and updated with each 'framenavigated' event
-        let entries
+        // perfTimeOrigin is used to get absolute timestamp values needed to set spans as values in entries represent time elapsed from timeOrigin
+        let entries, perfTimeOrigin
         page.on('framenavigated', async(page)=> {
           if(self.tracing){
             try{
-              const perfEntriesJSON = await page.evaluate(() => JSON.stringify(window.performance.getEntries()))
-              entries = JSON.parse(
+              const perfEntriesJSON = await page.evaluate(() => JSON.stringify([window.performance.getEntries(), window.performance.timeOrigin]))
+              const parsedEntries= JSON.parse(
                 perfEntriesJSON
               )
+              entries = parsedEntries[0]
+              perfTimeOrigin = Number(parsedEntries[1])
             }catch(err){
               throw new Error(err)
             }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -430,16 +430,16 @@ class OTelReporter {
     const timingEventsMap = {
       redirect: { start: 'redirectStart', end: 'redirectEnd' },
       fetch: { start: 'fetchStart', end: 'responseEnd' },
-      DNS_lookup: { start: 'domainLookupStart', end: 'domainLookupEnd' },
-      TCP_handshake: { start: 'connectStart', end: 'connectEnd' },
-      TLS_negotiation: { start: 'secureConnectionStart', end: 'requestStart' },
-      Request: { start: 'requestStart', end: 'responseStart' },
-      Response: { start: 'responseStart', end: 'responseEnd' },
-      'DOM.content_loaded.event': {
+      dns_lookup: { start: 'domainLookupStart', end: 'domainLookupEnd' },
+      tcp_handshake: { start: 'connectStart', end: 'connectEnd' },
+      tls_negotiation: { start: 'secureConnectionStart', end: 'requestStart' },
+      request: { start: 'requestStart', end: 'responseStart' },
+      response: { start: 'responseStart', end: 'responseEnd' },
+      dom_content_loaded: {
         start: 'domContentLoadedEventStart',
         end: 'domContentLoadedEventEnd'
       },
-      'load.event': { start: 'loadEventStart', end: 'loadEventEnd' }
+      load: { start: 'loadEventStart', end: 'loadEventEnd' }
     };
     // Set tracer for playwright
     this.playwrightTracer = trace.getTracer('artillery-playwright');
@@ -491,13 +491,18 @@ class OTelReporter {
                 'next.hop.protocol': entry.nextHopProtocol,
                 'render.blocking.status': entry.renderBlockingStatus,
                 duration: entry.duration,
-                'redirect.count': entry.redirectCount
+                'redirect.count': entry.redirectCount,
+                'initiator.type': entry.initiatorType,
+                'content.compressed': entry.decodedBodySize != entry.encodedBodySize
               });
+              if(entry.type){
+                span.setAttribute('type', entry.type)
+              }
               if (entry.domInteractive) {
-                span.addEvent('DOM.Interactive', entry.domInteractive);
+                span.addEvent('dom_interactive', entry.domInteractive);
               }
               if (entry.domComplete) {
-                span.addEvent('DOM.Complete', entry.domComplete);
+                span.addEvent('dom_complete', entry.domComplete);
               }
 
               // This is where we create the spans for the timing events that we have the data for

--- a/packages/artillery-plugin-publish-metrics/lib/util.js
+++ b/packages/artillery-plugin-publish-metrics/lib/util.js
@@ -24,9 +24,12 @@ function attachScenarioHooks(script, specs) {
   scenarios.forEach((scenario) => {
     specs.forEach((spec) => {
       // console.log(spec.engine, scenario.engine);
-      // if (spec.engine && spec.engine !== scenario.engine) {
-      //   return;
-      // }
+      if (
+        (spec.engine && spec.engine !== scenario.engine) ||
+        (!spec.engine && scenario.engine && scenario.engine !== 'http')
+      ) {
+        return;
+      }
 
       scenario[spec.type] = [].concat(scenario[spec.type] || []);
       scenario[spec.type].push(spec.name);

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.370.0",
     "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/context-async-hooks": "^1.17.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.2",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.41.2",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.2",


### PR DESCRIPTION
# What

Tracing support for Playwright Engine through OpenTelemetry reporter (`publish-metrics` plugin). 

This tracing support is implemented not through `request`-`response` events/object but through the use of [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API).

Traces are created for each `scenario`. The scenario is a parent span, within it there is a child span for each [`performanceEntry`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry) of [`resource`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) and [`navigation`](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming) type. Then each entry has child spans that represent each of the important timing events:

<img width="1360" alt="Screenshot 2023-10-05 at 17 03 31" src="https://github.com/artilleryio/artillery/assets/39635558/d97ee44b-f59b-46b5-a22f-64340b685953">


## Limitations
There are certain limitations to take in consideration: 
- Traces do not have the 'request.method' information
- `spanStatus` set as `ERROR` only if `response status code` is 400 or more
- An additional limitation seems to be that at times certain requests might be missed due to the speed of execution.

No additional/special configuration is needed, when OTel reporter is in use for tracing with the Playwright engine scenarios configured, it will automatically trace any Playwright, as well as HTTP engine scenarios.
# How

A scenario hook `traceFlowFunction` is used to hook the OTel reporter to the Playwright engine. 

The `performance.getEntries()` on the last `framenavigated` event gets the array of entries needed to set the spans which is stored in the `entries` variable outside of the eventListener callback. This way it is available to pass into the OTel reporters `tracePerformanceFlow` function that is called after the user flow function has finished and we have all the entries available. There we set all the spans manually with data available in the `entries`. 





