### PR TITLE
fix(ensure): improve handling of metric names with special chars

### DIFF
--- a/packages/artillery-plugin-ensure/index.js
+++ b/packages/artillery-plugin-ensure/index.js
@@ -7,6 +7,11 @@
 const debug = require('debug')('plugin:ensure');
 const filtrex = require('filtrex').compileExpression;
 const chalk = require('chalk');
+const {
+  hashString,
+  replaceMetricsWithHashes,
+  getHashedVarToValueMap
+} = require('./utils');
 
 class EnsurePlugin {
   constructor(script, events) {
@@ -87,9 +92,27 @@ class EnsurePlugin {
   // Combine counters/rates/summaries into a flat key->value object for filtrex
   static statsToVars(data) {
     const vars = Object.assign({}, data.report.counters, data.report.rates);
+
+    // Function to hash and assign keys from a given object to the vars object
+    const hashAndAssign = (obj) => {
+      for (const [key, value] of Object.entries(obj)) {
+        const hashedKey = hashString(key);
+        vars[key] = {
+          value,
+          hash: hashedKey
+        };
+      }
+    };
+
+    hashAndAssign(data.report.counters);
+    hashAndAssign(data.report.rates);
+
     for (const [name, values] of Object.entries(data.report.summaries || {})) {
       for (const [aggregation, value] of Object.entries(values)) {
-        vars[`${name}.${aggregation}`] = value;
+        vars[`${name}.${aggregation}`] = {
+          value,
+          hash: hashString(`${name}.${aggregation}`)
+        };
       }
     }
 
@@ -106,15 +129,25 @@ class EnsurePlugin {
           const metricName = Object.keys(o)[0]; // only one metric check per array entry
           const maxValue = o[metricName];
           const expr = `${metricName} < ${maxValue}`;
+
+          const hashedExpression = replaceMetricsWithHashes(
+            Object.keys(vars),
+            expr
+          );
           let f = () => {};
           try {
-            f = filtrex(expr);
+            f = filtrex(hashedExpression);
           } catch (err) {
             global.artillery.log(err);
           }
 
           // all threshold checks are strict:
-          checkTests.push({ f, strict: true, original: expr });
+          checkTests.push({
+            f,
+            strict: true,
+            original: expr,
+            hashed: hashedExpression
+          });
         }
       });
     }
@@ -125,14 +158,24 @@ class EnsurePlugin {
           const expression = o.expression;
           const strict = typeof o.strict === 'boolean' ? o.strict : true;
 
+          const hashedExpression = replaceMetricsWithHashes(
+            Object.keys(vars),
+            expression
+          );
+
           let f = () => {};
           try {
-            f = filtrex(expression);
+            f = filtrex(hashedExpression);
           } catch (err) {
             global.artillery.log(err);
           }
 
-          checkTests.push({ f, strict, original: expression });
+          checkTests.push({
+            f,
+            strict,
+            original: expression,
+            hashed: hashedExpression
+          });
         }
       });
     }
