### PR TITLE
feat(playwright): add trace support for playwright with otel reporter

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -20,21 +20,22 @@ const {
 } = require('@opentelemetry/semantic-conventions');
 
 const {
-  AsyncHooksContextManager
+  AsyncLocalStorageContextManager
 } = require('@opentelemetry/context-async-hooks');
-const contextManager = new AsyncHooksContextManager();
+const contextManager = new AsyncLocalStorageContextManager();
 contextManager.enable();
 context.setGlobalContextManager(contextManager);
 
 class OTelReporter {
   constructor(config, events, script) {
+    this.config = config;
     this.script = script;
     this.events = events;
     if (
       process.env.DEBUG &&
       process.env.DEBUG === 'plugin:publish-metrics:open-telemetry'
     ) {
-      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
     }
     this.metricExporters = {
       'otlp-proto'(options) {
@@ -122,6 +123,7 @@ class OTelReporter {
       });
     }
 
+    // Traces
     if (config.traces) {
       this.traceConfig = config.traces;
       this.validateExporter(
@@ -133,28 +135,53 @@ class OTelReporter {
 
       this.configureTrace(this.traceConfig);
 
-      attachScenarioHooks(script, [
-        {
-          type: 'beforeRequest',
-          name: 'startOTelSpan',
-          hook: this.startHTTPRequestSpan.bind(this)
-        },
-        {
-          type: 'afterResponse',
-          name: 'exportOTelSpan',
-          hook: this.endHTTPRequestSpan.bind(this)
-        },
-        {
-          type: 'beforeScenario',
-          name: 'startScenarioSpan',
-          hook: this.startScenarioSpan('http').bind(this)
-        },
-        {
-          type: 'afterScenario',
-          name: 'endScenarioSpan',
-          hook: this.endScenarioSpan('http').bind(this)
-        }
-      ]);
+      // Create set of all engines used in test -> even though we only support Playwright and HTTP engine for now this is future compatible
+      this.engines = new Set();
+      const scenarios = this.script.scenarios || [];
+      scenarios.forEach((scenario) => {
+        scenario.engine
+          ? this.engines.add(scenario.engine)
+          : this.engines.add('http');
+      });
+
+      if (this.engines.has('http')) {
+        attachScenarioHooks(script, [
+          {
+            type: 'beforeRequest',
+            name: 'startOTelSpan',
+            hook: this.startHTTPRequestSpan.bind(this)
+          },
+          {
+            type: 'afterResponse',
+            name: 'exportOTelSpan',
+            hook: this.endHTTPRequestSpan.bind(this)
+          },
+          {
+            type: 'beforeScenario',
+            name: 'startScenarioSpan',
+            hook: this.startScenarioSpan('http').bind(this)
+          },
+          {
+            type: 'afterScenario',
+            name: 'endScenarioSpan',
+            hook: this.endScenarioSpan('http').bind(this)
+          }
+        ]);
+      }
+
+      if (this.engines.has('playwright')) {
+        // Create tracer for Playwright engine
+        this.playwrightTracer = trace.getTracer('artillery-playwright');
+
+        attachScenarioHooks(script, [
+          {
+            engine: 'playwright',
+            type: 'traceFlowFunction',
+            name: 'runOtelTracingForPlaywright',
+            hook: this.runOtelTracingForPlaywright.bind(this)
+          }
+        ]);
+      }
     }
   }
 
@@ -454,6 +481,150 @@ class OTelReporter {
       // We don't do anything, if error occurs at this point it will be due to us already ending the span in beforeRequest hook in case of an error.
     }
     return done();
+  }
+
+  async runOtelTracingForPlaywright(
+    page,
+    vuContext,
+    events,
+    userFlowFunction,
+    specName
+  ) {
+    // Start scenarioSpan as a root span for the trace and set it as active context
+    return await this.playwrightTracer.startActiveSpan(
+      specName || 'Scenario execution',
+      { kind: SpanKind.CLIENT },
+      async (scenarioSpan) => {
+        scenarioSpan.setAttribute('vu.uuid', vuContext.vars.$uuid);
+        // Set variables to track state and context
+        const ctx = context.active();
+        let lastPageUrl;
+        let pageUrl;
+        let pageSpan;
+
+        // Listen to histograms to capture web vitals and other metrics set by Playwright engine, set them as attributes and if they are web vitals, as events too
+        events.on('histogram', (name, value, metadata) => {
+          // vuId from event must match current vuId
+          if (!metadata || metadata.vuId !== vuContext.vars.$uuid) {
+            return;
+          }
+
+          // only look for page metrics or memory_used_mb metric. step metrics are handled separately in the step helper itself
+          if (
+            !name.startsWith('browser.page') &&
+            name !== 'browser.memory_used_mb'
+          ) {
+            return;
+          }
+
+          // associate only the metrics that belong to the page
+          if (metadata.url !== pageSpan.name.replace('Page: ', '')) {
+            return;
+          }
+          const webVitals = ['LCP', 'FCP', 'CLS', 'TTFB', 'INP', 'FID'];
+
+          try {
+            const attrs = {};
+            const metricName =
+              name === 'browser.memory_used_mb' ? name : name.split('.')[2];
+
+            if (webVitals.includes(metricName)) {
+              attrs[`web_vitals.${metricName}.value`] = value;
+              attrs[`web_vitals.${metricName}.rating`] = metadata.rating;
+              pageSpan.addEvent(metricName, attrs);
+            } else {
+              attrs[metricName] = value;
+            }
+            pageSpan.setAttributes(attrs);
+          } catch (err) {
+            throw new Error(err);
+          }
+        });
+
+        // Upon navigation to main frame, if the URL is different than existing page span, the existing page span is closed and new opened with new URL
+        page.on('framenavigated', (frame) => {
+          //only interested in mainframe navigations (not iframes, etc)
+          if (frame !== page.mainFrame()) {
+            return;
+          }
+
+          pageUrl = page.url();
+
+          //only create a new span if the currently navigated page is different.
+          //this is because we can have multiple framenavigated for the same url, but we're only interested in navigation changes
+          if (pageUrl !== lastPageUrl) {
+            scenarioSpan.addEvent(`navigated to ${page.url()}`);
+            if (pageSpan) {
+              pageSpan.end();
+            }
+
+            pageSpan = this.playwrightTracer.startSpan(
+              'Page: ' + pageUrl,
+              { kind: SpanKind.CLIENT },
+              ctx
+            );
+            pageSpan.setAttribute('vu.uuid', vuContext.vars.$uuid);
+            lastPageUrl = pageUrl;
+          }
+        });
+
+        try {
+          // Set the tracing this.step function to test object which is exposed to the user
+          const test = {
+            step: (
+              await this.step(scenarioSpan, this.playwrightTracer, events, page)
+            ).bind(this)
+          };
+          // Execute the user-provided processor function within the context of the new span
+          await userFlowFunction(page, vuContext, events, test);
+        } catch (err) {
+          scenarioSpan.recordException(err, Date.now());
+          scenarioSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err.message
+          });
+          throw err;
+        } finally {
+          scenarioSpan.end();
+        }
+      }
+    );
+  }
+
+  async step(parent, tracer, events) {
+    return async function (stepName, callback, attributes) {
+      // Set the parent context to be scenarioSpan and within it we create step spans
+      return contextManager.with(
+        trace.setSpan(context.active(), parent),
+        async () => {
+          const span = tracer.startSpan(
+            stepName,
+            { kind: SpanKind.CLIENT },
+            context.active()
+          );
+          const startTime = Date.now();
+
+          try {
+            if (attributes) {
+              span.setAttributes(attributes);
+            }
+
+            await callback();
+          } catch (err) {
+            debug('There has been an error during step execution: ', err);
+            span.recordException(err, Date.now());
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: err.message
+            });
+          } finally {
+            const difference = Date.now() - startTime;
+            events.emit('histogram', `browser.step.${stepName}`, difference);
+            span.end();
+          }
+        }
+      );
+    };
   }
 
   validateExporter(supportedExporters, exporter, type) {

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -599,6 +599,9 @@ class OTelReporter {
           });
           throw err;
         } finally {
+          if (pageSpan && !pageSpan._ended) {
+            pageSpan.end();
+          }
           scenarioSpan.end();
         }
       }


