### PR TITLE
fix: set headless mode on Fargate if not already set

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -69,7 +69,7 @@ class PlaywrightEngine {
       );
 
       if (process.env.WORKER_ID) {
-        if (launchOptions.headless) {
+        if (!launchOptions.headless) {
           // Running inside a cloud worker, e.g. on AWS Fargate. Force headless mode
           console.log('Running inside a cloud worker. Forcing Playwright headless mode to true');
           launchOptions.headless = true;


### PR DESCRIPTION
Follow up to #2455. Actually force headless mode when running on Fargate.