### PR TITLE
fix(artillery): template variables coming from env var correctly

### DIFF
--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -80,6 +80,7 @@ async function resolveConfigTemplates(script, flags) {
   script.config = engineUtil.template(script.config, {
     vars: {
       $processEnvironment: process.env,
+      $env: process.env,
       $environment: flags.environment,
       ...cliVariables
     },

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -318,6 +318,66 @@ tap.test('Environment variables can be loaded from dotenv files', async (t) => {
   );
 });
 
+tap.test('Environment variables can be loaded using $env', async (t) => {
+  // test uses these variables (with $env) in scenarios, and in config (nested and root-level)
+  const variables = {
+    URL: 'http://asciiart.artillery.io:8080/',
+    ENVIRONMENT: 'testing',
+    ARRIVAL_RATE: 2,
+    NESTED_HEADER_VALUE: 'abc123'
+  };
+
+  const reportFile = 'report-with-env.json';
+  const reportFilePath = await getRootPath(reportFile);
+  const [exitCode, result] = await execute(
+    ['run', 'test/scripts/with-process-env/with-env.yml', '-o', reportFile],
+    { env: { ...variables } }
+  );
+  const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  t.ok(
+    deleteFile(reportFilePath) &&
+      exitCode === 0 &&
+      json.aggregate.counters['http.codes.200'] === 2 &&
+      result.stdout.includes(`Environment is ${variables.ENVIRONMENT}`) &&
+      result.stdout.includes(`Header is ${variables.NESTED_HEADER_VALUE}`)
+  );
+});
+
+tap.test(
+  'Environment variables can be loaded using legacy $processEnvironment',
+  async (t) => {
+    // test uses these variables (with $processEnvironment) in scenarios, and in config (nested and root-level)
+    const variables = {
+      URL: 'http://asciiart.artillery.io:8080/',
+      ENVIRONMENT: 'testing',
+      ARRIVAL_RATE: 2,
+      NESTED_HEADER_VALUE: 'abc123'
+    };
+
+    const reportFile = 'report-with-processEnvironment.json';
+    const reportFilePath = await getRootPath(reportFile);
+    const [exitCode, result] = await execute(
+      [
+        'run',
+        'test/scripts/with-process-env/with-processEnvironment.yml',
+        '-o',
+        reportFile
+      ],
+      { env: { ...variables } }
+    );
+    const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+    t.ok(
+      deleteFile(reportFilePath) &&
+        exitCode === 0 &&
+        json.aggregate.counters['http.codes.200'] === 2 &&
+        result.stdout.includes(`Environment is ${variables.ENVIRONMENT}`) &&
+        result.stdout.includes(`Header is ${variables.NESTED_HEADER_VALUE}`)
+    );
+  }
+);
+
 tap.test('Script using a plugin', async (t) => {
   const abortController = new AbortController();
   // a target is needed for the plugin to output properly

--- a/packages/artillery/test/scripts/with-process-env/processor.js
+++ b/packages/artillery/test/scripts/with-process-env/processor.js
@@ -1,6 +1,4 @@
 function myBeforeRequestHandler(req, res, context, ee, next) {
-  //Change your function name and add your logic here.
-  //For more information, check: https://docs.art/http-reference#function-signatures
   console.log(`Environment is ${context.vars.targetEnv}`);
   console.log(`Header is ${req.headers['x-fake-header']}`);
   next();

--- a/packages/artillery/test/scripts/with-process-env/processor.js
+++ b/packages/artillery/test/scripts/with-process-env/processor.js
@@ -1,0 +1,11 @@
+function myBeforeRequestHandler(req, res, context, ee, next) {
+  //Change your function name and add your logic here.
+  //For more information, check: https://docs.art/http-reference#function-signatures
+  console.log(`Environment is ${context.vars.targetEnv}`);
+  console.log(`Header is ${req.headers['x-fake-header']}`);
+  next();
+}
+
+module.exports = {
+  myBeforeRequestHandler
+};

--- a/packages/artillery/test/scripts/with-process-env/with-env.yml
+++ b/packages/artillery/test/scripts/with-process-env/with-env.yml
@@ -1,0 +1,18 @@
+config:
+  target: "https://www.wontresolve.none"
+  phases:
+    - duration: 1
+      arrivalRate: "{{ $env.ARRIVAL_RATE }}"
+  variables:
+    targetEnv: "{{ $env.ENVIRONMENT }}"
+  http:
+    defaults:
+      headers:
+        x-fake-header: "{{ $env.NESTED_HEADER_VALUE }}"
+  processor: ./processor.js
+
+scenarios:
+  - flow:
+      - get:
+          afterResponse: myBeforeRequestHandler
+          url: "{{ $env.URL }}"

--- a/packages/artillery/test/scripts/with-process-env/with-processEnvironment.yml
+++ b/packages/artillery/test/scripts/with-process-env/with-processEnvironment.yml
@@ -1,0 +1,18 @@
+config:
+  target: "https://www.wontresolve.none"
+  phases:
+    - duration: 1
+      arrivalRate: "{{ $processEnvironment.ARRIVAL_RATE }}"
+  variables:
+    targetEnv: "{{ $processEnvironment.ENVIRONMENT }}"
+  http:
+    defaults:
+      headers:
+        x-fake-header: "{{ $processEnvironment.NESTED_HEADER_VALUE }}"
+  processor: ./processor.js
+
+scenarios:
+  - flow:
+      - get:
+          afterResponse: myBeforeRequestHandler
+          url: "{{ $processEnvironment.URL }}"


### PR DESCRIPTION
## Description

Solves https://github.com/artilleryio/artillery/issues/2258

## Testing
Automated tests were added before introducing the change.

### Before

<img width="655" alt="Screenshot 2023-10-30 at 16 35 34" src="https://github.com/artilleryio/artillery/assets/39738771/5d966e84-d6f9-4126-91ac-2f1ac5d8c53a">


### After

<img width="329" alt="Screenshot 2023-10-30 at 16 57 22" src="https://github.com/artilleryio/artillery/assets/39738771/f002b8b0-880f-461c-997e-203a3c3662f2">

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? **No, has already been done to move away from $processEnvironment**
- [x] Does this require a changelog entry? Yes