### PR TITLE
fix(publish-metrics): throw caught err in step handler

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -169,12 +169,13 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
 
           await callback();
         } catch (err) {
-          debug('There has been an error during step execution: ', err);
           span.recordException(err, Date.now());
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: err.message
           });
+          debug('There has been an error during step execution: ');
+          throw err;
         } finally {
           const difference = Date.now() - startTime;
           events.emit('histogram', `browser.step.${stepName}`, difference);

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -174,7 +174,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             code: SpanStatusCode.ERROR,
             message: err.message
           });
-          debug('There has been an error during step execution: ');
+          debug('There has been an error during step execution:');
           throw err;
         } finally {
           const difference = Date.now() - startTime;


### PR DESCRIPTION

# Description
Fix for #2365 
When using `test.step` helper along with OTel tracing in a Playwright scenario, VUs that failed do not count toward `vusers.failed`.

The reason they are not counted is due to caught errors being debugged and not thrown from the reporters `step` method.

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
