### PR TITLE
feat(artillery): collect per url metrics by default

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -5,6 +5,7 @@ const {
   parseScript,
   addOverrides,
   addVariables,
+  addDefaultPlugins,
   resolveConfigTemplates,
   checkConfig
 } = require('../../util');
@@ -265,7 +266,8 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
 
     // TODO: Wire up workerLog or something like that
     const consoleReporter = createConsoleReporter(launcher.events, {
-      quiet: flags.quiet || false
+      quiet: flags.quiet || false,
+      script
     });
 
     let reporters = [consoleReporter];
@@ -492,7 +494,9 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
   }
 
   script5.config.statsInterval = script5.config.statsInterval || 30;
-  return script5;
+
+  const script6 = addDefaultPlugins(script5);
+  return script6;
 }
 
 async function readPayload(script) {

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -264,11 +264,11 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
     );
     let intermediates = [];
 
-    const suppressMetrics = getPluginMetricsToSuppress(script) || []
+    const metricsToSuppress = getPluginMetricsToSuppress(script);
     // TODO: Wire up workerLog or something like that
     const consoleReporter = createConsoleReporter(launcher.events, {
       quiet: flags.quiet || false,
-      suppressMetrics: suppressMetrics
+      metricsToSuppress
     });
 
     let reporters = [consoleReporter];
@@ -689,18 +689,17 @@ function getLogFilename(output, nameFormat) {
   return logfile;
 }
 
