### PR TITLE
fix(fargate): convert to posix paths before sending files to s3

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -16,6 +16,12 @@ const Table = require('cli-table3');
 
 // NOTE: Code below presumes that all paths are absolute
 
+//Tests in Fargate run on ubuntu, which uses posix paths
+//This function converts a path to posix path, in case the original path was not posix (e.g. windows runs)
+function _convertToPosixPath(p) {
+  return p.split(path.sep).join(path.posix.sep);
+}
+
 function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
   A.waterfall(
     [
@@ -70,6 +76,7 @@ function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
         prefix = commonPrefix(context.localFilePaths);
       }
 
+      prefix = _convertToPosixPath(prefix);
       debug('prefix', prefix);
 
       //
@@ -100,7 +107,15 @@ function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
       });
 
       const files = context.localFilePaths.map((p) => {
-        return { orig: p, noPrefix: p.substring(prefix.length, p.length) };
+        return {
+          orig: p,
+          noPrefix: p.substring(prefix.length, p.length),
+          origPosix: _convertToPosixPath(p),
+          noPrefixPosix: _convertToPosixPath(p).substring(
+            prefix.length,
+            p.length
+          )
+        };
       });
 
       const pkgPath = _.find(files, (f) => {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/create-test.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/create-test.js
@@ -129,7 +129,7 @@ function syncS3(context, callback) {
         return eachDone(null, context);
       }
 
-      const key = context.s3Prefix + '/' + item.noPrefix;
+      const key = context.s3Prefix + '/' + item.noPrefixPosix;
       plainS3.putObject(
         {
           Bucket: context.s3Bucket,
@@ -166,13 +166,13 @@ function writeTestMetadata(context, callback) {
     const res = context.manifest.files.filter((o) => {
       return o.orig === context.configPath;
     });
-    const newConfigPath = res[0].noPrefix; // if we have been given a config, we must have an entry
+    const newConfigPath = res[0].noPrefixPosix; // if we have been given a config, we must have an entry
     metadata.configPath = newConfigPath;
   }
 
   const newScriptPath = context.manifest.files.filter((o) => {
     return o.orig === context.scriptPath;
-  })[0].noPrefix;
+  })[0].noPrefixPosix;
   metadata.scriptPath = newScriptPath;
 
   debug('metadata', metadata);


### PR DESCRIPTION
## Description

Paths to send to s3 are built based on a windows file system, but they are ran in ubuntu in the AWS containers. We need to account for that and convert the paths if needed.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