### PR DESCRIPTION
# Description
## What
Tracing support for the Playwright Engine through OpenTelemetry reporter (publish-metrics plugin).

## How
### Spans
Tracing is implemented in 2 ways:
- Span is created for each `step` function call. (The `step` function is provided inside the `test` object argument of the processor `flow` function)
- Span is created for each `framenavigated` event where the main frame's `page.url()` changes, and is active until the next main frame change, portraying the time spent on each page. 

Each of these spans is nested within the root scenario span, creating an individual trace per scenario/VU run.

### Metrics
- Web vitals are added as attributes and events on corresponding `pageSpan`  as they happen, 
-  When `extendedMetrics` setting is set to `true`, other metrics emitted by the engine (`dominteractive`, `browser.memory_used_mb`) will be set as attributes as well.
- VU `uuid` is set on each span
- If `attributes` are set in the OpenTelemetry reporter config, they will be added to all spans.

### Errors
In case of an error, spans `SpanStatus` is set to `ERROR` and an `exception` is recorded on the span that contains additional info (e.g. exceptions stack trace)

### Configuration
Configuration is the same as for HTTP engine, when tracing is configured inside the OpenTelemetry reporter (within publish-metrics plugin) Playwright scenarios will automatically be traced.

### Note
If for some reason the same test is configured with both HTTP and Playwright engine scenarios, they will both be traced, and the same is true for `metrics`. The configuration provided will be applied to both engines.

## Example
Example user processor `flow` function:
```javascript
async function testFlow(page, userContext, events, test) {
  await page.goto('https://www.artillery.io/');
  
  await test.step('Go to cloud', async()=>{
      await page
      .getByLabel('Main navigation')
      .getByRole('link', { name: 'Cloud' }).click
  })
  
  await test.step('Click on Join button', async()=>{
    const b = await page
      .getByRole('button', { name: 'Join Artillery Cloud early access waitlist' })
    await b.click()
  })
}
```

Resulting scenario trace in Honeycomb UI:
<img width="1002" alt="Screenshot 2023-10-27 at 19 23 43" src="https://github.com/artilleryio/artillery/assets/39635558/1abce624-5348-4a3a-9740-59a81beacc66">

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?