### PR TITLE
refactor(cloud): add final log to cli when test run cancelled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22214,7 +22214,7 @@
       }
     },
     "packages/artillery-plugin-fake-data": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ngneat/falso": "^7.1.1"

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -160,12 +160,12 @@ class ArtilleryCloudPlugin {
           status: opts.earlyStop ? 'EARLY_STOP' : 'COMPLETED'
         });
 
+        const runUrlMessage = `Run URL: ${testEndInfo.testRunUrl}`;
         if (this.cancellationRequestedBy) {
-          console.log(
-            `\nTest run stopped by ${this.cancellationRequestedBy}. Run URL: ${testEndInfo.testRunUrl}`
-          );
+          console.log(`\nTest run stopped by ${this.cancellationRequestedBy}.`);
+          console.log(runUrlMessage);
         } else {
-          console.log(`\nRun URL: ${testEndInfo.testRunUrl}`);
+          console.log(`\n${runUrlMessage}}`);
         }
       }
     });

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -160,13 +160,11 @@ class ArtilleryCloudPlugin {
           status: opts.earlyStop ? 'EARLY_STOP' : 'COMPLETED'
         });
 
-        const runUrlMessage = `Run URL: ${testEndInfo.testRunUrl}`;
+        console.log('\n');
         if (this.cancellationRequestedBy) {
-          console.log(`\nTest run stopped by ${this.cancellationRequestedBy}.`);
-          console.log(runUrlMessage);
-        } else {
-          console.log(`\n${runUrlMessage}}`);
+          console.log(`Test run stopped by ${this.cancellationRequestedBy}.`);
         }
+        console.log(`Run URL: ${testEndInfo.testRunUrl}`);
       }
     });
 


### PR DESCRIPTION
## Description

Helps visualise better that the test run has stopped, in case there's a lot of logs between when it was requested, and when it finishes cancellation (e.g. high VU + expect).

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No, it will be part of the overall release of the feature
