### PR TITLE
Bernardobridge/art 1482 cli test run end changes

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -407,7 +407,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       const ps2 = [];
       for (const e of global.artillery.extensionEvents) {
         if (e.ext === 'onShutdown') {
-          ps2.push(e.method(opts));
+          ps2.push(e.method({ ...opts, report: finalReport }));
         }
       }
       await Promise.allSettled(ps2);

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -154,10 +154,9 @@ class ArtilleryCloudPlugin {
 
         await this._event('testrun:end', {
           ts: testEndInfo.endTime,
-          exitCode: global.artillery.suggestedExitCode || opts.exitCode
-        });
-        await this._event('testrun:changestatus', {
-          status: opts.earlyStop ? 'EARLY_STOP' : 'COMPLETED'
+          exitCode: global.artillery.suggestedExitCode || opts.exitCode,
+          isEarlyStop: !!opts.earlyStop,
+          report: opts.report
         });
 
         console.log(`\nRun URL: ${testEndInfo.testRunUrl}`);


### PR DESCRIPTION
## Description

Improves performance of the Cloud `testrun:end`, which makes the CLI end the test faster.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes