### PR TITLE
fix(cloud): set status interval after testrun init event

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -44,7 +44,6 @@ class ArtilleryCloudPlugin {
       testEndInfo.testRunUrl = testRunUrl;
 
       this.getLoadTestEndpoint = `${this.baseUrl}/api/load-tests/${this.testRunId}/status`;
-      this.setGetLoadTestInterval = this.setGetStatusInterval();
 
       console.log('Artillery Cloud reporting is configured for this test run');
       console.log(`Run URL: ${testRunUrl}`);
@@ -52,6 +51,8 @@ class ArtilleryCloudPlugin {
       await this._event('testrun:init', {
         metadata: testInfo.metadata
       });
+      this.setGetLoadTestInterval = this.setGetStatusInterval();
+
       if (typeof testInfo.flags.note !== 'undefined') {
         await this._event('testrun:addnote', { text: testInfo.flags.note });
       }


### PR DESCRIPTION
## Description

Noticed a couple of errors in the Artillery Cloud backend due to calling `/status` endpoint before test run exists in the DB. Since the stop test button only appears after the init event has completed, then we only need to start polling for `/status` at that point too.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No, it's a fix for an unreleased feature