### PR TITLE
fix(lambda): require esbuild-wasm conditionally to fix lambda failure

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -22,7 +22,6 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const os = require('os');
-const esbuild = require('esbuild-wasm');
 const createLauncher = require('../launch-platform');
 const createConsoleReporter = require('../../console-reporter');
 
@@ -405,6 +404,10 @@ function replaceProcessorIfTypescript(script, scriptPath, platform) {
     tmpDir,
     `${processorFileName}-${Date.now()}.js`
   );
+
+  //TODO: move require to top of file when Lambda bundle size issue is solved
+  //must be conditionally required for now as this package is removed in Lambda for now to avoid bigger package sizes
+  const esbuild = require('esbuild-wasm');
 
   try {
     esbuild.buildSync({


### PR DESCRIPTION
## Description

We [uninstall `esbuild-wasm` from Lambda](https://github.com/artilleryio/artillery/blob/0d6a000892bcf8d78e54b2cfb5178c2f768fc52d/packages/artillery/lib/platform/aws-lambda/index.js#L294) to prevent bundle size from increasing, as it's close to the limit. As a result, Lambda tests fail when they try to require the package on the top. 

As a workaround, conditionally requiring it only when TS usage is needed solves this. When bundle size is no longer an issue, we can revert this.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No, TS support is not released yet, so this isn't a user-facing bug yet
