### PR TITLE
feat(core): allow multiple time formats in think times

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23876,8 +23876,14 @@
         "deep-for-each": "^3.0.0",
         "espree": "^9.4.1",
         "jsonpath-plus": "^7.2.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.19",
+        "ms": "^2.1.3"
       }
+    },
+    "packages/commons/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "packages/core": {
       "name": "@artilleryio/int-core",

--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -10,6 +10,7 @@ const deepForEach = require('deep-for-each');
 const espree = require('espree');
 const L = require('lodash');
 const vm = require('vm');
+const ms = require('ms');
 const A = require('async');
 const { JSONPath: jsonpath } = require('jsonpath-plus');
 const cheerio = require('cheerio');
@@ -42,7 +43,15 @@ function createThink(requestSpec, opts) {
   let thinkspec = requestSpec.think;
 
   let f = function think(context, callback) {
-    let thinktime = parseFloat(template(thinkspec, context)) * 1000;
+    let templatedThink = template(thinkspec, context);
+    let thinktime = Number.isInteger(L.toNumber(templatedThink))
+      ? ms(`${templatedThink}s`)
+      : ms(templatedThink);
+
+    if (typeof thinktime == 'undefined') {
+      throw new Error(`Invalid think time: ${templatedThink || thinkspec}`);
+    }
+
     if (requestSpec.jitter || opts.jitter) {
       thinktime = jitter(`${thinktime}:${requestSpec.jitter || opts.jitter}`);
     }

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -10,7 +10,8 @@
     "deep-for-each": "^3.0.0",
     "espree": "^9.4.1",
     "jsonpath-plus": "^7.2.0",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "ms": "^2.1.3"
   },
   "scripts": {
     "lint": "eslint --ext \".js,.ts,.tsx\" .",

--- a/packages/core/test/core/scripts/thinks_http.json
+++ b/packages/core/test/core/scripts/thinks_http.json
@@ -3,7 +3,7 @@
     "target": "http://127.0.0.1:3003",
     "phases": [{ "duration": 10, "arrivalRate": 1 }],
     "variables": {
-      "durations": [0, 1, 2, 3, 4, 5]
+      "durations": [0, 1, 2, "3s", 4, 5]
     },
     "defaults": {
       "think": {
@@ -16,6 +16,7 @@
       "name": "Just think",
       "flow": [
         { "think": 2 },
+        { "think": "2s", "jitter": "10%" },
         { "think": "{{ durations }}" },
         { "think": "2", "jitter": 2 },
         { "think": "2", "jitter": "50%" }

--- a/packages/core/test/core/test_think.js
+++ b/packages/core/test/core/test_think.js
@@ -10,7 +10,29 @@ test('think', function (t) {
   runner(script).then(function (ee) {
     ee.on('done', function (nr) {
       const report = SSMS.legacyReport(nr).report();
-      t.ok('stats should be empty', report.codes === {});
+      t.ok(Object.keys(report.errors).length === 0, 'no errors');
+      t.ok(Object.keys(report.codes).length === 0, 'stats should be empty');
+      ee.stop().then(() => {
+        t.end();
+      });
+    });
+    ee.run();
+  });
+});
+
+test('think - invalid think time', function (t) {
+  const script = l.cloneDeep(require('./scripts/thinks_http.json'));
+  delete script.scenarios[0].flow;
+  script.scenarios[0].flow = [{ think: '1 potatoe' }];
+  runner(script).then(function (ee) {
+    ee.on('done', function (nr) {
+      const report = SSMS.legacyReport(nr).report();
+      console.log(report);
+      t.ok(
+        Object.keys(report.errors).includes('Invalid think time: 1 potatoe'),
+        'should have an error in report'
+      );
+      t.ok(Object.keys(report.codes).length === 0, 'stats should be empty');
       ee.stop().then(() => {
         t.end();
       });
@@ -28,8 +50,8 @@ test('think - with defaults from config.http.defaults instead', function (t) {
   runner(script).then(function (ee) {
     ee.on('done', function (nr) {
       const report = SSMS.legacyReport(nr).report();
-
-      t.ok('stats should be empty', report.codes === {});
+      t.ok(Object.keys(report.errors).length === 0, 'no errors');
+      t.ok(Object.keys(report.codes).length === 0, 'stats should be empty');
       ee.stop().then(() => {
         t.end();
       });


### PR DESCRIPTION
## Description

- Complements https://github.com/artilleryio/artillery/pull/2084 by allowing think times to also work similarly, causing less confusion (like for example this discussion: https://github.com/artilleryio/artillery/discussions/2222).
- Also fixes the `think_time` tests which were not doing anything (`t.ok('stats should be empty', report.codes === {});` doesn't work, as the first argument is meant to be the assertion, not the msg. Also `report.codes === {}` doesn't work as a check either)

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? _Yes_
- [x] Does this require a changelog entry? _Yes_
