### PR TITLE
refactor(expect): exclude failures from errors logged

### DIFF
--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -83,7 +83,7 @@ function expectationsPluginOnError(
   events,
   done
 ) {
-  if (scenarioErr.message.startsWith('Failed expectations for request')) {
+  if (scenarioErr instanceof FailedExpectationError) {
     return done();
   }
   if (userContext.expectationsPlugin.formatter === 'json') {
@@ -186,7 +186,9 @@ function expectationsPluginCheckExpectations(
         ? req.name
         : req.url;
     return done(
-      new Error(`Failed expectations for request ${filteredRequestName}`)
+      new FailedExpectationError(
+        `Failed expectations for request ${filteredRequestName}`
+      )
     );
   }
 
@@ -211,5 +213,12 @@ function maybeParseBody(res) {
     return body;
   } else {
     return res.body;
+  }
+}
+
+class FailedExpectationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'FailedExpectationError';
   }
 }

--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -89,7 +89,7 @@ function expectationsPluginOnError(
   if (userContext.expectationsPlugin.formatter === 'json') {
     artillery.log(JSON.stringify({ error: scenarioErr.message }));
   } else {
-    artillery.log(`\n${chalk.red('Error:')} ${scenarioErr.message}\n`);
+    artillery.log(`${chalk.red('Error:')} ${scenarioErr.message}`);
   }
   return done();
 }

--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -87,7 +87,7 @@ function expectationsPluginOnError(
     return done();
   }
   if (userContext.expectationsPlugin.formatter === 'json') {
-    artillery.log(JSON.stringify({ error: scenarioErr.message }));
+    artillery.log(JSON.stringify({ ok: false, error: scenarioErr.message }));
   } else {
     artillery.log(`${chalk.red('Error:')} ${scenarioErr.message}`);
   }

--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -83,10 +83,13 @@ function expectationsPluginOnError(
   events,
   done
 ) {
-  if (userContext.expectationsPlugin.outputFormat === 'json') {
-    artillery.log(JSON.stringify({ ok: false, error: scenarioErr.message }));
+  if (scenarioErr.message.startsWith('Failed expectations for request')) {
+    return done();
+  }
+  if (userContext.expectationsPlugin.formatter === 'json') {
+    artillery.log(JSON.stringify({ error: scenarioErr.message }));
   } else {
-    artillery.log(`${chalk.red('Error:')} ${scenarioErr.message}`);
+    artillery.log(`\n${chalk.red('Error:')} ${scenarioErr.message}\n`);
   }
   return done();
 }


### PR DESCRIPTION
# Description

## What
Exclude failed expectation errors (present when `reportFailuresAsErrors` is set to true) from errors being logged to console with `expectationsPluginOnError` function.

## Why
Currently expect plugins `onError` hook function - `expectationsPluginOnError` logs the `'Error: {error message}'` string ( 'Error' being logged in red chalk), on every error. As `'not ok'` is already logged in red chalk for failed expectations, having additional 'Error' logged in red chalk is unnecessary. 

## Notes
- The `expectationsPluginOnError` function was dormant until #2298 due to `onError` hook not functioning properly 

# Pre-merge checklist
 - [] Does this require an update to the docs?
 - [x] Does this require a changelog entry?
