### PR TITLE
dep(playwright): update playwright version to 1.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5059,23 +5059,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/browser-chromium": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.39.0.tgz",
+      "integrity": "sha512-s1WPO0qOE7PIZcdcJEd4CHQgXf9rOwy00Den8DsXTI26n/Eqa2HzFSbLRE1Eh2nIJZFSGyKLbopHR0HkT8ClZw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@playwright/test": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
-      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.37.1"
+        "playwright": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -10940,7 +10948,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15896,24 +15903,26 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.37.1.tgz",
-      "integrity": "sha512-bgUXRrQKhT48zHdxDYQTpf//0xDfDd5hLeEhjuSw8rXEGoT9YeElpfvs/izonTNY21IQZ7d3s22jLxYaAnubbQ==",
-      "hasInstallScript": true,
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
       "dependencies": {
-        "playwright-core": "1.37.1"
+        "playwright-core": "1.39.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
-      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -22712,11 +22721,12 @@
       "version": "0.3.2",
       "license": "MPL-2.0",
       "dependencies": {
+        "@playwright/browser-chromium": "1.39.0",
         "debug": "^4.3.2",
-        "playwright": "1.37.1"
+        "playwright": "1.39.0"
       },
       "devDependencies": {
-        "@playwright/test": "1.37.1"
+        "@playwright/test": "1.39.0"
       }
     },
     "packages/artillery-engine-posthog": {
@@ -23857,6 +23867,7 @@
     "packages/commons": {
       "name": "@artilleryio/int-commons",
       "version": "2.0.1",
+      "license": "MPL-2.0",
       "dependencies": {
         "async": "^2.6.4",
         "cheerio": "^1.0.0-rc.10",
@@ -23870,6 +23881,7 @@
     "packages/core": {
       "name": "@artilleryio/int-core",
       "version": "2.1.0",
+      "license": "MPL-2.0",
       "dependencies": {
         "@artilleryio/int-commons": "*",
         "@artilleryio/sketches-js": "^2.1.1",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,10 +1,8 @@
-FROM mcr.microsoft.com/playwright:v1.37.1
+FROM mcr.microsoft.com/playwright:v1.39.0
 LABEL maintainer="team@artillery.io"
 
-RUN npm install -g artillery artillery-engine-playwright && \
+RUN npm install -g artillery \
         npm cache clean --force && \
-        rm -rf /root/.cache && \
-        rm -rf /ms-playwright/firefox* && \
-        rm -rf /ms-playwright/webkit*
+        rm -rf /root/.cache &&
 
 ENTRYPOINT ["/usr/bin/artillery"]

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -11,9 +11,10 @@
   "license": "MPL-2.0",
   "dependencies": {
     "debug": "^4.3.2",
-    "playwright": "1.37.1"
+    "playwright": "1.39.0",
+    "@playwright/browser-chromium": "1.39.0"
   },
   "devDependencies": {
-    "@playwright/test": "1.37.1"
+    "@playwright/test": "1.39.0"
   }
 }


### PR DESCRIPTION
## Description 
Updating Playwright version. This will release a canary which can then be used to test and release Fargate.

Release details:
- https://github.com/microsoft/playwright/releases/tag/v1.39.0
- https://github.com/microsoft/playwright/releases/tag/v1.38.1
- https://github.com/microsoft/playwright/releases/tag/v1.38.0

## Breaking Changes
Since our previous version (1.37.1), the following breaking changes were released:

- **Playwright no longer downloads browsers automatically:** this affects Artillery's engine. However, we can now use the [workaround described here](https://github.com/microsoft/playwright/releases/tag/v1.38.0) of installing the browser directly in the dependency via `@playwright/browser-chromium`. Despite this being listed as the `not recommended` option, I believe this is the most sensible option for Artillery as a consumer of Playwright. It also has the nice added bonus of not needing to uninstall the browsers manually anymore.
- The remaining changes were mostly bug fixes or changes to `@playwright/test` API's and shouldn't affect us;

## Testing

- Tested against all Playwright examples
- Tested using the new `test.step` API

## Pre-merge checklist

- [x] Does this require a changelog entry?