### PR TITLE
feat(publish-metrics): send metrics to prometheus on done or stats event

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/prometheus.js
+++ b/packages/artillery-plugin-publish-metrics/lib/prometheus.js
@@ -107,8 +107,9 @@ class PrometheusReporter {
 
   sendMetrics(config, events) {
     let that = this;
+    const eventType = config.sendMetricsAtSummary ? 'done' : 'stats';
 
-    events.on('stats', (stats) => {
+    events.on(eventType, (stats) => {
       debug('On stats event: %O', stats);
 
       if (stats[COUNTERS_STATS]) {


### PR DESCRIPTION
## Description

Gives possibility to send metrics to Prometheus only summary report (on done event). This is configurable in test config using property `sendMetricsAtSummary` with boolean value.

**Reason:**
Currently metrics are send only at stats event which brings two issues:
- you cannot define mare than one phase - not all metrics are send to Prometheus
- summary metrics are not recalculated when send multiple metrics (based on `stats` event) - in Prometheus you see only latest metric send by Artillery.io.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
