### PR TITLE
fix: include original phase definition in phaseStarted/phaseCompleted events

### DIFF
--- a/packages/artillery/lib/launch-platform.js
+++ b/packages/artillery/lib/launch-platform.js
@@ -122,7 +122,8 @@ class Launcher {
           //get back original phase without any splitting for workers
           ...this.script.config.phases[message.phase.index],
           id: message.phase.id,
-          startTime: this.phaseStartedEventsSeen[message.phase.index]
+          startTime: this.phaseStartedEventsSeen[message.phase.index],
+          endTime: message.phase.endTime
         };
 
         this.events.emit('phaseCompleted', fullPhase);

--- a/packages/artillery/lib/launch-platform.js
+++ b/packages/artillery/lib/launch-platform.js
@@ -97,11 +97,18 @@ class Launcher {
         typeof this.phaseStartedEventsSeen[message.phase.index] === 'undefined'
       ) {
         this.phaseStartedEventsSeen[message.phase.index] = Date.now();
-        this.events.emit('phaseStarted', message.phase);
-        this.pluginEvents.emit('phaseStarted', message.phase);
-        this.pluginEventsLegacy.emit('phaseStarted', message.phase);
+        const fullPhase = {
+          //get back original phase without any splitting for workers
+          ...this.script.config.phases[message.phase.index],
+          id: message.phase.id,
+          startTime: this.phaseStartedEventsSeen[message.phase.index]
+        };
 
-        global.artillery.globalEvents.emit('phaseStarted', message.phase);
+        this.events.emit('phaseStarted', fullPhase);
+        this.pluginEvents.emit('phaseStarted', fullPhase);
+        this.pluginEventsLegacy.emit('phaseStarted', fullPhase);
+
+        global.artillery.globalEvents.emit('phaseStarted', fullPhase);
       }
     });
 
@@ -111,10 +118,17 @@ class Launcher {
         'undefined'
       ) {
         this.phaseCompletedEventsSeen[message.phase.index] = Date.now();
-        this.events.emit('phaseCompleted', message.phase);
-        this.pluginEvents.emit('phaseCompleted', message.phase);
-        this.pluginEventsLegacy.emit('phaseCompleted', message.phase);
-        global.artillery.globalEvents.emit('phaseCompleted', message.phase);
+        const fullPhase = {
+          //get back original phase without any splitting for workers
+          ...this.script.config.phases[message.phase.index],
+          id: message.phase.id,
+          startTime: this.phaseStartedEventsSeen[message.phase.index]
+        };
+
+        this.events.emit('phaseCompleted', fullPhase);
+        this.pluginEvents.emit('phaseCompleted', fullPhase);
+        this.pluginEventsLegacy.emit('phaseCompleted', fullPhase);
+        global.artillery.globalEvents.emit('phaseCompleted', fullPhase);
       }
     });
 


### PR DESCRIPTION
This fixes the issue with `phaseStarted`/`phaseCompleted` events receiving an incorrect phase spec.

This is happening because we "split" the original phase definition to give each worker thread a subset of the total workload, e.g. a phase definition with `arrivalCount` of 20, becomes 4 phases with `arrivalCount` of 5 each when running on a system with 4 CPUs. We currently emit one of those split phase definitions with global `phaseStarted` &  `phaseCompleted` events.