@@ -142,23 +185,40 @@ class EnsurePlugin {
       .forEach((k) => {
         const metricName = `http.response_time.${k}`;
         const maxValue = parseInt(checks[k], 10);
+        const expression = `${metricName} < ${maxValue}`;
+
+        const hashedExpression = replaceMetricsWithHashes(
+          Object.keys(vars),
+          expression
+        );
         let f = () => {};
         try {
-          f = filtrex(`${metricName} < ${maxValue}`);
+          f = filtrex(hashedExpression);
         } catch (err) {
           global.artillery.log(err);
         }
 
         // all legacy threshold checks are strict:
-        checkTests.push({ f, strict: true, original: `${k} < ${maxValue}` });
+        checkTests.push({
+          f,
+          strict: true,
+          original: `${k} < ${maxValue}`,
+          hash: hashedExpression
+        });
       });
 
     if (typeof checks.maxErrorRate !== 'undefined') {
       const maxValue = Number(checks.maxErrorRate);
       const expression = `((vusers.created - vusers.completed)/vusers.created * 100) <= ${maxValue}`;
+
+      const hashedExpression = replaceMetricsWithHashes(
+        Object.keys(vars),
+        expression
+      );
+
       let f = () => {};
       try {
-        f = filtrex(expression);
+        f = filtrex(hashedExpression);
       } catch (err) {
         global.artillery.log(err);
       }
@@ -166,7 +226,8 @@ class EnsurePlugin {
       checkTests.push({
         f,
         strict: true,
-        original: `maxErrorRate < ${maxValue}`
+        original: `maxErrorRate < ${maxValue}`,
+        hash: hashedExpression
       });
     }
 
@@ -174,8 +235,10 @@ class EnsurePlugin {
       global.artillery.log('\nChecks:');
     }
 
+    const hashedVarsMap = getHashedVarToValueMap(vars);
+
     checkTests.forEach((check) => {
-      const result = check.f(vars);
+      const result = check.f(hashedVarsMap);
       check.result = result;
       debug(`check ${check.original} -> ${result}`);
     });

--- a/packages/artillery-plugin-ensure/index.js
+++ b/packages/artillery-plugin-ensure/index.js
@@ -65,19 +65,21 @@ class EnsurePlugin {
         global.artillery.globalEvents.emit('checks', checkTests);
 
         checkTests
-          .sort((a, b) => (a.result < b.result) ? 1 : -1)
+          .sort((a, b) => (a.result < b.result ? 1 : -1))
           .forEach((check) => {
-          if (check.result !== 1) {
-            global.artillery.log(
-              `${chalk.red('fail')}: ${check.original}${check.strict ? '' : ' (optional)'}`
-            );
-            if (check.strict) {
-              global.artillery.suggestedExitCode = 1;
+            if (check.result !== 1) {
+              global.artillery.log(
+                `${chalk.red('fail')}: ${check.original}${
+                  check.strict ? '' : ' (optional)'
+                }`
+              );
+              if (check.strict) {
+                global.artillery.suggestedExitCode = 1;
+              }
+            } else {
+              global.artillery.log(`${chalk.green('ok')}: ${check.original}`);
             }
-          } else {
-            global.artillery.log(`${chalk.green('ok')}: ${check.original}`);
-          }
-        });
+          });
       }
     });
   }
