### PR TITLE
feat: improve fargate cli flag descriptions and usage

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -8,6 +8,7 @@ const telemetry = require('../telemetry').init();
 const { Plugin: CloudPlugin } = require('../platform/cloud/cloud');
 
 const runCluster = require('../platform/aws-ecs/legacy/run-cluster');
+const { supportedRegions } = require('../platform/aws-ecs/legacy/util');
 const PlatformECS = require('../platform/aws-ecs/ecs');
 const { ECS_WORKER_ROLE_NAME } = require('../platform/aws/constants');
 
@@ -66,7 +67,8 @@ RunCommand.flags = {
   }),
   region: Flags.string({
     char: 'r',
-    description: 'The AWS region to run in'
+    description: 'The AWS region to run in',
+    options: supportedRegions
   }),
   secret: Flags.string({
     multiple: true,

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -47,16 +47,6 @@ class RunCommand extends Command {
   }
 }
 
-const runTestDescriptions = {
-  count: 'Number of load generator workers to launch',
-  cluster: 'Name of the Fargate/ECS cluster to run the test on',
-  region: 'The AWS region to run in',
-  packages:
-    'Path to package.json file which lists dependencies for the test script',
-  maxDuration: 'Maximum duration of the test run',
-  dotenv: 'Path to a .env file to load environment variables from'
-};
-
 RunCommand.description = `launch a test using AWS ECS/Fargate
 
 Examples:
@@ -69,14 +59,14 @@ Examples:
 RunCommand.flags = {
   ...CommonRunFlags,
   count: Flags.integer({
-    description: runTestDescriptions.count
+    description: 'Number of load generator workers to launch'
   }),
   cluster: Flags.string({
-    description: runTestDescriptions.cluster
+    description: 'Name of the Fargate/ECS cluster to run the test on'
   }),
   region: Flags.string({
     char: 'r',
-    description: runTestDescriptions.region
+    description: 'The AWS region to run in'
   }),
   secret: Flags.string({
     multiple: true,
@@ -113,13 +103,14 @@ RunCommand.flags = {
     default: '8'
   }),
   packages: Flags.string({
-    description: runTestDescriptions.packages
+    description:
+      'Path to package.json file which lists dependencies for the test script'
   }),
   'max-duration': Flags.string({
-    description: runTestDescriptions.maxDuration
+    description: 'Maximum duration of the test run'
   }),
   dotenv: Flags.string({
-    description: runTestDescriptions.dotenv
+    description: 'Path to a .env file to load environment variables from'
   })
 };
 

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -108,9 +108,6 @@ RunCommand.flags = {
   }),
   'max-duration': Flags.string({
     description: 'Maximum duration of the test run'
-  }),
-  dotenv: Flags.string({
-    description: 'Path to a .env file to load environment variables from'
   })
 };
 

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -19,8 +19,6 @@ class RunCommand extends Command {
 
   async run() {
     const { flags, _argv, args } = await this.parse(RunCommand);
-    flags.region = flags.region || 'us-east-1';
-
     flags['platform-opt'] = [`region=${flags.region}`];
 
     flags.platform = 'aws:ecs';
@@ -68,7 +66,8 @@ RunCommand.flags = {
   region: Flags.string({
     char: 'r',
     description: 'The AWS region to run in',
-    options: supportedRegions
+    options: supportedRegions,
+    default: 'us-east-1'
   }),
   secret: Flags.string({
     multiple: true,

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -79,14 +79,29 @@ RunCommand.flags = {
     description: runTestDescriptions.region
   }),
   secret: Flags.string({
-    multiple: true
+    multiple: true,
+    description:
+      'Make secrets available to workers. The secret must exist in SSM parameter store for the given region, under /artilleryio/<SECRET_NAME>'
   }),
-  // TODO: Descriptions
-  'launch-type': Flags.string({}),
-  'launch-config': Flags.string({}),
-  'subnet-ids': Flags.string({}),
-  'security-group-ids': Flags.string({}),
-  'task-role-name': Flags.string({}),
+  'launch-type': Flags.string({
+    description: 'The launch type to use for the test. Defaults to Fargate.',
+    options: ['ecs:fargate', 'ecs:ec2']
+  }),
+  'launch-config': Flags.string({
+    description:
+      'JSON to customize launch configuration of ECS/Fargate tasks (see https://www.artillery.io/docs/reference/cli/run-fargate#using---launch-config)'
+  }),
+  'subnet-ids': Flags.string({
+    description:
+      'Comma-separated list of AWS VPC subnet IDs to launch Fargate tasks in'
+  }),
+  'security-group-ids': Flags.string({
+    description:
+      'Comma-separated list of AWS VPC security group IDs to launch Fargate tasks in'
+  }),
+  'task-role-name': Flags.string({
+    description: 'Custom IAM role name for Fargate containers to assume'
+  }),
   cpu: Flags.string({
     description:
       'Set task vCPU on Fargate. Value may be set as a number of vCPUs between 1-16 (e.g. 4), or as number of vCPU units (e.g. 4096)',

--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -56,9 +56,6 @@ RunLambdaCommand.flags = {
     char: 'p',
     description: 'Specify a CSV file for dynamic data'
   }),
-  dotenv: Flags.string({
-    description: 'Path to a dotenv file to load environment variables from'
-  }),
   count: Flags.string({
     // locally defaults to number of CPUs with mode = distribute
     default: '1'

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -454,6 +454,7 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     scriptPath: absoluteScriptPath,
     originalScriptPath: scriptPath,
     count: count,
+    region: options.region,
     taskName: `${TASK_NAME}_${
       IS_FARGATE ? 'fargate' : ''
     }_${clusterName}_${IMAGE_VERSION}_${Math.floor(Math.random() * 1e6)}`,
@@ -466,10 +467,6 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     packageJsonPath,
     taskArns: []
   });
-
-  if (typeof options.region !== 'undefined') {
-    context.region = options.region;
-  }
 
   let subnetIds = [];
   if (options.publicSubnetIds) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -467,18 +467,6 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     taskArns: []
   });
 
-  if (
-    typeof options.region !== 'undefined' &&
-    util.supportedRegions.indexOf(options.region) === -1
-  ) {
-    console.log(
-      `Unsupported region (${
-        options.region
-      }) provided. Please specify one of: ${util.supportedRegions.join(', ')} `
-    );
-    process.exit(1);
-  }
-
   if (typeof options.region !== 'undefined') {
     context.region = options.region;
   }


### PR DESCRIPTION
## Description

- [feat(cli): add missing fargate flag descriptions](https://github.com/artilleryio/artillery/commit/ed4759ba97fb1eab6ab9fa0cf1974a7f58790336)
- [refactor(cli): move fargate flag descriptions inline](https://github.com/artilleryio/artillery/commit/550ed100cf586f3dafc79c797884b49db15da975)
- [fix(cli): make --secret fargate flag hidden](https://github.com/artilleryio/artillery/commit/078fda76a2e2001651660964fea69fab3a5ab720) (this might actually be meant to be deleted?)
- [feat(cli): set supported fargate regions as options to --region flag](https://github.com/artilleryio/artillery/commit/960b5ae505221bf0cbf7f840a5c5562923af65c6)
- [refactor(cli): set default fargate region in cli](https://github.com/artilleryio/artillery/commit/81e02ca5555a7f4590d003bf5a455be5baf74d3e)

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry? Yes, probably for fargate regions one 