-function getPluginMetricsToSuppress(script){
-  if (!script.config.plugins){
-    return
+function getPluginMetricsToSuppress(script) {
+  if (!script.config.plugins) {
+    return [];
   }
-  const metrics = []
-  for (const [plugin, options] of Object.entries(script.config.plugins)){
-    if (options.suppressOutput){
-      metrics.push(`plugins.${plugin}`)
+  const metrics = [];
+  for (const [plugin, options] of Object.entries(script.config.plugins)) {
+    if (options.suppressOutput) {
+      metrics.push(`plugins.${plugin}`);
     }
   }
-  return metrics
+  return metrics;
 }
-
 
 module.exports = RunCommand;

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -264,10 +264,11 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
     );
     let intermediates = [];
 
+    const suppressMetrics = getPluginMetricsToSuppress(script) || []
     // TODO: Wire up workerLog or something like that
     const consoleReporter = createConsoleReporter(launcher.events, {
       quiet: flags.quiet || false,
-      script
+      suppressMetrics: suppressMetrics
     });
 
     let reporters = [consoleReporter];
@@ -687,5 +688,19 @@ function getLogFilename(output, nameFormat) {
 
   return logfile;
 }
+
+function getPluginMetricsToSuppress(script){
+  if (!script.config.plugins){
+    return
+  }
+  const metrics = []
+  for (const [plugin, options] of Object.entries(script.config.plugins)){
+    if (options.suppressOutput){
+      metrics.push(`plugins.${plugin}`)
+    }
+  }
+  return metrics
+}
+
 
 module.exports = RunCommand;

--- a/packages/artillery/lib/console-reporter.js
+++ b/packages/artillery/lib/console-reporter.js
@@ -29,6 +29,7 @@ function ConsoleReporter(opts) {
   this.outputFormat = opts.outputFormat || process.env.OUTPUT_FORMAT || 'new';
 
   this.quiet = opts.quiet;
+  this.script = opts.script;
   this.spinner = ora({
     spinner: 'dots'
   });
@@ -228,6 +229,10 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
 
     let result = [];
     for (const metricName of sortedAlphabetically) {
+
+      if(suppressedOutputMetric(metricName, opts.script)) {
+        continue;
+      }
       if (typeof report.counters?.[metricName] !== 'undefined') {
         result = result.concat(printCounters([metricName], report));
       }
@@ -417,4 +422,8 @@ function printSummaries(summaries, report) {
     // result.push(padded(`${trimName(n)}:`, `min: ${r.min} | max: ${r.max} | p50: ${r.p50} | p95: ${r.p95} | p99: ${r.p99}`));
   }
   return result;
+}
+
+function suppressedOutputMetric(metricName, script) {
+  return script.config.plugins['metrics-by-endpoint'].suppressOutput && metricName.includes('plugins.metrics-by-endpoint')
 }

--- a/packages/artillery/lib/console-reporter.js
+++ b/packages/artillery/lib/console-reporter.js
@@ -29,7 +29,7 @@ function ConsoleReporter(opts) {
   this.outputFormat = opts.outputFormat || process.env.OUTPUT_FORMAT || 'new';
 
   this.quiet = opts.quiet;
-  this.metricsToSuppress = opts.suppressMetrics;
+  this.metricsToSuppress = opts.metricsToSuppress;
   this.spinner = ora({
     spinner: 'dots'
   });
@@ -230,9 +230,9 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
     let result = [];
     for (const metricName of sortedAlphabetically) {
 
-      if(shouldSuppressOutput(metricName, this.metricsToSuppress)) {
+      if (shouldSuppressOutput(metricName, this.metricsToSuppress)) {
         continue;
-      }
+      };
       if (typeof report.counters?.[metricName] !== 'undefined') {
         result = result.concat(printCounters([metricName], report));
       }
@@ -425,8 +425,8 @@ function printSummaries(summaries, report) {
 }
 
 function shouldSuppressOutput(currMetricName, suppressMetricsList) {
-  if (!suppressMetricsList){
-    return
-  }
-  return suppressMetricsList.some((metric)=> currMetricName.includes(metric))
+  if (!suppressMetricsList) {
+    return;
+  };
+  return suppressMetricsList.some((metric)=> currMetricName.includes(metric));
 }

--- a/packages/artillery/lib/console-reporter.js
+++ b/packages/artillery/lib/console-reporter.js
@@ -29,7 +29,7 @@ function ConsoleReporter(opts) {
   this.outputFormat = opts.outputFormat || process.env.OUTPUT_FORMAT || 'new';
 
   this.quiet = opts.quiet;
-  this.script = opts.script;
+  this.metricsToSuppress = opts.suppressMetrics;
   this.spinner = ora({
     spinner: 'dots'
   });
@@ -230,7 +230,7 @@ ConsoleReporter.prototype.printReport = function printReport(report, opts) {
     let result = [];
     for (const metricName of sortedAlphabetically) {
 
-      if(suppressedOutputMetric(metricName, opts.script)) {
+      if(shouldSuppressOutput(metricName, this.metricsToSuppress)) {
         continue;
       }
       if (typeof report.counters?.[metricName] !== 'undefined') {
@@ -424,6 +424,9 @@ function printSummaries(summaries, report) {
   return result;
 }
 
-function suppressedOutputMetric(metricName, script) {
-  return script.config.plugins['metrics-by-endpoint'].suppressOutput && metricName.includes('plugins.metrics-by-endpoint')
+function shouldSuppressOutput(currMetricName, suppressMetricsList) {
+  if (!suppressMetricsList){
+    return
+  }
+  return suppressMetricsList.some((metric)=> currMetricName.includes(metric))
 }

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -21,6 +21,7 @@ module.exports = {
   parseScript,
   addOverrides,
   addVariables,
+  addDefaultPlugins,
   resolveConfigTemplates,
   checkConfig,
   renderVariables,
@@ -72,6 +73,26 @@ async function addVariables(script, flags) {
   }
 
   return script;
+}
+
+function addDefaultPlugins(script) {
+  const finalScript = _.cloneDeep(script);
+
+  if (!script.config.plugins) {
+    finalScript.config.plugins = {}
+  }
+
+  const additionalPluginsAndOptions = {
+    'metrics-by-endpoint': { suppressOutput: true, stripQueryString: true }
+  }
+
+  for (const [pluginName, pluginOptions] of Object.entries(additionalPluginsAndOptions)) {
+    if (!finalScript.config.plugins[pluginName]) {
+      finalScript.config.plugins[pluginName] = pluginOptions
+    }
+  }
+
+  return finalScript
 }
 
 async function resolveConfigTemplates(script, flags) {

--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -180,6 +180,30 @@ tap.test(
   }
 );
 
+tap.test('Loads metrics-by-endpoint plugin by default, with output supressed', async (t) => {
+  const reportFile = 'report-metrics-by-endpoint.json';
+  const reportFilePath = await getRootPath(reportFile);
+  const [exitCode, output] = await execute([
+    'run',
+    'test/scripts/hello.json',
+    '--config',
+    './test/scripts/hello_config.json',
+    '-o',
+    `${reportFile}`
+  ])
+
+  const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+  const pluginPrefix = 'plugins.metrics-by-endpoint';
+  
+  t.ok(
+    deleteFile(reportFilePath) &&
+    exitCode === 0 &&
+    !output.stdout.includes(pluginPrefix) &&
+    Object.keys(json.aggregate.counters).some(key => key.includes(pluginPrefix)) &&
+    Object.keys(json.aggregate.summaries).some(key => key.includes(pluginPrefix))
+  );
+})
+
 tap.test('Run a script overwriting default options (output)', async (t) => {
   const reportFile = 'artillery_report_custom.json';
   const [exitCode, output] = await execute([


### PR DESCRIPTION
# Description

## What
Collecting per-url metrics by default by loading the `metrics-by-endpoint` plugin by default behind the scenes.

## How

- Creating `addDefaultPlugins` function that takes the final version of the script and adds the  default plugins and their config if they are not already listed on the script. (For now we only add `metrics-by-endpoint` by default but the function is created with extensibility in mind.)
The `metrics-by-endpoint` plugin  is set on the script with the two config settings: 
  - `suppressOutput` - a newly created setting, used to exclude plugin created metrics from console
  - `stripQueryString` - existing setting, removes query string from endpoint

- `addDefaultPlugins` is then called in the `prepareTestExecutionPlan` function as a last modification to the script.
- The final script is then passed to the `ConsoleReporter` where we use it to check for `suppressOutput` along with the default metric prefix to filter out and exclude plugin created metrics when reporting to the console.
It is worth noting that if `suppressOutput` setting is ever exposed to the user we would have to check for the `metricsPrefix` setting here as well. 

## Testing

A `'Loads metrics-by-endpoint plugin by default, with output supressed'` test is created to test the new functionality, and it has been tested manually.

# Pre-merge checklist


- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?