### PR TITLE
fix(fargate): send taskArns of non-leader tasks to cloud

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1583,9 +1583,11 @@ async function ecsRunTask(context) {
       }
 
       if (runData.tasks?.length > 0) {
-        context.taskArns = context.taskArns.concat(
-          runData.tasks.map((task) => task.taskArn)
-        );
+        const newTaskArns = runData.tasks.map((task) => task.taskArn);
+        context.taskArns = context.taskArns.concat(newTaskArns);
+        artillery.globalEvents.emit('metadata', {
+          platformMetadata: { taskArns: newTaskArns }
+        });
         debug(`Launched ${launchCount} tasks`);
         tasksRemaining -= launchCount;
         await sleep(250);


### PR DESCRIPTION
## Description

Only the arn of the leader task was being sent to cloud. This sends the arn of other created tasks too, as they're created.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
