### PR TITLE
ci: use the right docker image version in published artillery versions

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -2,9 +2,6 @@ name: Build & publish ECS/Fargate worker image to ECR
 
 on:
   workflow_dispatch: 
-  push:
-    branches:
-      - main
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
+      - run: node ./github/workflows/scripts/replace-worker-version-in-js-file.js
+        env:
+          COMMIT_SHA: ${{ github.sha }}
       - run: | 
           export COMMIT_SHA=$(git rev-parse --short HEAD)
           node .github/workflows/scripts/replace-package-versions-with-commit-sha.js

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -19,6 +19,7 @@ on:
       
 jobs:
   publish-fargate-worker-image:
+    if: "!contains( github.event.head_commit.message, 'ci: release v')"
     uses: ./.github/workflows/docker-ecs-worker-image.yml
     permissions:
       contents: read
@@ -28,6 +29,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: "!contains( github.event.head_commit.message, 'ci: release v')"
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -18,6 +18,14 @@ on:
       - 'packages/artillery-plugin-memory-inspector/**'
       
 jobs:
+  publish-fargate-worker-image:
+    uses: ./.github/workflows/docker-ecs-worker-image.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/npm-publish-artillery.yml
+++ b/.github/workflows/npm-publish-artillery.yml
@@ -29,7 +29,12 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
-      - run: PACKAGE_FOLDER_NAME=artillery node .github/workflows/scripts/rename-packages-to-correct-version.js
+      - run: node ./github/workflows/scripts/replace-worker-version-in-js-file.js
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+      - run: node .github/workflows/scripts/rename-packages-to-correct-version.js
+        env:
+          PACKAGE_FOLDER_NAME: artillery
       - run: npm -w artillery publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-artillery.yml
+++ b/.github/workflows/npm-publish-artillery.yml
@@ -6,8 +6,18 @@ on:
     paths:
       - packages/artillery/package.json
 jobs:
+  publish-fargate-worker-image:
+    if: "contains( github.event.head_commit.message, 'ci: release v')"
+    uses: ./.github/workflows/docker-ecs-worker-image.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
+  
   build:
     if: "contains(github.event.head_commit.message, 'ci: release v')"
+    needs: publish-fargate-worker-image
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/scripts/replace-worker-version-in-js-file.js
+++ b/.github/workflows/scripts/replace-worker-version-in-js-file.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+const commitSha = process.env.COMMIT_SHA;
+
+const filePath = path.join(
+  __dirname,
+  '../../../packages/artillery/lib/platform/aws-ecs/legacy/constants.js'
+);
+
+try {
+  let content = fs.readFileSync(filePath, 'utf8');
+
+  // This regex matches "const DEFAULT_IMAGE_TAG" followed by any characters, and then an equal sign and more characters
+  // until it reaches a semicolon or end of the line
+  const regex = /const DEFAULT_IMAGE_TAG\s*=\s*(['"])[^'"]*?\1/;
+  const replacement = `const DEFAULT_IMAGE_TAG = '${commitSha}'`; // Replace with commitSha in single quotes
+  content = content.replace(regex, replacement);
+
+  // Write the modified content back to the file
+  fs.writeFileSync(filePath, content);
+
+  // Verify by reading the content again and console logging it
+  const verifyContent = fs.readFileSync(filePath, 'utf8');
+  console.log(verifyContent);
+
+  if (!verifyContent.includes(commitSha)) {
+    throw new Error('Failed to replace commit SHA in JS file');
+  }
+} catch (error) {
+  console.error('Error occurred:', error);
+}

--- a/packages/artillery/lib/platform/aws-ecs/legacy/constants.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/constants.js
@@ -1,3 +1,4 @@
+// NOTE: if changing this, change replace-worker-version-in-js-file.js script in github workflows that looks for a specific pattern here.
 const DEFAULT_IMAGE_TAG = 'f7534a2844b58ee2a851081a3c498e671ad94f17';
 
 module.exports = {


### PR DESCRIPTION
## Description

Creates script to replace `DEFAULT_IMAGE_TAG` dynamically, and makes some changes to workflows to support it:
- https://github.com/artilleryio/artillery/commit/1be86387f1ebb6a3a2d1baad43c59f3a0b51633a: starts running docker publish as part of the npm publish. This is to prevent race condition where npm build might be pushed (with tests starting to use it) before publish is done.
- https://github.com/artilleryio/artillery/commit/7d6e8c9f2daf0f6e1fea0e24703cdcd5d45b9feb, https://github.com/artilleryio/artillery/commit/7e1810322bc0896099e36f17534aa122453359ad: add replace script and use it in canary/artillery publishes
- https://github.com/artilleryio/artillery/commit/219bff26a8950baf4c2566854b9c1f41f5894117: also publish worker image on canary publishes, since it is no longer doing so with `push:main` trigger
- https://github.com/artilleryio/artillery/commit/dbe2c0160e9918d5007c7969312b809a225378ff: only run canary when not releasing. this prevents images being published twice with the same tag, but also just makes sense, and prevents what  currently happens where every release has a canary version published with it, which is unnecessary and confusing

## Testing

Tested the substitution locally with a couple of strings and variations on the file. The canary that gets published to main on merging this should also test it!

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Maybe, it does prevent the bug we had with last release.
