### PR TITLE
fix(apdex): show all metrics in report

### DIFF
--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -36,11 +36,7 @@ class ApdexPlugin {
 
       function apdexAfterResponse(req, res, userContext, events, done) {
         const total = res.timings.phases.total;
-        const counts = {
-          satisfied: 0,
-          tolerated: 0,
-          frustrated: 0
-        };
+        const counts = {};
         if (total <= t) {
           counts.satisfied = 1;
         } else if (total <= 4 * t) {

--- a/packages/artillery-plugin-apdex/index.js
+++ b/packages/artillery-plugin-apdex/index.js
@@ -36,13 +36,21 @@ class ApdexPlugin {
 
       function apdexAfterResponse(req, res, userContext, events, done) {
         const total = res.timings.phases.total;
+        const counts = {
+          satisfied: 0,
+          tolerated: 0,
+          frustrated: 0
+        };
         if (total <= t) {
-          events.emit('counter', METRICS.satisfied, 1);
+          counts.satisfied = 1;
         } else if (total <= 4 * t) {
-          events.emit('counter', METRICS.tolerated, 1);
+          counts.tolerated = 1;
         } else {
-          events.emit('counter', METRICS.frustrated, 1);
+          counts.frustrated = 1;
         }
+        events.emit('counter', METRICS.satisfied, counts.satisfied);
+        events.emit('counter', METRICS.tolerated, counts.tolerated);
+        events.emit('counter', METRICS.frustrated, counts.frustrated);
 
         return done();
       }

--- a/packages/artillery-plugin-apdex/test/index.spec.js
+++ b/packages/artillery-plugin-apdex/test/index.spec.js
@@ -34,3 +34,28 @@ test('apdex plugin works when other after response hooks are set', async (t) => 
     'After Response Handler did not run five times'
   );
 });
+
+// Related to the following discussion: https://github.com/artilleryio/artillery/discussions/2209#discussion-5729379
+test('apdex plugin reports all apdex metrics even if they never occured', async (t) => {
+  //Arrange: Plugin overrides
+  const override = JSON.stringify({
+    config: {
+      plugins: { apdex: {} },
+      apdex: {
+        threshold: 100
+      }
+    }
+  });
+
+  //Act: run the test
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+  const allMetricsReported =
+    output.stdout.includes('apdex.satisfied:') &&
+    output.stdout.includes('apdex.tolerated:') &&
+    output.stdout.includes('apdex.frustrated:');
+  t.ok(
+    allMetricsReported,
+    'All Apdex metrics counters are displayed in the report'
+  );
+});

--- a/packages/artillery-plugin-apdex/test/index.spec.js
+++ b/packages/artillery-plugin-apdex/test/index.spec.js
@@ -35,7 +35,7 @@ test('apdex plugin works when other after response hooks are set', async (t) => 
   );
 });
 
-// Related to the following discussion: https://github.com/artilleryio/artillery/discussions/2209#discussion-5729379
+// Related to the following discussion: https://github.com/artilleryio/artillery/discussions/2209
 test('apdex plugin reports all apdex metrics even if they never occured', async (t) => {
   //Arrange: Plugin overrides
   const override = JSON.stringify({


### PR DESCRIPTION
Related to #2209

# What
Making `apdex` plugin show all 3 metrics in the report even if their count is 0 (even if no metrics were frustrated/satisfied/tolerated) just like we do for `vusers.failed`. This is needed so that when the `threshold` for the given `apdex` metric is set in the `ensure` plugin, the `ensure` does not fail the check for metrics whose count is 0. 