### PR TITLE
feat(fargate): include datadog agent in worker image

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -29,7 +29,17 @@ RUN cd /artillery && \
  
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker /artillery/loadgen-worker
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/helpers.sh /artillery/helpers.sh
+COPY ./packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh /artillery/dd-agent-setup.sh
 
 RUN chmod +x /artillery/loadgen-worker
+
+# Datadog install setup
+
+# Install yq to be able to alter the dd-agent config easily later
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+    chmod +x /usr/bin/yq
+
+# Datadog will not install without API key so we set a placeholder dummy key and replace it later
+RUN DD_INSTALL_ONLY=true DD_SITE="datadoghq.com" DD_API_KEY="placeholder_key" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 ENTRYPOINT ["/artillery/loadgen-worker"]

--- a/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
+++ b/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
@@ -21,6 +21,7 @@ start_and_configure_dd_agent() {
 
     # Add otlp config
     yq -i ".otlp_config.receiver.protocols.http.endpoint = \"localhost:4318\"" "$yaml_file"
+    yq -i ".otlp_config.receiver.protocols.grpc.endpoint = \"localhost:4317\"" "$yaml_file"
 
     # Add apm_config trace_buffer
     yq -i ".apm_config.trace_buffer = 100" "$yaml_file"

--- a/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
+++ b/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
@@ -2,6 +2,7 @@
 start_and_configure_dd_agent() {
     # Check if DD_API_KEY is set in the environment
     if [ -z "${DD_API_KEY-}" ]; then
+        echo "DD_API_KEY not set. Not running Datadog Agent."
         return 0
     fi
 
@@ -25,13 +26,11 @@ start_and_configure_dd_agent() {
     # Add apm_config trace_buffer
     yq -i ".apm_config.trace_buffer = 100" "$yaml_file"
 
-    # TODO might need to change max_traces_per_second
+    # TODO investigate if max_traces_per_second needs adjusting 
     # TODO review other config options. Reference https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1279C1-L1287C30
 
-    echo "Configuration added to $yaml_file."
     echo "Starting datadog-agent..."
-    #TODO check how verbose starting is in terms of logs
     service datadog-agent start
 
-    echo "Started datadog-agent."
+    echo "Started datadog-agent successfully!"
 }

--- a/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
+++ b/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
@@ -7,7 +7,6 @@ start_and_configure_dd_agent() {
     fi
 
     # Specify the YAML file to modify
-    # TODO might need to set the path to yaml_file dynamically?
     yaml_file="/etc/datadog-agent/datadog.yaml"
     hostname="task-$1"
 

--- a/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
+++ b/packages/artillery/lib/platform/aws-ecs/worker/dd-agent-setup.sh
@@ -1,0 +1,37 @@
+
+start_and_configure_dd_agent() {
+    # Check if DD_API_KEY is set in the environment
+    if [ -z "${DD_API_KEY-}" ]; then
+        return 0
+    fi
+
+    # Specify the YAML file to modify
+    # TODO might need to set the path to yaml_file dynamically?
+    yaml_file="/etc/datadog-agent/datadog.yaml"
+    hostname="task-$1"
+
+    # Reference of configuration to add
+    # https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+
+    # Update API Key in the config file
+    yq -i ".api_key = \"$DD_API_KEY\"" "$yaml_file"
+
+    # Add/Update hostname
+    yq -i ".hostname = \"$hostname\"" "$yaml_file"
+
+    # Add otlp config
+    yq -i ".otlp_config.receiver.protocols.http.endpoint = \"localhost:4318\"" "$yaml_file"
+
+    # Add apm_config trace_buffer
+    yq -i ".apm_config.trace_buffer = 100" "$yaml_file"
+
+    # TODO might need to change max_traces_per_second
+    # TODO review other config options. Reference https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1279C1-L1287C30
+
+    echo "Configuration added to $yaml_file."
+    echo "Starting datadog-agent..."
+    #TODO check how verbose starting is in terms of logs
+    service datadog-agent start
+
+    echo "Started datadog-agent."
+}

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -337,7 +337,7 @@ main () {
     progress "Installing dependencies"
     install_dependencies
 
-    progress "Start DD Agent if needed"
+    progress "Checking if Datadog Agent should run"
     start_and_configure_dd_agent "$worker_id"
 
     progress "Ready to run"

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -13,6 +13,7 @@ fi
 declare -r DIR=$(cd "$(dirname "$0")" && pwd)
 
 source "$DIR/helpers.sh"
+source "$DIR/dd-agent-setup.sh"
 
 # shellcheck disable=2155
 # declare -r DIR=$(cd "$(dirname "$0")" && pwd)
@@ -335,6 +336,9 @@ main () {
 
     progress "Installing dependencies"
     install_dependencies
+
+    progress "Start DD Agent if needed"
+    start_and_configure_dd_agent "$worker_id"
 
     progress "Ready to run"
     signal_ready


### PR DESCRIPTION
# Description

Since Datadog is different to other vendors in first-class support for OTeL, and it's not as simple as just an API endpoint and headers (data via OTLP can only be ingested through the DD agent or the OTel collector), we decided to provide a solution that would make it easier to send data to Datadog via OTel reporter when running on Fargate.

In order to accomplish this the Datadog agent is bundled with the worker image. 
Installation is being done using [DD's install script](https://app.datadoghq.com/account/settings/agent/latest?platform=ubuntu), as that is what the DD documentation shows. The Ubuntu platform script was chosen, as the Docker one seems to be aimed at starting this as a sidecar container, and Ubuntu is what the Playwright image uses.

The agent can not be installed without providing an API key so we set a dummy one on installation and then override it before starting the agent.

## Configuration
- In order to enable the Datadog agent in Fargate the user needs to set the `DD_API_KEY` environment variable in a `dotenv` file, and provide the file path in the run command with the `--dotenv` flag as follows:

  **artillery run-fargate < path to your test script > --dotenv <path to your `dotenv` file**

In this case no `endpoint` or  `headers` need to be provided to the OpenTelemetry reporter, as it will use the default signal specific endpoints. [Reference](https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/#otel_exporter_otlp_traces_endpoint)

**Example config in test script:**
```yaml
  plugins:
    publish-metrics:
      - type: open-telemetry
        serviceName: your_service_name
        traces: {}
```

**Example command:**

```stout
artillery run-fargate scenario.yml --dotenv ./.env
```



No modifications were needed to the OpenTelemetry reporter itself.

## Notes
- **The image size has a significant increase (40%, 1GB -> 1.4GB) due to the agent size**, which seems to be a known [issue](https://github.com/DataDog/datadog-agent/issues/3542). 
However, the startup time does not seem to be significantly affected by this so it was decided to proceed with this implementation and optimise in future releases

- Instructions for sending the data over the OpenTelemetry reporter to Datadog locally are provided [here](https://artillery.notion.site/Playwright-tracing-with-Datadog-local-set-up-bb23b137915b48aa80854afbc5a8b726) and will be added to the docs.

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?