### PR TITLE
feat(schema): improve metrics-by-endpoint schema

### DIFF
--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -8,7 +8,7 @@ const MetricsByEndpointPluginConfigSchema = Joi.object({
   useOnlyRequestNames: artilleryBooleanOrString,
   stripQueryString: artilleryBooleanOrString,
   ignoreUnnamedRequests: artilleryBooleanOrString,
-  metricsPrefix: Joi.string()
+  metricsNamespace: Joi.string()
 })
   .unknown(false)
   .meta({ title: 'Metrics by Endpoint Plugin' });

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -2,16 +2,33 @@ const Joi = require('joi');
 
 const { artilleryBooleanOrString } = require('../joi.helpers');
 
-//TODO: type internal properties of this plugin
-
 const MetricsByEndpointPluginConfigSchema = Joi.object({
-  useOnlyRequestNames: artilleryBooleanOrString,
-  stripQueryString: artilleryBooleanOrString,
-  ignoreUnnamedRequests: artilleryBooleanOrString,
+  useOnlyRequestNames: artilleryBooleanOrString
+    .meta({ title: 'Use Only Request Names' })
+    .description(
+      'Use request name property as endpoint name instead of the full URL. Recommended for dynamic URLs.'
+    )
+    .default(false),
+  stripQueryString: artilleryBooleanOrString
+    .meta({ title: 'Strip Query String' })
+    .description('Strip query strings from the endpoint name automatically.')
+    .default(false),
+  ignoreUnnamedRequests: artilleryBooleanOrString
+    .meta({ title: 'Strip Query String' })
+    .description(
+      'Ignore per-endpoint metrics for requests without a name property set.'
+    )
+    .default(false),
   metricsNamespace: Joi.string()
+    .meta({ title: 'Metrics Namespace' })
+    .description('Custom prefix to use for metrics published by this plugin.')
+    .default('plugins.metrics-by-endpoint')
 })
   .unknown(false)
-  .meta({ title: 'Metrics by Endpoint Plugin' });
+  .meta({ title: 'Metrics by Endpoint Plugin' })
+  .description(
+    'Visualise metrics per endpoint visited during your HTTP test. Docs: https://www.artillery.io/docs/reference/extensions/metrics-by-endpoint\nNote: this plugin is enabled by default, and will display per endpoint metrics in the report. If you want to see them in the console, enable it manually.'
+  );
 
 module.exports = {
   MetricsByEndpointPluginConfigSchema

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -14,7 +14,7 @@ const MetricsByEndpointPluginConfigSchema = Joi.object({
     .description('Strip query strings from the endpoint name automatically.')
     .default(false),
   ignoreUnnamedRequests: artilleryBooleanOrString
-    .meta({ title: 'Strip Query String' })
+    .meta({ title: 'Ignore Unnamed Requests' })
     .description(
       'Ignore per-endpoint metrics for requests without a name property set.'
     )


### PR DESCRIPTION
## Description

- Fixes the `metricsPrefix` option to be the correct `metricsNamespace`
- Adds some information (description, titles, defaults) to the plugin