### PR TITLE
feat(playwright): Added testIdAttribute configuration to playwright engine

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('engine:playwright');
-const { chromium } = require('playwright');
+const { chromium, selectors } = require('playwright');
 
 class PlaywrightEngine {
   constructor(script) {
@@ -21,6 +21,8 @@ class PlaywrightEngine {
         this.config.defaultPageTimeout || this.config.defaultTimeout,
         10
       ) || 30) * 1000;
+    
+    this.testIdAttribute = this.config.testIdAttribute;
 
     this.aggregateByName =
       script.config.engines.playwright.aggregateByName || false;
@@ -84,6 +86,9 @@ class PlaywrightEngine {
 
       context.setDefaultNavigationTimeout(self.defaultNavigationTimeout);
       context.setDefaultTimeout(self.defaultTimeout);
+      if (self.testIdAttribute) {
+        selectors.setTestIdAttribute(self.testIdAttribute);
+      }
       debug('context created');
 
       const uniquePageLoadToTiming = {};

--- a/packages/types/definitions.ts
+++ b/packages/types/definitions.ts
@@ -121,6 +121,12 @@ export type PlaywrightEngineConfig = {
    */
   defaultNavigationTimeout?: number;
   /**
+   * When set, changes the attribute used by locator `page.getByTestId` in Playwright.
+   * https://playwright.dev/docs/api/class-framelocator#frame-locator-get-by-test-id
+   * @title Test ID Attribute
+   */
+  testIdAttribute?: string;
+  /**
    * Aggregate Artillery metrics by test scenario name.
    * https://www.artillery.io/docs/reference/engines/playwright#aggregate-metrics-by-scenario-name
    * @title Aggregate by name

--- a/packages/types/schema/engines/playwright.js
+++ b/packages/types/schema/engines/playwright.js
@@ -32,6 +32,11 @@ const PlaywrightConfigSchema = Joi.object({
     .description(
       'Default maximum navigation time (in seconds) for Playwright navigation methods, like `page.goto()`.\nhttps://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-navigation-timeout'
     ),
+  testIdAttribute: Joi.string()
+    .meta({ title: 'Test ID Attribute'})
+    .description(
+      'When set, changes the attribute used by locator `page.getByTestId` in Playwright. \n https://playwright.dev/docs/api/class-framelocator#frame-locator-get-by-test-id'
+    ),
   extendedMetrics: artilleryBooleanOrString
     .meta({ title: 'Playwright Extended Metrics' })
     .description(


### PR DESCRIPTION
As discussed in #2438 

Introduces the ability to configure the selector by exposing the same variables that playwright.config.ts usually exposes in use. Similar to defaultNavigationTimeout and defaultTimeout.

I would have added tests but I could find an existing setup for the playwright engine to contribute to.

Resolves: #2438 