### PR TITLE
fix(fargate): start workers in parallel with lead task

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1538,8 +1538,6 @@ async function launchLeadTask(context) {
     throw runErr;
   }
 
-  await awaitOnEE(context.reporterEvents, 'prepack_end', 1000 * 60 * 1);
-
   return context;
 }
 


### PR DESCRIPTION
This reverts the behavior introduced in [1] where worker tasks may wait for up to 60s whilst the lead task is preparing npm dependencies.

The only benefit of waiting is to save up to 60s worth of Fargate compute costs for tests where the lead task fails to startup. This is rare.

Every test pays a penalty of having to wait for some time for the lead task to be ready before the rest of the workers even begin initializing however.

1. https://github.com/artilleryio/artillery/pull/2428