### PR TITLE
fix(http): add debug log when got errors

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -712,6 +712,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           })
           .catch((gotErr) => {
             // TODO: Handle the error properly with run hooks
+            debug(gotErr);
             return callback(gotErr, context);
           });
       }


### PR DESCRIPTION
## Description

Currently we are swallowing those errors, because we only show err.code, and don't log with debug anything else: `ee.emit('error', taskErr.code || taskErr.message);`

So the user only gets `ERR_GOT_REQUEST_ERROR` in the report, with no other clues. We have a user experiencing that here: https://github.com/artilleryio/artillery/discussions/958#discussioncomment-7339572

### Before

<img width="585" alt="Screenshot 2023-10-23 at 15 26 00" src="https://github.com/artilleryio/artillery/assets/39738771/7489e5b6-b203-4253-a9a9-21540fb1988d">

### After

<img width="739" alt="Screenshot 2023-10-23 at 15 26 43" src="https://github.com/artilleryio/artillery/assets/39738771/758bcd1c-119c-4058-9b9d-0d1a025e41c1">

## Pre-Merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?