### PR TITLE
fix: improve task startup logic for Fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1538,6 +1538,8 @@ async function launchLeadTask(context) {
     throw runErr;
   }
 
+  await awaitOnEE(context.reporterEvents, 'prepack_end', 1000 * 60 * 1);
+
   return context;
 }
 
@@ -1852,6 +1854,10 @@ async function listen(context, ee) {
         } catch (parseErr) {
           console.error('Error processing ensure directive');
         }
+      }
+
+      if (body.type === 'leader' && body.msg === 'prepack_end') {
+        ee.emit('prepack_end');
       }
     });
 

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -137,7 +137,7 @@ check_dependencies () {
 sync_test_data () {
     mkdir "$TEST_DATA"
     pushd "$TEST_DATA" >/dev/null
-    aws s3 sync "$s3_test_data_path" . >/dev/null
+    aws s3 sync --exclude node_modules_stream.zip "$s3_test_data_path" . >/dev/null
 
     debug "$(pwd)"
     debug "$(ls -a)"

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -179,6 +179,7 @@ install_dependencies () {
         echo "Modules pre-packaged"
         aws s3 mv "$s3_test_data_path/node_modules_stream.zip" "$s3_test_data_path/node_modules.zip"
         send_message "leader npm prepack end `date +%s`" "debug"
+        send_message "prepack_end" "leader"
     else
         # wait until node_modules.zip is available and unzip, or timeout
         # TODO: use aws s3api wait object-exists with a custom timeout


### PR DESCRIPTION
Two changes here:

1. Explicitly exclude `node_modules_stream.zip` from being synced into workers, and wait for `node_modules.zip` to be available as intended instead.
2. Add a short wait in between launching a lead worker and launching more workers. This gives the lead task some time to finish pre-packing dependencies, but still allows other workers to provision in parallel should pre-packing take a while (which would be the case for tests with large dependency trees).

Fixes https://github.com/artilleryio/artillery/issues/2427