@@ -139,7 +141,7 @@ class EnsurePlugin {
       .filter((k) => LEGACY_CONDITIONS.indexOf(k) > -1)
       .forEach((k) => {
         const metricName = `http.response_time.${k}`;
-        const maxValue = parseInt(checks[k]);
+        const maxValue = parseInt(checks[k], 10);
         let f = () => {};
         try {
           f = filtrex(`${metricName} < ${maxValue}`);

--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "tap ./test/*.spec.js --timeout 300 --no-coverage --color"
+    "test": "npm run test:unit && npm run test:acceptance",
+    "test:acceptance": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap ./test/*.spec.js --timeout 300 --no-coverage --color",
+    "test:unit": "tap ./test/*.unit.js --no-coverage --color"
   },
   "keywords": [],
   "author": "Artillery.io <team@artillery.io>",

--- a/packages/artillery-plugin-ensure/test/fixtures/processor.js
+++ b/packages/artillery-plugin-ensure/test/fixtures/processor.js
@@ -1,0 +1,20 @@
+function runFibonacci(req, context, ee, next) {
+  function fibonacci(num) {
+    if (num == 1) return 0;
+    if (num == 2) return 1;
+    return fibonacci(num - 1) + fibonacci(num - 2);
+  }
+  const time = Date.now();
+  fibonacci(35);
+  const difference = Date.now() - time;
+  ee.emit(
+    'histogram',
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-',
+    difference
+  );
+  next();
+}
+
+module.exports = {
+  runFibonacci
+};

--- a/packages/artillery-plugin-ensure/test/fixtures/scenario-custom-metrics.yml
+++ b/packages/artillery-plugin-ensure/test/fixtures/scenario-custom-metrics.yml
@@ -1,0 +1,14 @@
+config:
+  target: "http://asciiart.artillery.io:8080"
+  phases:
+    - duration: 2
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: processor.js
+
+scenarios:
+  - name: ensure Plug$n custom metrics.p99. (a1rb3nd3r)
+    flow:
+      - get:
+          beforeRequest: runFibonacci
+          url: "/"

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -31,7 +31,9 @@ test('works with multiple thresholds set', async (t) => {
     'Console did not include vusers.created check'
   );
   t.ok(
-    output.stdout.includes(`${chalk.green('ok')}: http.response_time.p99 < 10000`),
+    output.stdout.includes(
+      `${chalk.green('ok')}: http.response_time.p99 < 10000`
+    ),
     'Console did not include http.response_time.p99 check'
   );
 });
@@ -62,7 +64,9 @@ test('works with config under config.plugins.ensure instead', async (t) => {
     'Console did not include vusers.created check'
   );
   t.ok(
-    output.stdout.includes(`${chalk.green('ok')}: http.response_time.p99 < 10000`),
+    output.stdout.includes(
+      `${chalk.green('ok')}: http.response_time.p99 < 10000`
+    ),
     'Console did not include http.response_time.p99 check'
   );
 });
@@ -90,7 +94,9 @@ test('fails thresholds correctly', async (t) => {
       'Console did not include vusers.created check'
     );
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p99 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p99 < 1`
+      ),
       'Console did not include http.response_time.p99 failed check'
     );
   }
@@ -151,7 +157,9 @@ test('passes and fails correctly multiple conditions and thresholds', async (t) 
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p99 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p99 < 1`
+      ),
       'Console did not include http.response_time.p99 threshold check'
     );
     t.ok(
@@ -190,7 +198,9 @@ test('strict set to false correctly does not fail conditions', async (t) => {
   t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
 
   t.ok(
-    output.stdout.includes(`${chalk.red('fail')}: ${failingExpression} (optional)`),
+    output.stdout.includes(
+      `${chalk.red('fail')}: ${failingExpression} (optional)`
+    ),
     'Console did not include failing expression check with optional from strict'
   );
   t.ok(
@@ -224,7 +234,9 @@ test('works with legacy thresholds (passing and failing) together with new thres
       'Console did not p99 check'
     );
     t.ok(
-      output.stdout.includes(`${chalk.red('fail')}: http.response_time.p95 < 1`),
+      output.stdout.includes(
+        `${chalk.red('fail')}: http.response_time.p95 < 1`
+      ),
       'Console did not include p95 check'
     );
     t.ok(
@@ -280,22 +292,131 @@ test('checks are grouped in the correct order (ok first, fail after)', async (t)
   } catch (output) {
     const startIndex = output.stdout.indexOf('Checks:');
     // Get the relevant logs (the first 4 lines after the Checks: line)
-    const relevantLogs = output.stdout.slice(startIndex).split('\n').slice(1, 5)
+    const relevantLogs = output.stdout
+      .slice(startIndex)
+      .split('\n')
+      .slice(1, 5);
 
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(output.stdout.includes('Checks:', 'Console did not include Checks'));
-    t.ok(relevantLogs[0] == `${chalk.green('ok')}: maxErrorRate < 0` || relevantLogs[0] == `${chalk.green('ok')}: p99 < 10000`,
+    t.ok(
+      relevantLogs[0] == `${chalk.green('ok')}: maxErrorRate < 0` ||
+        relevantLogs[0] == `${chalk.green('ok')}: p99 < 10000`,
       'First check should be a passed expectation'
     );
-    t.ok(relevantLogs[1] == `${chalk.green('ok')}: maxErrorRate < 0` || relevantLogs[1] == `${chalk.green('ok')}: p99 < 10000`,
+    t.ok(
+      relevantLogs[1] == `${chalk.green('ok')}: maxErrorRate < 0` ||
+        relevantLogs[1] == `${chalk.green('ok')}: p99 < 10000`,
       'Second check should be a passed expectation'
     );
-    t.ok(relevantLogs[2] == `${chalk.red('fail')}: max < 1` || relevantLogs[2] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
+    t.ok(
+      relevantLogs[2] == `${chalk.red('fail')}: max < 1` ||
+        relevantLogs[2] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
       'Third check should be a failed expectation'
     );
-    t.ok(relevantLogs[3] == `${chalk.red('fail')}: max < 1` || relevantLogs[3] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
+    t.ok(
+      relevantLogs[3] == `${chalk.red('fail')}: max < 1` ||
+        relevantLogs[3] == `${chalk.red('fail')}: http.response_time.p95 < 1`,
       'Fourth check should be a failed expectation'
     );
   }
+});
+
+test('works with custom metrics including weird characters like urls', async (t) => {
+  //Arrange: Plugin overrides
+  const failingExpression =
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.min < 1 and vusers.created == 2';
+  const passingExpression =
+    'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.p99 < 1 or vusers.created_by_name.ensure Plug$n custom metrics.p99. (a1rb3nd3r) == 2';
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [
+          {
+            'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median': 1000
+          }
+        ],
+        conditions: [
+          { expression: failingExpression },
+          { expression: passingExpression }
+        ]
+      }
+    }
+  });
+
+  try {
+    //Act: run the test
+    await $`../artillery/bin/run run ./test/fixtures/scenario-custom-metrics.yml --overrides ${override}`;
+  } catch (output) {
+    //Assert
+    t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+    t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+    t.ok(
+      output.stdout.includes(
+        `${chalk.green(
+          'ok'
+        )}: browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 1000`
+      ),
+      'Console did not include browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
+    );
+    t.ok(
+      output.stdout.includes(`${chalk.red('fail')}: ${failingExpression}`),
+      'Console did not include failing expression check'
+    );
+    t.ok(
+      output.stdout.includes(`${chalk.green('ok')}: ${passingExpression}`),
+      'Console did not include passing expression check'
+    );
+  }
+});
+
+test('works with templated values used in metrics', async (t) => {
+  //Arrange: Plugin overrides
+  const passingExpression =
+    'http.downloaded_bytes >= {{ conditionVar }} or http.response_time.min >= {{ conditionVar }}';
+  const override = JSON.stringify({
+    config: {
+      plugins: { ensure: {} },
+      ensure: {
+        thresholds: [
+          {
+            'browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median':
+              '{{ thresholdVar }}'
+          }
+        ],
+        conditions: [{ expression: passingExpression }]
+      }
+    }
+  });
+
+  const variables = JSON.stringify({
+    conditionVar: 0,
+    thresholdVar: 1000
+  });
+
+  //Act: run the test
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario-custom-metrics.yml --overrides ${override} --variables ${variables}`;
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.ok(output.stdout.includes('Checks:'), 'Console did not include Checks');
+
+  t.ok(
+    output.stdout.includes(
+      `${chalk.green(
+        'ok'
+      )}: browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median < 1000`
+    ),
+    'Console did not include browser.page.FCP.https://www.artillery.io/13eba89r?a>;02-.median threshold check'
+  );
+
+  t.ok(
+    output.stdout.includes(
+      `${chalk.green(
+        'ok'
+      )}: http.downloaded_bytes >= 0 or http.response_time.min >= 0`
+    ),
+    'Console did not include passing expression check'
+  );
 });

--- a/packages/artillery-plugin-ensure/test/utils.unit.js
+++ b/packages/artillery-plugin-ensure/test/utils.unit.js
@@ -1,0 +1,154 @@
+const { test } = require('tap');
+const { replaceMetricsWithHashes, hashString } = require('../utils');
+
+test('works with boolean operators', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'someMetricB';
+  const originalExpression = `${metricA} < 20 and ${metricB} < 30`;
+  const modifiedExpression = `'${hashString(metricA)}' < 20 and '${hashString(
+    metricB
+  )}' < 30`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with built-in functions, even if a metric name includes it', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'vusers.random.ceil';
+  const originalExpression = `(ceil(${metricA}) < 20) or random(${metricB}) == 30`;
+  const modifiedExpression = `(ceil('${hashString(
+    metricA
+  )}') < 20) or random('${hashString(metricB)}') == 30`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with boolean operators without spaces', async (t) => {
+  const metricA = 'someMetricA';
+  const metricB = 'someMetricB';
+  const originalExpression = `${metricA}<20 and ${metricB}<30`;
+  const modifiedExpression = `'${hashString(metricA)}'<20 and '${hashString(
+    metricB
+  )}'<30`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with ternary boolean operator', async (t) => {
+  const metricA = 'someMetricA';
+  const originalExpression = `${metricA}<20 ? 30 : 40`;
+  const modifiedExpression = `'${hashString(metricA)}'<20 ? 30 : 40`;
+
+  const result = replaceMetricsWithHashes([metricA], originalExpression);
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with explicit operator precedence (parentheses) with spaces', async (t) => {
+  const metricA = 'vusers.created';
+  const metricB = 'vusers.completed';
+  const metricC = 'vusers.created';
+  const metricD = 'vusers.skipped';
+  const metricE = 'http.request_rate';
+  const originalExpression = `( ( ( ${metricA} - ${metricB}) / floor(${metricC}) * 100 ) + ${metricD} ) <= 0 or ${metricE} > 0`;
+  const modifiedExpression = `( ( ( '${hashString(metricA)}' - '${hashString(
+    metricB
+  )}') / floor('${hashString(metricC)}') * 100 ) + '${hashString(
+    metricD
+  )}' ) <= 0 or '${hashString(metricE)}' > 0`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB, metricC, metricD, metricE],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with explicit operator precedence (parentheses) without spaces', async (t) => {
+  const metricA = 'vusers.created';
+  const metricB = 'vusers.completed';
+  const metricC = 'vusers.created';
+  const metricD = 'vusers.skipped';
+  const metricE = 'http.request_rate';
+  const originalExpression = `(((${metricA}-${metricB})/floor(${metricC})*100)+${metricD})<= 0 or ${metricE}>0`;
+  const modifiedExpression = `((('${hashString(metricA)}'-'${hashString(
+    metricB
+  )}')/floor('${hashString(metricC)}')*100)+'${hashString(
+    metricD
+  )}')<= 0 or '${hashString(metricE)}'>0`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB, metricC, metricD, metricE],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with complex url expressions', async (t) => {
+  const metricA = 'browser.page.FCP.https://www.artillery.io/abc.p99';
+  const metricB = 'browser.page.TTFB.https://www.artillery.io/docs.min';
+  const originalExpression = `${metricA} < 20 and ${metricB} < 30`;
+  const modifiedExpression = `'${hashString(metricA)}' < 20 and '${hashString(
+    metricB
+  )}' < 30`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works with space in name', async (t) => {
+  const metricA = 'vusers.created_by_name.Scenario with some space';
+  const metricB = 'vusers.created_by_name.Other named scenario';
+  const originalExpression = `${metricA} /${metricB} > 20 or ${metricB}>= 30`;
+  const modifiedExpression = `'${hashString(metricA)}' /'${hashString(
+    metricB
+  )}' > 20 or '${hashString(metricB)}'>= 30`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});
+
+test('works when metric names include special named operators and we use those special operators', async (t) => {
+  const metricA = 'vusers.created_by_name.andy'; //relevant because andy includes "and" in the name
+  const metricB = 'vusers.created_by_name.nottinghill'; //relevant because nottinghill includes "not" in the name
+  const metricC = 'custom.orders'; //relevant because orders includes "or" in the name
+
+  const originalExpression = `(not ${metricA} < 100 and not ${metricB} < 100) or ${metricC} >= 300`;
+  const modifiedExpression = `(not '${hashString(
+    metricA
+  )}' < 100 and not '${hashString(metricB)}' < 100) or '${hashString(
+    metricC
+  )}' >= 300`;
+
+  const result = replaceMetricsWithHashes(
+    [metricA, metricB, metricC],
+    originalExpression
+  );
+
+  t.equal(result, modifiedExpression);
+});

--- a/packages/artillery-plugin-ensure/utils.js
+++ b/packages/artillery-plugin-ensure/utils.js
@@ -1,0 +1,48 @@
+const crypto = require('crypto');
+const debug = require('debug')('plugin:ensure');
+
+const hashString = (str) => {
+  const hash = crypto.createHash('sha256'); // sha256 is a good choice for uniqueness and speed
+  hash.update(str);
+  return hash.digest('hex');
+};
+
+function replaceMetricsWithHashes(replacementsArray, targetString) {
+  let skippedMetrics = [];
+
+  replacementsArray.forEach((str) => {
+    if (targetString.includes(str)) {
+      while (targetString.includes(str)) {
+        targetString = targetString.replace(str, `'${hashString(str)}'`);
+      }
+    } else {
+      debug(`Warning: Skipping non-string replacement value: ${str}`);
+      skippedMetrics.push(str);
+    }
+  });
+
+  if (skippedMetrics.length > 0) {
+    debug(
+      "WARNING: The following metrics from the report were skipped because they weren't found in your expression. It's possible you misspelled them or they're not being reported by your test."
+    );
+    debug(skippedMetrics);
+  }
+
+  return targetString;
+}
+
+function getHashedVarToValueMap(varsWithHashes) {
+  let hashedMetrics = {};
+
+  for (const metric of Object.values(varsWithHashes)) {
+    hashedMetrics[metric.hash] = metric.value;
+  }
+
+  return hashedMetrics;
+}
+
+module.exports = {
+  hashString,
+  replaceMetricsWithHashes,
+  getHashedVarToValueMap
+};


### PR DESCRIPTION
## Description

This PR is a rework of https://github.com/artilleryio/artillery/pull/2180.

Originally reported here: https://github.com/artilleryio/artillery/discussions/2166#discussioncomment-7110325, ensure is currently broken for most Playwright test assertions that include urls. The problem is more general though - any metric that includes special characters can hit this (such as custom metrics, created by name and metrics by endpoint).

### Approach

As it's hard to predict what patterns can fall into this (as it depends on how the package filtrex is handling it), rather than going with an approach of replacing specific patterns, we hash all metricNames in the expression and variables, and use that with filtrex.

Unlike the previous PR, the source of truth for metric names now comes from the list of metrics themselves. As long as the metric exists, it will be replaced and hashed in the expression. This avoids us having complicated regexes to do pattern recognition in the expression defined by the user.

### Testing
This has been thoroughly tested, as you can see from the added unit tests and acceptance tests, including with all sorts of weird characters and expressions. If you can think of another edge case, please let me know. As you can see, it's now even working against Artillery Cloud:

<img width="503" alt="Screenshot 2023-11-08 at 17 55 51" src="https://github.com/artilleryio/artillery/assets/39738771/8b0fdfaf-86fc-4a24-882a-7eac31c39ef3">

### Limitations
- I only encountered one limitation, and it's a bit of an edge case: if the metric name doesn't exist (e.g. a web vital that never got emitted) AND it has characters that filtrex doesn't like, it will error [in these try catches](https://github.com/artilleryio/artillery/blob/7f0201829853af4e084e52f6d088f81d6ba02ce3/packages/artillery-plugin-ensure/index.js#L140-L142)).
- We may want to change that from `global.artillery.log` to only show errors with `debug`.

Still, this seemed acceptable to me, as it's still much better for most cases, and not any worse for that one particular edge case. This is also IMO the simplest solution that avoids tanking more time into filtrex or other parsing solutions.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? _We could add a warning to the docs about non-existing metrics. Other than that, no._
- [x] Does this require a changelog entry? _Yes_
