### PR TITLE
fix(apdex): run apdex logic correctly in workers

### DIFF
--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -20,7 +20,7 @@ class ApdexPlugin {
       Number(global.artillery.version.slice(0, 1)) > 1 &&
       typeof process.env.LOCAL_WORKER_ID === 'undefined'
     ) {
-      debug('Running in a worker, registering apdex beforeExit hook');
+      debug('Running in parent thread. Registering apdex beforeExit hook.');
       global.artillery.ext({
         ext: 'beforeExit',
         method: async (testInfo) => {

--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -4,7 +4,7 @@
   "description": "Calculate and report Apdex scores",
   "main": "index.js",
   "scripts": {
-    "test": "tap ./test/*.spec.js --timeout 300 --no-coverage --color"
+    "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap ./test/*.spec.js --timeout 300 --no-coverage --color"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -4,7 +4,7 @@
   "description": "Calculate and report Apdex scores",
   "main": "index.js",
   "scripts": {
-    "test": "exit 0"
+    "test": "tap ./test/*.spec.js --timeout 300 --no-coverage --color"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-plugin-apdex/test/fixtures/processor.js
+++ b/packages/artillery-plugin-apdex/test/fixtures/processor.js
@@ -1,0 +1,10 @@
+function myAfterResponseHandler(req, res, context, ee, next) {
+  //Change your function name and add your logic here.
+  //For more information, check: https://docs.art/http-reference#function-signatures
+  console.log('After Response Handler still working');
+  next();
+}
+
+module.exports = {
+  myAfterResponseHandler
+};

--- a/packages/artillery-plugin-apdex/test/fixtures/scenario.yml
+++ b/packages/artillery-plugin-apdex/test/fixtures/scenario.yml
@@ -1,0 +1,14 @@
+config:
+  target: "http://asciiart.artillery.io:8080"
+  processor: "./processor.js"
+  phases:
+    - duration: 5
+      arrivalRate: 1
+      name: "Phase 1"
+
+scenarios:
+  - name: apdexPluginTest
+    flow:
+      - get:
+          afterResponse: myAfterResponseHandler
+          url: "/"

--- a/packages/artillery-plugin-apdex/test/index.spec.js
+++ b/packages/artillery-plugin-apdex/test/index.spec.js
@@ -31,6 +31,6 @@ test('apdex plugin works when other after response hooks are set', async (t) => 
   t.equal(
     afterResponseOccurrences,
     5,
-    'After Response Handler did not run three times'
+    'After Response Handler did not run five times'
   );
 });

--- a/packages/artillery-plugin-apdex/test/index.spec.js
+++ b/packages/artillery-plugin-apdex/test/index.spec.js
@@ -1,0 +1,36 @@
+const { test, afterEach } = require('tap');
+const { $ } = require('zx');
+
+test('apdex plugin works when other after response hooks are set', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { apdex: {} },
+      apdex: {
+        threshold: 100
+      }
+    }
+  });
+
+  //Act: run the test
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+
+  const apdexRegex =
+    /Apdex score: (\d(?:\.\d+)?) \((unacceptable|poor|fair|good|excellent)\)/;
+
+  const apdexTest = apdexRegex.test(output.stdout);
+  const afterResponseOccurrences = (
+    output.stdout.match(
+      new RegExp(/After Response Handler still working/, 'g')
+    ) || []
+  ).length;
+
+  // Assert
+  t.ok(apdexTest, 'Console did not include Apdex score');
+  t.equal(
+    afterResponseOccurrences,
+    5,
+    'After Response Handler did not run three times'
+  );
+});


### PR DESCRIPTION
## Why

Solves https://github.com/artilleryio/artillery/issues/2193. Apdex has actually had this issue all along when using a processor. 

It happens because in the parent thread, the processors are not available as an array, that's an implementation detail of workers only.

In the case of this specific plugin, part of the logic has to run only on the parent thread, and the rest of the logic has to run in workers.

## Testing

Automated testing was implemented.

### Before
The implemented test replicates the issue:
https://github.com/artilleryio/artillery/actions/runs/6455923510/job/17524361652?pr=2195

<img width="675" alt="Screenshot 2023-10-09 at 12 24 29" src="https://github.com/artilleryio/artillery/assets/39738771/ce77be84-e9e3-48e4-a5de-dc666435b162">

### After
https://github.com/artilleryio/artillery/actions/runs/6456170500/job/17525111146?pr=2195
<img width="317" alt="Screenshot 2023-10-09 at 13 21 16" src="https://github.com/artilleryio/artillery/assets/39738771/7396fff9-3a79-4bb3-a4fe-a87435a60501">