### PR TITLE
feat: allow setting memory on Fargate as just a number

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -93,8 +93,8 @@ RunCommand.flags = {
   }),
   memory: Flags.string({
     description:
-      'Set task memory on Fargate. May be set in GB, e.g. 8gb, or as number of MiB, e.g. 8192',
-    default: '8gb'
+      'Set task memory on Fargate. Value be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)',
+    default: '8'
   }),
   output: Flags.string({
     char: 'o',

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -88,7 +88,7 @@ RunCommand.flags = {
   }),
   cpu: Flags.string({
     description:
-      'Set task vCPU on Fargate. May be set as number of vCPUs, e.g. 4, or as vCPU units, e.g. 4096',
+      'Set task vCPU on Fargate. Value may be set as a number of vCPUs between 1-16 (e.g. 4), or as number of vCPU units (e.g. 4096)',
     default: '4'
   }),
   memory: Flags.string({

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -369,16 +369,17 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
   }
 
   if (options.memory) {
-    if (/^[0-9]+gb/gi.test(options.memory)) {
-      // given with gb suffix
+    const n = Number(options.memory);
+    if (isNaN(n)) {
+      artillery.log('The value of --memory must be a number');
+      process.exit(1);
+    }
+
+    const MAX_MEMORY_IN_GB = 120;
+    if (n <= MAX_MEMORY_IN_GB) {
       options.launchConfig.memory = String(parseInt(options.memory, 10) * 1024);
-    } else if (!isNaN(Number(options.memory))) {
-      // just a number
-      options.launchConfig.memory = options.memory;
     } else {
-      artillery.log(
-        'The value of --memory must be a whole number (in MiB) or a number followed by "gb" (in GB)'
-      );
+      options.launchConfig.memory = options.memory;
     }
   }
 


### PR DESCRIPTION
Treat the argument to `--memory` as number of GB if <= 120, and as MiB otherwise.