### PR TITLE
test(aws): send aws tests to artillery cloud dashboard

### DIFF
--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -69,3 +69,7 @@ jobs:
         env:
           FORCE_COLOR: 1
           ECR_IMAGE_VERSION: ${{ github.sha }} # the image is published with the sha of the commit within this repo
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+          GITHUB_REPO: ${{ github.repository }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/packages/artillery/test/cli/_helpers.js
+++ b/packages/artillery/test/cli/_helpers.js
@@ -30,4 +30,18 @@ async function getRootPath(filename) {
   return path.resolve(__dirname, '..', '..', filename);
 }
 
-module.exports = { execute, deleteFile, getRootPath, returnTmpPath };
+function getTestTags(additionalTags) {
+  const actorTag = `actor:${process.env.GITHUB_ACTOR || 'localhost'}`;
+  const repoTag = `repo:${process.env.GITHUB_REPO || 'artilleryio/artillery'}`;
+  const ciTag = `ci:${process.env.GITHUB_ACTIONS ? 'true' : 'false'}`;
+
+  return `${repoTag},${actorTag},${ciTag},${additionalTags.join(',')}`;
+}
+
+module.exports = {
+  execute,
+  deleteFile,
+  getRootPath,
+  returnTmpPath,
+  getTestTags
+};

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda.test.js
@@ -1,19 +1,14 @@
 const tap = require('tap');
-const { execute } = require('../../cli/_helpers.js');
+const { $ } = require('zx');
 
 tap.test('Run a test on AWS Lambda', async (t) => {
-  const [exitCode, output] = await execute([
-    'run:lambda',
-    '--count',
-    '10',
-    '--region',
-    'eu-west-1',
-    '--config',
-    './test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/config.yml',
-    './test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/blitz.yml'
-  ]);
+  const configPath = `${__dirname}/fixtures/quick-loop-with-csv/config.yml`;
+  const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
-  t.equal(exitCode, 0, 'CLI should exit with code 0');
+  const output =
+    await $`artillery run-lambda --count 10 --region eu-west-1 --config ${configPath} ${scenarioPath}`;
+
+  t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 
   t.ok(
     output.stdout.indexOf('Summary report') > 0,

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda.test.js
@@ -1,12 +1,14 @@
 const tap = require('tap');
 const { $ } = require('zx');
+const { getTestTags } = require('../../cli/_helpers.js');
 
 tap.test('Run a test on AWS Lambda', async (t) => {
+  const tags = getTestTags(['type:acceptance']);
   const configPath = `${__dirname}/fixtures/quick-loop-with-csv/config.yml`;
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
   const output =
-    await $`artillery run-lambda --count 10 --region eu-west-1 --config ${configPath} ${scenarioPath}`;
+    await $`artillery run-lambda --count 10 --region eu-west-1 --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
 
   t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 


### PR DESCRIPTION
## Description

Debugging some CI AWS failures in https://github.com/artilleryio/artillery/pull/2407 proved quite challenging.

This PR exposes `ARTILLERY_CLOUD_ENDPOINT` and `ARTILLERY_CLOUD_API_KEY` when running the tests, so they will be sent to the cloud. It also adds `GITHUB_REPO` and `GITHUB_ACTOR` so we can add some additional tags to the tests for additional context.

*Note: this won't apply to this PR, as workflow changes (the passing of the variables) don't get reflected due to the usage of `pull_request_target`.*

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
