### PR TITLE
feat(publish-metrics): implement smartSampling for Playwright tracing

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/outlier-detection-processor.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/outlier-detection-processor.js
@@ -10,34 +10,29 @@ class OutlierDetectionBatchSpanProcessor extends BatchSpanProcessor {
   }
 
   onEnd(span) {
-    if (span.instrumentationLibrary.name === 'artillery-playwright') {
-      super.onEnd(span);
-    } else {
-      const traceId = span.spanContext().traceId;
+    const traceId = span.spanContext().traceId;
 
-      // When an outlier span is recognised the whole trace it belongs to is exported, so all the spans that belong to the trace need to be grouped and held until the trace finishes.
-      if (!this._traces.has(traceId)) {
-        this._traces.set(traceId, {
-          spans: [],
-          hasOutlier: false
-        });
-      }
-      const traceData = this._traces.get(traceId);
-      traceData.spans.push(span);
+    // When an outlier span is recognised the whole trace it belongs to is exported, so all the spans that belong to the trace need to be grouped and held until the trace finishes.
+    if (!this._traces.has(traceId)) {
+      this._traces.set(traceId, {
+        spans: [],
+        hasOutlier: false
+      });
+    }
+    const traceData = this._traces.get(traceId);
+    traceData.spans.push(span);
 
-      // Since only request level spans are screened for outliers, the outlier check is performed only if the span is a request level span - has 'http.url' attribute
-      if (span.attributes['http.url'] && this._isOutlier(span)) {
-        traceData.hasOutlier = true;
-      }
+    if (this._isOutlier(span)) {
+      traceData.hasOutlier = true;
+    }
 
-      // The trace ends when the root span ends, so we only filter and send data when the span that ended is the root span
-      // The traces that do not have outlier spans are dropped and the rest is sent to buffer/export
-      if (!span.parentSpanId) {
-        if (traceData.hasOutlier) {
-          traceData.spans.forEach(super.onEnd, this);
-        }
-        this._traces.delete(traceId);
+    // The trace ends when the root span ends, so we only filter and send data when the span that ended is the root span
+    // The traces that do not have outlier spans are dropped and the rest is sent to buffer/export
+    if (!span.parentSpanId) {
+      if (traceData.hasOutlier) {
+        traceData.spans.forEach(super.onEnd, this);
       }
+      this._traces.delete(traceId);
     }
   }
   // Export only outliers on shut down as well for http engine

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -15,7 +15,7 @@ const {
 class OTelHTTPTraceReporter extends OTelTraceBase {
   constructor(config, script) {
     super(config, script);
-    this.outlierCriteria = config.smartSampling;
+    this.outlierCriteria = config.smartSampling?.http;
     this.statusAsErrorThreshold = 400;
   }
   run() {

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -142,6 +142,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             code: SpanStatusCode.ERROR,
             message: err.message
           });
+          scenarioSpan.setAttribute('outlier', true);
           throw err;
         } finally {
           if (pageSpan && !pageSpan.endTime[0]) {
@@ -180,6 +181,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             code: SpanStatusCode.ERROR,
             message: err.message
           });
+          span.setAttribute('outlier', true);
           debug('There has been an error during step execution:');
           throw err;
         } finally {


### PR DESCRIPTION
# Description

## This PR introduces two main changes:
### 1. `smartSampling` support for the Playwright engine tracing.

If `smartSampling` is configured in the test script (as shown below), only traces that have recorded errors will be exported.

```yaml
  plugins:
    publish-metrics:
      - type: open-telemetry
        traces:
          smartSampling: {}
```
### 2. A **breaking change** is introduced in the `smartSampling` configuration for the HTTP engine. 

The additional optional `threshold` settings will now be nested inside the `http` key:

**Old config:**
```yaml
  plugins:
    publish-metrics:
      - type: open-telemetry
        traces:
          smartSampling:
            thresholds:
              firstByte: 500
              total: 2000
```
**New config:**
```yaml
  plugins:
    publish-metrics:
      - type: open-telemetry
        traces:
          smartSampling:
            http:
              thresholds:
                firstByte: 500
                total: 2000
```
# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?

