### PR TITLE
ci(publish): fix path and missing needs workflow step

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains( github.event.head_commit.message, 'ci: release v')"
+    needs: publish-fargate-worker-image
     permissions:
       contents: read
       packages: write
@@ -42,7 +43,7 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
-      - run: node ./github/workflows/scripts/replace-worker-version-in-js-file.js
+      - run: node .github/workflows/scripts/replace-worker-version-in-js-file.js
         env:
           COMMIT_SHA: ${{ github.sha }}
       - run: | 


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2456

- `needs: publish-fargate-worker-image` is needed, or otherwise the two workflows will run in parallel. I had put it in the main publish, but forgot it in canary!
- Typo in path