### PR TITLE
refactor(cli): consolidate common run flags in same file

### DIFF
--- a/packages/artillery/lib/cli/common-flags.js
+++ b/packages/artillery/lib/cli/common-flags.js
@@ -1,0 +1,65 @@
+const { Flags } = require('@oclif/core');
+
+const CommonRunFlags = {
+  target: Flags.string({
+    char: 't',
+    description:
+      'Set target endpoint. Overrides the target already set in the test script'
+  }),
+  config: Flags.string({
+    char: 'c',
+    description: 'Read configuration for the test from the specified file'
+  }),
+  // TODO: Replace with --profile
+  environment: Flags.string({
+    char: 'e',
+    description: 'Use one of the environments specified in config.environments'
+  }),
+  'scenario-name': Flags.string({
+    description: 'Name of the specific scenario to run'
+  }),
+  output: Flags.string({
+    char: 'o',
+    description: 'Write a JSON report to file'
+  }),
+  dotenv: Flags.string({
+    description: 'Path to a dotenv file to load environment variables from'
+  }),
+  overrides: Flags.string({
+    description: 'Dynamically override values in the test script; a JSON object'
+  }),
+  insecure: Flags.boolean({
+    char: 'k',
+    description: 'Allow insecure TLS connections; do not use in production'
+  }),
+  // multiple allows multiple arguments for the -i flag, which means that e.g.:
+  // artillery -i one.yml -i two.yml main.yml
+  // does not work as expected. Instead of being considered an argument, "main.yml"
+  // is considered to be input for "-i" and oclif then complains about missing
+  // argument
+  input: Flags.string({
+    char: 'i',
+    description: 'Input script file',
+    multiple: true,
+    hidden: true
+  }),
+
+  //Artillery Cloud commands
+  tags: Flags.string({
+    description:
+      'Comma-separated list of tags in key:value format to tag the test run, for example: --tags team:sqa,service:foo'
+  }),
+  note: Flags.string({
+    description: 'Add a note/annotation to the test run'
+  }),
+  record: Flags.boolean({
+    description: 'Record test run to Artillery Cloud'
+  }),
+  key: Flags.string({
+    description: 'API key for Artillery Cloud'
+  })
+};
+
+module.exports = {
+  CommonRunFlags
+};

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { Command, Flags, Args } = require('@oclif/core');
+const { CommonRunFlags } = require('../cli/common-flags');
 const telemetry = require('../telemetry').init();
 const { Plugin: CloudPlugin } = require('../platform/cloud/cloud');
 
