### PR TITLE
feat(cli): record publish-metrics reporters usage with posthog

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -639,6 +639,30 @@ async function sendTelemetry(script, flags, extraProps) {
       }
     }
 
+    // publish-metrics reporters
+    if (script.config.plugins['publish-metrics']) {
+      const OFFICIAL_REPORTERS = [
+        'datadog',
+        'open-telemetry',
+        'lightstep',
+        'newrelic',
+        'splunk',
+        'dynatrace',
+        'cloudwatch',
+        'honeycomb',
+        'mixpanel',
+        'prometheus'
+      ];
+
+      properties.officialReporters = script.config.plugins[
+        'publish-metrics'
+      ].map((reporter) => {
+        if (OFFICIAL_REPORTERS.includes(reporter.type)) {
+          return reporter.type;
+        }
+      });
+    }
+
     // before/after hooks
     if (script.before) {
       properties.beforeHook = true;

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -654,7 +654,7 @@ async function sendTelemetry(script, flags, extraProps) {
         'prometheus'
       ];
 
-      properties.officialReporters = script.config.plugins[
+      properties.officialMonitoringReporters = script.config.plugins[
         'publish-metrics'
       ].map((reporter) => {
         if (OFFICIAL_REPORTERS.includes(reporter.type)) {


### PR DESCRIPTION
# Description

Extending `sendTelemetry` function to send `publish-metrics` reporters used in order to get insights into which reporters are most popular with users.

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?