### PR TITLE
refactor: graceful shutdowns on ECS/Fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -821,24 +821,26 @@ async function cleanupResources(context) {
       context.sqsReporter.stop();
     }
 
-    for (const taskArn of context.taskArns) {
-      try {
-        const ecs = new AWS.ECS({
-          apiVersion: '2014-11-13',
-          region: context.region
-        });
-        await ecs
-          .stopTask({
-            task: taskArn,
-            cluster: context.clusterName,
-            reason: 'Test cleanup'
-          })
-          .promise();
-      } catch (err) {
-        // TODO: Retry if appropriate, give the user more information
-        // to be able to fall back to manual intervention if possible.
-        // TODO: Consumer has no idea if this succeeded or not
-        debug(err);
+    if (context.taskArns && context.taskArns.length > 0) {
+      for (const taskArn of context.taskArns) {
+        try {
+          const ecs = new AWS.ECS({
+            apiVersion: '2014-11-13',
+            region: context.region
+          });
+          await ecs
+            .stopTask({
+              task: taskArn,
+              cluster: context.clusterName,
+              reason: 'Test cleanup'
+            })
+            .promise();
+        } catch (err) {
+          // TODO: Retry if appropriate, give the user more information
+          // to be able to fall back to manual intervention if possible.
+          // TODO: Consumer has no idea if this succeeded or not
+          debug(err);
+        }
       }
     }
 


### PR DESCRIPTION
This PR refactors the shutdown code for ECS/Fargate to bring it closer to what local runs already do.

- Expose shutdown functionality via `global.artillery.shutdown()`
- Run `beforeExit` and `onShutdown` hooks inside the new `gracefulShutdown` function
- Centralize all shutdown logic in that function
- Ctrl+C stops the test straightaway now without needing to press it twice

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? Yes, the behavior on `Ctrl+C` has changed
