### PR TITLE
feat(playwright): run VUs in new context rather than browsers by default

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -30,6 +30,10 @@ class PlaywrightEngine {
       typeof script.config.engines.playwright.showAllPageMetrics !==
       'undefined';
 
+    this.useSeparateBrowserPerVU = 
+      typeof script.config.engines.playwright.useSeparateBrowserPerVU === 'boolean' ? 
+        script.config.engines.playwright.useSeparateBrowserPerVU : false;
+
     return this;
   }
 
@@ -64,8 +68,18 @@ class PlaywrightEngine {
 
       const contextOptions = self.contextOptions || {};
 
-      const browser = await chromium.launch(launchOptions);
-      debug('browser created');
+      let browser;
+      if (self.useSeparateBrowserPerVU) {
+        browser = await chromium.launch(launchOptions);
+        debug('new browser created');
+      } else {
+        if (!global.artillery.__browser) {
+          global.artillery.__browser = await chromium.launch(launchOptions);
+          debug('shared browser created');
+        }
+        browser = global.artillery.__browser;
+      }
+
       const context = await browser.newContext(contextOptions);
 
       context.setDefaultNavigationTimeout(self.defaultNavigationTimeout);
@@ -226,7 +240,10 @@ class PlaywrightEngine {
         }
       } finally {
         await context.close();
-        await browser.close();
+        
+        if (self.useSeparateBrowserPerVU) {
+          await browser.close();
+        }
       }
     };
   }

--- a/packages/types/schema/engines/playwright.js
+++ b/packages/types/schema/engines/playwright.js
@@ -51,6 +51,11 @@ const PlaywrightConfigSchema = Joi.object({
     .meta({ title: 'Playwright context options' })
     .description(
       'Arguments for the `browser.newContext()` call in Playwright.\nhttps://playwright.dev/docs/api/class-browser#browser-new-context'
+    ),
+  useSeparateBrowserPerVU: artilleryBooleanOrString
+    .meta({ title: 'Use a separate browser process for each VU' })
+    .description(
+      'If enabled, a new browser process will be created for each VU. By default Artillery uses new browser contexts for new VUs.\nWARNING: Using this option is discouraged as it will increase CPU/memory usage of your tests.\nhttps://www.artillery.io/docs/reference/engines/playwright#configuration'
     )
 });
 


### PR DESCRIPTION
Switch to using browser contexts rather than browsers for VU isolation.

This is the same approach as that used by the Playwright Test Runner: 

https://playwright.dev/docs/browser-contexts

Previous behavior of using a new browser per VU can be enabled by setting `config.engines.playwright.useSeparateBrowserPerVU` to true.

----

- [x] Docs updated
- [x] Draft changelog entry added
- [x] VS Code schema updated