### PR TITLE
fix(artillery): include index in phases emitted

### DIFF
--- a/packages/artillery/lib/launch-platform.js
+++ b/packages/artillery/lib/launch-platform.js
@@ -100,6 +100,7 @@ class Launcher {
         const fullPhase = {
           //get back original phase without any splitting for workers
           ...this.script.config.phases[message.phase.index],
+          index: message.phase.index,
           id: message.phase.id,
           startTime: this.phaseStartedEventsSeen[message.phase.index]
         };
@@ -122,6 +123,7 @@ class Launcher {
           //get back original phase without any splitting for workers
           ...this.script.config.phases[message.phase.index],
           id: message.phase.id,
+          index: message.phase.index,
           startTime: this.phaseStartedEventsSeen[message.phase.index],
           endTime: message.phase.endTime
         };


### PR DESCRIPTION
## Why

After this PR (https://github.com/artilleryio/artillery/pull/2203), emitted phase events are now pulled from the original script, but this only includes phase names, not indexes. Sometimes phases don't have names, and the index is an alternative way to identify which phase we are on. 

_Note: This will also be relevant to a fix needed for Fargate, where this index is needed for deduplication of messages._