### PR TITLE
fix(publish-metrics): otel tracing bug

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -101,10 +101,10 @@ class OTelReporter {
       return done();
     }
     if (this.httpReporter) {
-      await this.httpReporter.cleanup();
+      await this.httpReporter.cleanup('http');
     }
     if (this.playwrightReporter) {
-      await this.playwrightReporter.cleanup();
+      await this.playwrightReporter.cleanup('playwright');
     }
     await this.traceConfig.shutDown();
     return done();

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -89,6 +89,9 @@ class OTelTraceBase {
     this.script = script;
     this.pendingRequestSpans = 0;
     this.pendingScenarioSpans = 0;
+    this.pendingPageSpans = 0;
+    this.pendingStepSpans = 0;
+    this.pendingPlaywrightScenarioSpans = 0;
   }
   setTracer(engine) {
     // Get and set the tracer by engine
@@ -144,10 +147,19 @@ class OTelTraceBase {
 
   async cleanup() {
     while (this.pendingRequestSpans > 0 || this.pendingScenarioSpans > 0) {
-      debug('Waiting for pending traces ...');
+      debug('Waiting for pending HTTP traces ...');
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
-    debug('Pending traces done');
+    debug('Pending HTTP traces done');
+    while (
+      this.pendingPageSpans > 0 ||
+      this.pendingStepSpans > 0 ||
+      this.pendingPlaywrightScenarioSpans > 0
+    ) {
+      debug('Waiting for pending Playwright traces ...');
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    debug('Pending Playwright traces done');
   }
 }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -60,15 +60,16 @@ class OTelTraceConfig {
       this.exporterOpts
     );
 
+    this.processorOpts = {
+      scheduledDelayMillis: this.config.scheduledDelayMillis || 5000,
+      maxExportBatchSize: this.config.maxExportBatchSize || 1000,
+      maxQueueSize: this.config.maxQueueSize || 2000
+    };
     const Processor = this.config.smartSampling
       ? OutlierDetectionBatchSpanProcessor
       : BatchSpanProcessor;
 
-    this.tracerProvider.addSpanProcessor(
-      new Processor(this.exporter, {
-        scheduledDelayMillis: 1000
-      })
-    );
+    this.tracerProvider.addSpanProcessor(new Processor(this.exporter));
     this.tracerProvider.register();
   }
 
@@ -160,6 +161,8 @@ class OTelTraceBase {
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
     debug('Pending Playwright traces done');
+    debug('Waiting for flush period to complete');
+    await new Promise((resolve) => setTimeout(resolve, 5000));
   }
 }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -105,7 +105,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             scenarioSpan.addEvent(`navigated to ${page.url()}`);
             if (pageSpan) {
               pageSpan.end();
-              this.pendingPageSpans--;
+              this.pendingPlaywrightSpans--;
             }
 
             pageSpan = this.playwrightTracer.startSpan(
@@ -118,7 +118,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
               ...(this.config.attributes || {})
             });
             lastPageUrl = pageUrl;
-            this.pendingPageSpans++;
+            this.pendingPlaywrightSpans++;
           }
         });
 
@@ -146,7 +146,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
         } finally {
           if (pageSpan && !pageSpan.endTime[0]) {
             pageSpan.end();
-            this.pendingPageSpans--;
+            this.pendingPlaywrightSpans--;
           }
           scenarioSpan.end();
           this.pendingPlaywrightScenarioSpans--;
@@ -164,7 +164,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
           { kind: SpanKind.CLIENT },
           context.active()
         );
-        this.pendingStepSpans++;
+        this.pendingPlaywrightSpans++;
         const startTime = Date.now();
 
         try {
@@ -186,7 +186,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
           const difference = Date.now() - startTime;
           events.emit('histogram', `browser.step.${stepName}`, difference);
           span.end();
-          this.pendingStepSpans--;
+          this.pendingPlaywrightSpans--;
         }
       });
     };

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -320,8 +320,6 @@ run_a9 () {
         EXIT_CODE=$ERR_CLI_ERROR
     fi
 
-    sleep 10 # wait for datadog worker to finish flushing data
-
     exit $EXIT_CODE
 }
 

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -320,6 +320,8 @@ run_a9 () {
         EXIT_CODE=$ERR_CLI_ERROR
     fi
 
+    sleep 10 # wait for datadog worker to finish flushing data
+
     exit $EXIT_CODE
 }
 


### PR DESCRIPTION
# Description

Fix for OTel traces arriving inconsistently (in number and format) to observability platforms when running in Fargate 

## Context
Two different issues were observed, and usually at least one would happen:
1. All traces properly formed with the correct attributes and status, but some traces missing
2. Traces not properly formed - missing parent root spans, incorrect span status (errors not set on spans)
 
*Note: the issues would not happen on local runs, and issue 2. seems to only happen on Datadog.*

The issues seem to be a result of multiple factors:
- The wait for pending traces was not implemented in Playwright tracing possibly leading to triggering the `traceProvider ` shut down prematurely.
- In large tests with many traces the `maxExportBatchSize` and eventually the `maxQueueSize` could be reached in which case spans would be dropped


## Solution

This PR addresses the mentioned factors that seem to be causing the issues:

1. Waiting for pending traces is implemented in the Playwright tracing itself 
2. The defaults for `maxExportBatchSize`, `maxQueueSize` and the `scheduledDelayMillis` were increased, and the settings exposed to user for configuration if needed (this would allow users to adjust the number of traces that a batch can take before dropping them)
3. Additional 5sec wait is added prior to shutting down the `traceProvider` in order to wait for the exporters flush.

