### PR TITLE
fix(docker): remove playwright browsers from image

### DIFF
--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \
         npm cache clean --force && \
-        rm -rf /root/.cache &&
+        rm -rf /root/.cache && \
+        rm -rf /ms-playwright/firefox* && \
+        rm -rf /ms-playwright/webkit*
 
 ENTRYPOINT ["/usr/bin/artillery"]


### PR DESCRIPTION
## Description

Related to https://github.com/artilleryio/artillery/pull/2230, where this was removed. The playwright image (`mcr.microsoft.com/playwright:v1.39.0`) actually still contains all the browsers, regardless of what we install in the package, so we still need to manually remove them.