### PR TITLE
feat(playwright): force headless mode when running in the cloud

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -66,6 +66,14 @@ class PlaywrightEngine {
         self.launchOptions
       );
 
+      if (process.env.WORKER_ID) {
+        if (launchOptions.headless) {
+          // Running inside a cloud worker, e.g. on AWS Fargate. Force headless mode
+          console.log('Running inside a cloud worker. Forcing Playwright headless mode to true');
+          launchOptions.headless = true;
+        }
+      }
+
       const contextOptions = self.contextOptions || {};
 
       let browser;


### PR DESCRIPTION
This prevents a common annoyance where you run in headful mode locally to see what your script is doing and forget to turn it off before trying a run on Fargate.