### PR TITLE
fix(artillery): reduce bundle size on AWS Lambda

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -282,9 +282,20 @@ class PlatformLambda {
       stderr: stderr3,
       status: status3,
       error: error3
-    } = spawn.sync('npm', ['uninstall', '@artilleryio/platform-fargate'], {
-      cwd: a9cwd
-    });
+    } = spawn.sync(
+      'npm',
+      [
+        'uninstall',
+        'dependency-tree',
+        'detective',
+        'is-builtin-module',
+        'try-require',
+        'walk-sync'
+      ],
+      {
+        cwd: a9cwd
+      }
+    );
     if (error3) {
       artillery.log(stdout3?.toString(), stderr3?.toString(), status3, error3);
     } else {


### PR DESCRIPTION
The dependencies became direct dependencies of Artillery when @platform/fargate was moved into the monorepo. They are not needed for workers running on AWS Lambda.

Fixes #2337 