### PR TITLE
test(cli): send report files to tmpdir

### DIFF
--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "test:unit": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 --color test/unit/*.test.js",
-    "test:acceptance": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 test/cli/*.test.js",
+    "test:acceptance": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 test/cli/*.test.js && bash test/lib/run.sh && tap --no-coverage --color test/testcases/plugins/*.test.js",
     "test": "npm run test:unit && npm run test:acceptance",
     "test:cloud": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=300 test/cloud-e2e/*.test.js",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -43,7 +43,9 @@
     }
   },
   "scripts": {
-    "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 --color test/unit/*.test.js test/cli/*.test.js && bash test/lib/run.sh && tap --no-coverage --color test/testcases/plugins/*.test.js",
+    "test:unit": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 --color test/unit/*.test.js",
+    "test:acceptance": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=420 test/cli/*.test.js",
+    "test": "npm run test:unit && npm run test:acceptance",
     "test:cloud": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --timeout=300 test/cloud-e2e/*.test.js",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "lint-fix": "npm run lint -- --fix"

--- a/packages/artillery/test/cli/_helpers.js
+++ b/packages/artillery/test/cli/_helpers.js
@@ -2,6 +2,7 @@ const sh = require('execa');
 const temp = require('temp').track();
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { getBinPathSync } = require('get-bin-path');
 const a9path = getBinPathSync();
 
@@ -21,8 +22,12 @@ async function deleteFile(path) {
   return true;
 }
 
+function returnTmpPath(fileName) {
+  return path.resolve(`${os.tmpdir()}/${fileName}`);
+}
+
 async function getRootPath(filename) {
   return path.resolve(__dirname, '..', '..', filename);
 }
 
-module.exports = { execute, deleteFile, getRootPath };
+module.exports = { execute, deleteFile, getRootPath, returnTmpPath };

--- a/packages/artillery/test/cli/command-report.test.js
+++ b/packages/artillery/test/cli/command-report.test.js
@@ -1,17 +1,15 @@
 const tap = require('tap');
-const { execute, deleteFile } = require('../cli/_helpers.js');
-const path = require('path');
+const { execute, returnTmpPath } = require('../cli/_helpers.js');
 
 tap.test('If we report specifying output, no browser is opened', async (t) => {
-  const outputFile = 'report.html';
-  const outputPath = path.resolve(__dirname, '..', '..', outputFile);
+  const outputFilePath = returnTmpPath('report.html');
 
   const [exitCode] = await execute([
     'report',
     '--output',
-    outputFile,
+    outputFilePath,
     'test/scripts/report.json'
   ]);
 
-  t.ok(exitCode === 0 && deleteFile(outputPath));
+  t.ok(exitCode === 0);
 });


### PR DESCRIPTION
## Description

A step towards making these more readable and actionable on failures. 

Removes unneeded deleteFiles from within test assertions, and instead sends reports to a temporary directory. I'd like to also break out multiple conditional assertions into its own assertion, but that can be done later.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
