### PR TITLE
test(cli): enable wrongly commented out TS test

### DIFF
--- a/packages/artillery/test/cli/run-typescript.test.js
+++ b/packages/artillery/test/cli/run-typescript.test.js
@@ -12,32 +12,32 @@ tap.beforeEach(async (t) => {
   );
 });
 
-// tap.test('Can run a Typescript processor', async (t) => {
-//   const [exitCode, output] = await execute([
-//     'run',
-//     '-o',
-//     `${reportFilePath}`,
-//     'test/scripts/scenarios-typescript/lodash.yml'
-//   ]);
+tap.test('Can run a Typescript processor', async (t) => {
+  const [exitCode, output] = await execute([
+    'run',
+    '-o',
+    `${reportFilePath}`,
+    'test/scripts/scenarios-typescript/lodash.yml'
+  ]);
 
-//   t.equal(exitCode, 0, 'CLI should exit with code 0');
-//   t.ok(
-//     output.stdout.includes('Got context using lodash: true'),
-//     'Should be able to use lodash in a scenario to get context'
-//   );
-//   const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+  t.equal(exitCode, 0, 'CLI should exit with code 0');
+  t.ok(
+    output.stdout.includes('Got context using lodash: true'),
+    'Should be able to use lodash in a scenario to get context'
+  );
+  const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 
-//   t.equal(
-//     json.aggregate.counters['http.codes.200'],
-//     2,
-//     'Should have made 2 requests'
-//   );
-//   t.equal(
-//     json.aggregate.counters['hey_from_ts'],
-//     2,
-//     'Should have emitted 2 custom metrics from ts processor'
-//   );
-// });
+  t.equal(
+    json.aggregate.counters['http.codes.200'],
+    2,
+    'Should have made 2 requests'
+  );
+  t.equal(
+    json.aggregate.counters['hey_from_ts'],
+    2,
+    'Should have emitted 2 custom metrics from ts processor'
+  );
+});
 
 tap.test(
   'Failure from a Typescript processor has a resolvable stack trace via source maps',


### PR DESCRIPTION
## Description

Enable test I accidentally disabled testing something. This test still ran successfully against all the logic, so no problem, but needs to be enabled for future runs.