### PR TITLE
feat(schema): use proper schema for environments and arbitrary keyvalue

### DIFF
--- a/packages/types/schema/engines/http.js
+++ b/packages/types/schema/engines/http.js
@@ -12,7 +12,8 @@ const { ExpectPluginImplementationSchema } = require('../plugins/expect');
 
 const {
   artilleryNumberOrString,
-  artilleryBooleanOrString
+  artilleryBooleanOrString,
+  buildArtilleryKeyValue
 } = require('../joi.helpers');
 
 const CaptureSchema = Joi.alternatives()
@@ -66,15 +67,22 @@ const SharedHttpMethodProperties = {
     .description(
       'Descriptive name for your URL. Certain plugins and features use this name instead of the full URL due to dynamic request urls.'
     ),
-  headers: Joi.object().meta({ title: 'Headers' }),
-  cookie: Joi.object() //TODO: maybe make this a [name: string]: string
-    .meta({ title: 'Cookies' }),
+  headers: buildArtilleryKeyValue(Joi.string())
+    .meta({ title: 'Request Headers' })
+    .description(
+      'Headers to be used in this request. Replace *. with your header name, and set string value.'
+    ),
+  cookie: buildArtilleryKeyValue(Joi.string())
+    .meta({ title: 'Request Cookies' })
+    .description(
+      'Cookies to be used in this request. Replace *. with your cookie name, and set string value.'
+    ),
   followRedirect: artilleryBooleanOrString
     .meta({ title: 'Disable redirect following' })
     .description(
       'Artillery follows redirects by default.\nSet this option to `false` to stop following redirects.'
     ),
-  qs: Joi.object().meta({ title: 'Query string object' }),
+  qs: Joi.object().meta({ title: 'Query string object' }), //TODO: add proper schema to this one. potential bug in joi-to-schema in generating from alternatives
   gzip: artilleryBooleanOrString
     .meta({ title: 'Compression' })
     .default(true)
@@ -116,12 +124,12 @@ const HttpMethodPropertiesWithBody = {
   ...SharedHttpMethodProperties,
   json: Joi.any().meta({ title: 'JSON response body' }),
   body: Joi.any().meta({ title: 'Raw response body' }),
-  form: Joi.object()
+  form: buildArtilleryKeyValue(Joi.string())
     .meta({ title: 'Url-encoded Form' })
     .description(
       'https://www.artillery.io/docs/reference/engines/http#url-encoded-forms-applicationx-www-form-urlencoded'
     ),
-  formData: Joi.object()
+  formData: Joi.object() //TODO: add proper schema to this one. not working due to artillery pro plugin
     .meta({ title: 'Multipart Forms' })
     .description(
       'https://www.artillery.io/docs/reference/engines/http#multipart-forms-multipartform-data'
@@ -176,14 +184,16 @@ const HttpFlowItemSchema = Joi.alternatives()
   .id('HttpFlowItemSchema');
 
 const HttpDefaultsConfigSchema = Joi.object({
-  headers: Joi.object()
-    .meta({ title: 'Request Headers' })
+  headers: buildArtilleryKeyValue(Joi.string())
+    .meta({ title: 'Default Headers' })
     .description(
-      'Default headers to be used in all requests.\nhttps://www.artillery.io/docs/reference/engines/http#default-configuration'
+      'Default headers to be used in all requests. Replace *. with your header name, and set string value.\nhttps://www.artillery.io/docs/reference/engines/http#default-configuration'
     ),
-  cookie: Joi.object()
-    .meta({ title: 'Request Cookies' })
-    .description('Default cookies to be used in all requests.'),
+  cookie: buildArtilleryKeyValue(Joi.string())
+    .meta({ title: 'Default Cookies' })
+    .description(
+      'Default cookies to be used in all requests. Replace *. with your cookie name, and set string value.'
+    ),
   strictCapture: Joi.alternatives(Joi.boolean(), Joi.string())
     .meta({ title: 'Strict capture' })
     .description(

--- a/packages/types/schema/engines/socketio.js
+++ b/packages/types/schema/engines/socketio.js
@@ -4,6 +4,7 @@ const Joi = require('joi').defaults((schema) =>
 
 const { LoopOptions, MatchSchema, JsonCaptureSchema } = require('./common');
 const { BaseWithHttp } = require('./http');
+const { buildArtilleryKeyValue } = require('../joi.helpers');
 
 const SocketioDataSchema = Joi.alternatives(
   Joi.string(),
@@ -101,13 +102,13 @@ const SocketIoFlowItemSchema = Joi.alternatives()
   .id('SocketIoFlowItemSchema');
 
 const SocketIoConfigSchema = Joi.object({
-  query: Joi.alternatives(Joi.string(), Joi.object())
+  query: Joi.alternatives(Joi.string(), buildArtilleryKeyValue(Joi.string()))
     .meta({ title: 'Query' })
     .description(
       'Query parameters can be specified as a string or dictionary.'
     ),
   path: Joi.string(),
-  extraHeaders: Joi.object()
+  extraHeaders: buildArtilleryKeyValue(Joi.string())
     .meta({ title: 'Extra Headers' })
     .description(
       "Extra headers may be passed with this option. \nThe extraHeaders option only works if the default polling transport is used. When using other transports, extra headers won't be taken into account by the server."

--- a/packages/types/schema/engines/websocket.js
+++ b/packages/types/schema/engines/websocket.js
@@ -3,6 +3,7 @@ const Joi = require('joi').defaults((schema) =>
 );
 
 const { BaseFlowItemAlternatives, LoopOptions } = require('./common');
+const { buildArtilleryKeyValue } = require('../joi.helpers');
 
 //TODO: add metadata
 
@@ -50,7 +51,7 @@ const WsConfigSchema = Joi.object({
   subprotocols: Joi.array()
     .items(Joi.string().valid('json', 'soap', 'wamp', 'xmpp'))
     .meta({ title: 'Websocket sub-protocols' }),
-  headers: Joi.object().meta({ title: 'Headers' }),
+  headers: buildArtilleryKeyValue(Joi.string()).meta({ title: 'Headers' }),
   proxy: Joi.object({
     url: Joi.string().required().meta({ title: 'URL' })
   }).meta({ title: 'Proxy' })

--- a/packages/types/schema/joi.helpers.js
+++ b/packages/types/schema/joi.helpers.js
@@ -5,7 +5,11 @@ const Joi = require('joi').defaults((schema) =>
 const artilleryNumberOrString = Joi.alternatives(Joi.number(), Joi.string());
 const artilleryBooleanOrString = Joi.alternatives(Joi.boolean(), Joi.string());
 
+const buildArtilleryKeyValue = (joiSchema) =>
+  Joi.object().pattern(/.*/, joiSchema);
+
 module.exports = {
   artilleryNumberOrString,
-  artilleryBooleanOrString
+  artilleryBooleanOrString,
+  buildArtilleryKeyValue
 };

--- a/packages/types/test/helpers.ts
+++ b/packages/types/test/helpers.ts
@@ -6,7 +6,9 @@ const schema = require('../schema.json');
 const ajv = new Ajv({
   validateSchema: true,
   allErrors: true,
-  allowUnionTypes: true
+  allowUnionTypes: true,
+  allowMatchingProperties: true,
+  strictTypes: false
 });
 
 export function validateTestScript(scriptText: string) {


### PR DESCRIPTION
## Description

- Adds `buildArtilleryKeyValue` to be reused throughout schema for adding arbitrary key:value pairs
- Adds correct typing for `environments` from config
- Adds correct typing for `cookies`, `headers`, `form` for http engine (`formData` and `qs` left out for now)
- Adds correct typings for some additional properties in ws and socketio engine

## Testing

Tested directly with VS Code extension debugger. Example autocomplete of `environments`:

<img width="407" alt="Screenshot 2023-11-29 at 12 28 20" src="https://github.com/artilleryio/artillery/assets/39738771/590c2529-2f72-408d-a9f9-746d1e631ba8">


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes, we need to remove the `environments` limitation
- [ ] Does this require a changelog entry? We still need to decide where to put VS Code schema changes . So yes, maybe
