### PR TITLE
fix(lambda): disable publish metrics in lambda due to bundle size

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -291,7 +291,8 @@ class PlatformLambda {
         'is-builtin-module',
         'try-require',
         'walk-sync',
-        'esbuild-wasm'
+        'esbuild-wasm',
+        'artillery-plugin-publish-metrics'
       ],
       {
         cwd: a9cwd


### PR DESCRIPTION
## Description

Uninstalls `artillery-plugin-publish-metrics` in Lambda tests, making it incompatible with Lambda tests for the short term (until we are able to move to Lambda container images).

### Testing

I tested this locally. Without the uninstall I am also getting bundle size issues, with the install I don't. The Lambda test running in CI should also confirm this.

## Pre-merge checklist

- [x] Does this require an update to the docs? Yes, we need to update limitations
- [x] Does this require a changelog entry? Yes
