### PR TITLE
fix(ci): remove --key flag from example run

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
-          command: run ./endpoint-metrics.yml --record --key ${{ env.CLOUD_KEY }} --tags ${{ env.CLI_TAGS }},group:http-metrics-by-endpoint --note ${{ env.CLI_NOTE }}
+          command: run ./endpoint-metrics.yml --record --tags ${{ env.CLI_TAGS }},group:http-metrics-by-endpoint --note ${{ env.CLI_NOTE }}
           working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
           ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
-          CLOUD_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
 
   multiple-scenarios-spec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

I had originally used `--key` on this one example to allow for us testing that path. However, since in forks the GH secret is not available, it errors when trying to use it. 

By using the environment variable directly, it will just not send to cloud when that's not available, allowing the tests to still run.