### PR TITLE
ci(docker): allow arbitrary building of worker image

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -1,6 +1,7 @@
 name: Build & publish ECS/Fargate worker image to ECR
 
 on:
+  workflow_dispatch: 
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

At some point we'll enable this in branches too, but right now it this is a simple way to just trigger the workflow against a branch on demand, to get an ECR image to test against.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
