### PR TITLE
feat(publish-metrics): increase trace visibility for OTel reporter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4620,6 +4620,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.17.1.tgz",
+      "integrity": "sha512-up5I+RiQEkGrVEHtbAtmRgS+ZOnFh3shaDNHqZPBlGy+O92auL6yMmjzYpSKmJOGWowvs3fhVHePa8Exb5iHUg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
+      }
+    },
     "node_modules/@opentelemetry/core": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
@@ -23025,6 +23036,7 @@
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.370.0",
         "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/context-async-hooks": "^1.17.1",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.2",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.41.2",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.2",
@@ -24347,7 +24359,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/tap": "^15.0.8",

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -373,7 +373,7 @@ class OTelReporter {
       const span = this.httpTracer.startSpan(spanName, {
         startTime,
         kind: SpanKind.CLIENT,
-        attributes: { vuId: userContext.$uuid }
+        attributes: { 'vu.uuid': userContext.$uuid }
       });
       userContext.vars['__otlpHTTPRequestSpan'] = span;
 
@@ -399,10 +399,10 @@ class OTelReporter {
     let endTime;
 
     if (res.timings && res.timings.phases) {
-      span.setAttribute('responseTimeMs', res.timings.phases.firstByte);
+      span.setAttribute('response.time.ms', res.timings.phases.firstByte);
 
-      // Child spans are created for each part of request from the timings object and named accordingly. More info here: https://github.com/sindresorhus/got/blob/main/source/core/response.ts
-      // Map names of parts of request that we are going to create spans for, to the timings parameters representing their start and end times for easier span creation
+      // Child spans are created for each phase of the request from the timings object and named accordingly. More info here: https://github.com/sindresorhus/got/blob/main/source/core/response.ts
+      // Map names of request phases to the timings parameters representing their start and end times for easier span creation
       const timingsMap = {
         dns_lookup: { start: 'socket', end: 'lookup' },
         tcp_handshake: { start: 'lookup', end: 'connect' },
@@ -412,10 +412,10 @@ class OTelReporter {
           end: 'upload'
         },
         download: { start: 'response', end: 'end' },
-        firstByte: { start: 'upload', end: 'response' }
+        first_byte: { start: 'upload', end: 'response' }
       };
 
-      // Create child spans within the request span context
+      // Create phase spans within the request span context
       context.with(trace.setSpan(context.active(), span), () => {
         for (const [name, value] of Object.entries(timingsMap)) {
           if (res.timings[value.start] && res.timings[value.end]) {

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.370.0",
     "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/context-async-hooks": "^1.17.1",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.2",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.41.2",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.2",


### PR DESCRIPTION
# What

Multiple improvements to OTel reporter tracing feature for the HTTP engine:

 ### Before:
   - Each request is its own root span and a separate trace with no information on which scenario it belongs to
   - No insight on individual request phases except for `responseTimeMs` attribute
   - Request spans have `http_request_started` and `http_request_ended` events
   - Errors are set as a `status` on spans
   
Individual trace:
<img width="1015" alt="Screenshot 2023-10-12 at 20 43 22" src="https://github.com/artilleryio/artillery/assets/39635558/206dc555-a830-4690-9fda-19eb0c412355">


  
  ### After:
   - Scenarios are the root spans with all requests that are executed as a part of each scenario nested inside them as their child spans
   - Each request is broken down further into the following child spans (they represent the request phases respectively as they are recorded in the `got`  [`response.timings.phases`](https://github.com/sindresorhus/got/blob/main/source/core/response.ts) object): 
     - `dns_lookup` , 
     - `tcp_handshake` ,
     - `tls_negotiation` ,
     - `request` ,
     - `first_byte` ,
     - `download`
   - The `http_request_started` and `http_request_ended` events have been removed due to the implementation of the request phases spans
   - Errors that occur during execution (not the ones set due to response code being 400 or more) are also recorded with `span.setException()` not just as a span `status`,
   - virtual user id is set as an attribute on all request spans as `vu.uuid`
   - `responseTimeMs` attribute changed to `response.time.ms` for consistency
  
Individual trace:
<img width="1007" alt="Screenshot 2023-10-12 at 20 49 40" src="https://github.com/artilleryio/artillery/assets/39635558/6db9ea22-9788-45e8-b706-657295788431">

