### PR TITLE
test(core): make templates test have longer max time in ci

### DIFF
--- a/packages/core/test/core/unit/templates.test.js
+++ b/packages/core/test/core/unit/templates.test.js
@@ -87,9 +87,12 @@ test('buffers - huge buffers are OK', function (t) {
   t.same(b1, b2);
   console.log('# delta:', end - start);
 
-  const expectedMaxTime = (process.env.GITHUB_ACTIONS) ? 15 : 10;
+  const expectedMaxTime = process.env.GITHUB_ACTIONS ? 15 : 10;
   const timeTaken = end - start;
-  t.ok(timeTaken < expectedMaxTime, `expected to be templated in <${expectedMaxTime}ms. took ${timeTaken}ms}`);
+  t.ok(
+    timeTaken < expectedMaxTime,
+    `expected to be templated in <${expectedMaxTime}ms. took ${timeTaken}ms}`
+  );
 
   t.end();
 });
@@ -157,23 +160,28 @@ test('template functions', (t) => {
     vars: { greeting: 'hello', foo: 'bar' }
   };
 
+  const templateRandomString = template('{{ $randomString( ) }}', context);
   t.ok(
-    template('{{ $randomString( ) }}', context).length > 0,
-    'template functions may be used'
+    templateRandomString.length > 0,
+    `templated string should have length > 0. got ${templateRandomString}`
   );
 
+  const templateMultipleFunctions = template(
+    '{{ $randomString(3) }} hello world {{ $randomString(10) }} {{ $randomNumber(   100, 900) }}',
+    context
+  );
   t.ok(
-    template(
-      '{{ $randomString(3) }} hello world {{ $randomString(10) }} {{ $randomNumber(   100, 900) }}',
-      context
-    ).length === 30,
-    'multiple template functions may be used'
+    templateMultipleFunctions.length === 30,
+    `multiple template functions may be used. got ${templateMultipleFunctions} (length ${templateMultipleFunctions.length})`
   );
 
+  const templateFuncAndVarSubstitutions = template(
+    '{{ greeting}} {{ $randomString(5) }}! {{ foo }}',
+    context
+  );
   t.ok(
-    template('{{ greeting}} {{ $randomString(5) }}! {{ foo }}', context)
-      .length === 16,
-    'functions and variable substitutions may be mixed'
+    templateFuncAndVarSubstitutions.length === 16,
+    `functions and variable substitutions may be mixed. got ${templateFuncAndVarSubstitutions} (length ${templateFuncAndVarSubstitutions.length})`
   );
 
   t.end();

--- a/packages/core/test/core/unit/templates.test.js
+++ b/packages/core/test/core/unit/templates.test.js
@@ -86,7 +86,10 @@ test('buffers - huge buffers are OK', function (t) {
   const end = Date.now();
   t.same(b1, b2);
   console.log('# delta:', end - start);
-  t.ok(end - start < 10, 'templated in <10ms');
+
+  const expectedMaxTime = (process.env.GITHUB_ACTIONS) ? 20 : 10;
+  const timeTaken = end - start;
+  t.ok(timeTaken < expectedMaxTime, `expected to be templated in <${expectedMaxTime}ms. took ${timeTaken}ms}`);
 
   t.end();
 });

--- a/packages/core/test/core/unit/templates.test.js
+++ b/packages/core/test/core/unit/templates.test.js
@@ -87,7 +87,7 @@ test('buffers - huge buffers are OK', function (t) {
   t.same(b1, b2);
   console.log('# delta:', end - start);
 
-  const expectedMaxTime = (process.env.GITHUB_ACTIONS) ? 20 : 10;
+  const expectedMaxTime = (process.env.GITHUB_ACTIONS) ? 15 : 10;
   const timeTaken = end - start;
   t.ok(timeTaken < expectedMaxTime, `expected to be templated in <${expectedMaxTime}ms. took ${timeTaken}ms}`);
 


### PR DESCRIPTION
## Description

This test occasionally fails, but presumably only in CI. This could be due to the machine being attributed in CI occasionally not being powerful enough. 

- This PR makes the CI templated max time be 50% longer (let me know if you think this should be another value).
- We also add the time taken to the error log, so we can actually see how much it is taking in case it keeps failing. This will let us adjust the values better.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
