### PR TITLE
feat(artillery): enable 11 more AWS regions for ECS/Fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/util.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/util.js
@@ -12,24 +12,23 @@ const A = require('async');
 
 const createS3Client = require('./create-s3-client');
 
-// NOTE: When updating this list remember to update create-worker-images too
 const supportedRegions = [
   'us-east-1',
-  // 'us-east-2',
+  'us-east-2',
   'us-west-1',
-  // 'us-west-2',
-  // 'ca-central-1',
+  'us-west-2',
+  'ca-central-1',
   'eu-west-1',
-  // 'eu-west-2',
-  // 'eu-west-3',
+  'eu-west-2',
+  'eu-west-3',
   'eu-central-1',
   'ap-south-1',
-  // 'ap-east-1',
-  // 'ap-northeast-2',
-  // 'ap-southeast-1',
-  // 'ap-southeast-2',
-  'ap-northeast-1'
-  // 'me-south-1',
+  'ap-east-1',
+  'ap-northeast-2',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'ap-northeast-1',
+  'me-south-1'
 ];
 
 const getAccountId = require('../../aws/aws-get-account-id');


### PR DESCRIPTION
This allows ECS/Fargate tests to be used in:

- `eu-west-2`
- `eu-west-3`
- `us-east-2`
- `us-west-2`
- `ca-central-1`
- `ap-east-1`
- `ap-northeast-2`
- `ap-southeast-1`
- `ap-southeast-2`
- `ap-northeast-1`
- `me-south-1`