### PR TITLE
refactor(publish-metrics): set tracer once per test 

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -551,9 +551,7 @@ class OTelReporter {
           'vu.uuid': vuContext.vars.$uuid,
           ...(this.traceConfig.attributes || {})
         });
-        if (this.traceConfig.attributes) {
-          scenarioSpan.setAttributes(this.traceConfig.attributes);
-        }
+
         // Set variables to track state and context
         const ctx = context.active();
         let lastPageUrl;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -367,7 +367,9 @@ class OTelReporter {
     return function (userContext, ee, next) {
       // get and set the tracer by engine
       const tracerName = engine + 'Tracer';
-      this[tracerName] = trace.getTracer(`artillery-${engine}`);
+      if (!this[tracerName]) {
+        this[tracerName] = trace.getTracer(`artillery-${engine}`);
+      }
       const span = this[tracerName].startSpan(
         userContext.scenario?.name || `artillery-${engine}-scenario`,
         {


### PR DESCRIPTION
# Description

Improvements to OTel reporter:
- Ensure tracer is set only once per test rather than on every scenario run
- Remove mistakenly duplicated code - custom attributes are set on the span twice (they just replace the first ones set - no user facing change)