@@ -66,6 +67,7 @@ Examples:
 `;
 
 RunCommand.flags = {
+  ...CommonRunFlags,
   count: Flags.integer({
     description: runTestDescriptions.count
   }),
@@ -85,11 +87,6 @@ RunCommand.flags = {
   'subnet-ids': Flags.string({}),
   'security-group-ids': Flags.string({}),
   'task-role-name': Flags.string({}),
-  target: Flags.string({
-    char: 't',
-    description:
-      'Set target endpoint. Overrides the target already set in the test script'
-  }),
   cpu: Flags.string({
     description:
       'Set task vCPU on Fargate. Value may be set as a number of vCPUs between 1-16 (e.g. 4), or as number of vCPU units (e.g. 4096)',
@@ -100,38 +97,6 @@ RunCommand.flags = {
       'Set task memory on Fargate. Value may be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)',
     default: '8'
   }),
-  output: Flags.string({
-    char: 'o',
-    description: 'Write a JSON report to file'
-  }),
-  insecure: Flags.boolean({
-    char: 'k',
-    description: 'Allow insecure TLS connections; do not use in production'
-  }),
-  environment: Flags.string({
-    char: 'e',
-    description: 'Use one of the environments specified in config.environments'
-  }),
-  config: Flags.string({
-    description: 'Read configuration for the test from the specified file'
-  }),
-  'scenario-name': Flags.string({
-    description: 'Name of the specific scenario to run'
-  }),
-  overrides: Flags.string({
-    description: 'Dynamically override values in the test script; a JSON object'
-  }),
-  input: Flags.string({
-    char: 'i',
-    description: 'Input script file',
-    multiple: true,
-    hidden: true
-  }),
-  tags: Flags.string({
-    description:
-      'Comma-separated list of tags in key:value format to tag the test run, for example: --tags team:sre,service:foo'
-  }),
-  note: Flags.string({}), // TODO: description
   packages: Flags.string({
     description: runTestDescriptions.packages
   }),
@@ -140,12 +105,6 @@ RunCommand.flags = {
   }),
   dotenv: Flags.string({
     description: runTestDescriptions.dotenv
-  }),
-  record: Flags.boolean({
-    description: 'Record test run to Artillery Cloud'
-  }),
-  key: Flags.string({
-    description: 'API key for Artillery Cloud'
   })
 };
 

--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -1,4 +1,5 @@
 const { Command, Flags, Args } = require('@oclif/core');
+const { CommonRunFlags } = require('../cli/common-flags');
 
 const RunCommand = require('./run');
 
@@ -50,50 +51,15 @@ Examples:
     $ artillery run:lambda --region us-east-1 --count 10 my-test.yml
 `;
 RunLambdaCommand.flags = {
-  target: Flags.string({
-    char: 't',
-    description:
-      'Set target endpoint. Overrides the target already set in the test script'
-  }),
-  output: Flags.string({
-    char: 'o',
-    description: 'Write a JSON report to file'
-  }),
-  insecure: Flags.boolean({
-    char: 'k',
-    description: 'Allow insecure TLS connections; do not use in production'
-  }),
-  overrides: Flags.string({
-    description: 'Dynamically override values in the test script; a JSON object'
-  }),
+  ...CommonRunFlags,
   variables: Flags.string({
     char: 'v',
     description:
       'Set variables available to vusers during the test; a JSON object'
   }),
-  // TODO: Replace with --profile
-  environment: Flags.string({
-    char: 'e',
-    description: 'Use one of the environments specified in config.environments'
-  }),
-  config: Flags.string({
-    char: 'c',
-    description: 'Read configuration for the test from the specified file'
-  }),
   payload: Flags.string({
     char: 'p',
     description: 'Specify a CSV file for dynamic data'
-  }),
-  // multiple allows multiple arguments for the -i flag, which means that e.g.:
-  // artillery -i one.yml -i two.yml main.yml
-  // does not work as expected. Instead of being considered an argument, "main.yml"
-  // is considered to be input for "-i" and oclif then complains about missing
-  // argument
-  input: Flags.string({
-    char: 'i',
-    description: 'Input script file',
-    multiple: true,
-    hidden: true
   }),
   dotenv: Flags.string({
     description: 'Path to a dotenv file to load environment variables from'
@@ -101,22 +67,6 @@ RunLambdaCommand.flags = {
   count: Flags.string({
     // locally defaults to number of CPUs with mode = distribute
     default: '1'
-  }),
-  tags: Flags.string({
-    description:
-      'Comma-separated list of tags in key:value format to tag the test run, for example: --tags team:sqa,service:foo'
-  }),
-  note: Flags.string({
-    description: 'Add a note/annotation to the test run'
-  }),
-  record: Flags.boolean({
-    description: 'Record test run to Artillery Cloud'
-  }),
-  key: Flags.string({
-    description: 'API key for Artillery Cloud'
-  }),
-  'scenario-name': Flags.string({
-    description: 'Name of the specific scenario to run'
   }),
   architecture: Flags.string({
     description: 'Architecture of the Lambda function',

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -1,4 +1,5 @@
 const { Command, Flags, Args } = require('@oclif/core');
+const { CommonRunFlags } = require('../cli/common-flags');
 
 const {
   readScript,
@@ -74,25 +75,10 @@ Examples:
 // TODO: Link to an Examples section in the docs
 
 RunCommand.flags = {
-  target: Flags.string({
-    char: 't',
-    description:
-      'Set target endpoint. Overrides the target already set in the test script'
-  }),
-  output: Flags.string({
-    char: 'o',
-    description: 'Write a JSON report to file'
-  }),
-  insecure: Flags.boolean({
-    char: 'k',
-    description: 'Allow insecure TLS connections; do not use in production'
-  }),
+  ...CommonRunFlags,
   quiet: Flags.boolean({
     char: 'q',
     description: 'Quiet mode'
-  }),
-  overrides: Flags.string({
-    description: 'Dynamically override values in the test script; a JSON object'
   }),
   variables: Flags.string({
     char: 'v',
@@ -100,37 +86,13 @@ RunCommand.flags = {
       'Set variables available to vusers during the test; a JSON object'
   }),
   // TODO: Deprecation notices for commands below:
-
-  // TODO: Replace with --profile
-  environment: Flags.string({
-    char: 'e',
-    description: 'Use one of the environments specified in config.environments'
-  }),
-  config: Flags.string({
-    char: 'c',
-    description: 'Read configuration for the test from the specified file'
-  }),
   payload: Flags.string({
     char: 'p',
     description: 'Specify a CSV file for dynamic data'
   }),
-  // multiple allows multiple arguments for the -i flag, which means that e.g.:
-  // artillery -i one.yml -i two.yml main.yml
-  // does not work as expected. Instead of being considered an argument, "main.yml"
-  // is considered to be input for "-i" and oclif then complains about missing
-  // argument
-  input: Flags.string({
-    char: 'i',
-    description: 'Input script file',
-    multiple: true,
-    hidden: true
-  }),
   solo: Flags.boolean({
     char: 's',
     description: 'Create only one virtual user'
-  }),
-  dotenv: Flags.string({
-    description: 'Path to a dotenv file to load environment variables from'
   }),
   platform: Flags.string({
     description: 'Runtime platform',
@@ -144,22 +106,6 @@ RunCommand.flags = {
   count: Flags.string({
     // locally defaults to number of CPUs with mode = distribute
     default: '1'
-  }),
-  tags: Flags.string({
-    description:
-      'Comma-separated list of tags in key:value format to tag the test run, for example: --tags team:sqa,service:foo'
-  }),
-  note: Flags.string({
-    description: 'Add a note/annotation to the test run'
-  }),
-  record: Flags.boolean({
-    description: 'Record test run to Artillery Cloud'
-  }),
-  key: Flags.string({
-    description: 'API key for Artillery Cloud'
-  }),
-  'scenario-name': Flags.string({
-    description: 'Name of the specific scenario to run'
   })
 };
 


### PR DESCRIPTION
## Description

With Fargate now in this repo, it's easier to consolidate common flags together. This prevents drift in descriptions and missing flags implemented in commands (e.g. Fargate doesn't have --variables, which has been reported as an issue).

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
