### PR TITLE
feat(artillery): implement stopping test from artillery cloud

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -33,6 +33,7 @@ class ArtilleryCloudPlugin {
       'x-auth-token': this.apiKey
     };
     this.unprocessedLogsCounter = 0;
+    this.hasCancellationRequest = false;
 
     let testEndInfo = {};
     global.artillery.globalEvents.on('test:init', async (testInfo) => {
@@ -177,6 +178,9 @@ class ArtilleryCloudPlugin {
 
   setGetStatusInterval() {
     const interval = setInterval(async () => {
+      if (this.hasCancellationRequest) {
+        return;
+      }
       const res = await this._getLoadTestStatus();
 
       if (!res) {
@@ -189,10 +193,11 @@ class ArtilleryCloudPlugin {
       }
 
       console.log(
-        `WARNING: Test run cancellation requested through Artillery Cloud by: ${res.cancelledBy}. Cancelling test run - this may take a few seconds.`
+        `WARNING: Artillery Cloud user ${res.cancelledBy} requested to stop the test. Stopping test run - this may take a few seconds.`
       );
+      this.hasCancellationRequest = true;
       global.artillery.suggestedExitCode = 8;
-      global.artillery.shutdown({ earlyStop: true });
+      await global.artillery.shutdown({ earlyStop: true });
     }, 5000);
 
     return interval;


### PR DESCRIPTION
## Description

Leverages https://github.com/artilleryio/artillery/pull/2293 to initiate a `gracefulShutdown` of type `earlyStop` when Cloud API has set status of the test to `CANCELLATION_REQUESTED`.

A couple of things that could use opinions:
- I've set a 5 second timer on the interval. Please let me know if that's too long.
- Set a custom exit code to 8. No particular reason other than it being the number given in CP for this status - once we have a taxonomy for exit codes, we can change it if needed.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes, although we may want to defer it until Fargate is implemented
