### PR TITLE
fix(core): make randomString deterministic and allow larger values

### DIFF
--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -471,8 +471,17 @@ function $randomNumber(min, max) {
   return _.random(min, max);
 }
 
-function $randomString(length) {
-  return Math.random().toString(36).substr(2, length);
+function $randomString(length = 10) {
+  let s = '';
+  const alphabet =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const alphabetLength = alphabet.length;
+
+  while (s.length < length) {
+    s += alphabet.charAt((Math.random() * alphabetLength) | 0);
+  }
+
+  return s;
 }
 
 function handleScriptHook(hook, script, hookEvents, contextVars = {}) {

--- a/packages/core/test/core/unit/context_functions.test.js
+++ b/packages/core/test/core/unit/context_functions.test.js
@@ -1,0 +1,30 @@
+const { test } = require('tap');
+const { contextFuncs } = require('../../../lib/runner');
+
+test('$randomString should return a string of the specified length', async function (t) {
+  const testStringOfLength = (length) => {
+    const defaultStringLength = 10;
+    const errors = [];
+    for (let i = 0; i < 10000; i++) {
+      const string = contextFuncs.$randomString(length);
+      if (string.length != (length || defaultStringLength)) {
+        errors.push(string);
+      }
+    }
+
+    t.ok(
+      errors.length == 0,
+      `All strings should be of length ${length || defaultStringLength}. Got ${
+        errors.length
+      } bad strings: ${JSON.stringify(errors)}`
+    );
+  };
+
+  //test with different size strings
+  testStringOfLength();
+  testStringOfLength(1);
+  testStringOfLength(2);
+  testStringOfLength(10);
+  testStringOfLength(100);
+  testStringOfLength(1000);
+});


### PR DESCRIPTION
## Description

There are two issues with the current `$randomString` function:
- It will sometimes return a different length than specified, due to trailing zeroes
- It actually doesn't work for large lengths (n>10 I believe). It just always returns up to 10 chars

I tried and benchmarked quite a few possible variations of the function (e.g. using `crypto.randomBytes`, `lodash` utilities, etc). This solution was by far the fastest I got, even surpassing the existing function. 

Notes:
- This solution allows capital letters, but we can remove that if we want (I believe the previous solution didn't).
- Defaults to length=10 if no length is specified to keep it backwards compatible, since the previous function implicitly did this

## Testing

- Added thorough unit test that checks for the regression. I also ran it with the old function, and it catches the issue (i.e. fails successfully)
- Benchmarks to make sure it works at load-test scale

## Pre-merge checklist

- [ ] Does this require an update to the docs? These functions aren't mentioned in the docs. I think maybe we should add `$randomString` and `$randomNumber` to the docs as part of this
- [ ] Does this require a changelog entry? Yes