### PR TITLE
fix(cloud): wait for unprocessed logs before shutdown

### DIFF
--- a/packages/artillery/lib/util/await-on-ee.js
+++ b/packages/artillery/lib/util/await-on-ee.js
@@ -1,19 +1,21 @@
 const sleep = require('./sleep');
 
-async function awaitOnEE(ee, message, pollMs = 1000) {
+async function awaitOnEE(ee, message, pollMs = 1000, maxWaitMs = Infinity) {
   let messageFired = false;
   let args = null;
+  let waitedMs = 0;
 
   ee.once(message, () => {
     messageFired = true;
     args = arguments;
   });
 
-  while (true) {
+  while (true && waitedMs < maxWaitMs) {
     if (messageFired) {
       break;
     }
     await sleep(pollMs);
+    waitedMs += pollMs;
   }
 
   return args;


### PR DESCRIPTION
## Why

As logs take time to be sent as an API call, and there is also an onShutdown method that takes care of console logs, sometimes there isn't enough time for the logs to be sent to the API before Cloud's own onShutdown has already started processing.

We now wait for the unprocessed logs in the `onShutdown` before starting the actual cloud shutdown.

## Testing

Tested in Cloud with tests that were dropping logs (usually short tests had almost no logs, and longer tests tended to drop the Summary report). Problem went away.

You can also see this working by enabling `DEBUG=cloud`:

### Before
Notice how `logLines event` gets called after the Run URL has been printed, which is the last thing to be done `onShutdown` - those logs would be lost.
<img width="657" alt="Screenshot 2023-10-13 at 09 51 11" src="https://github.com/artilleryio/artillery/assets/39738771/a356d642-ae24-4848-9106-625e5dfd299d">

### After
waiting on unprocessed logs -> `textlog sent event` -> all the cleanup hooks run -> url is printed
<img width="671" alt="Screenshot 2023-10-13 at 09 50 02" src="https://github.com/artilleryio/artillery/assets/39738771/bbcb3f21-cafc-460a-8fa7-02a200c6f8b5">
