### PR TITLE
fix(fargate): propagate phase events to cli and cloud

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/plugins/artillery-plugin-sqs-reporter/index.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/plugins/artillery-plugin-sqs-reporter/index.js
@@ -75,6 +75,7 @@ function ArtillerySQSPlugin(script, events) {
     });
   });
 
+  //TODO: reconcile some of this code with how lambda does sqs reporting
   events.on('phaseStarted', (phaseContext) => {
     this.unsent++;
     const body = JSON.stringify({
@@ -99,6 +100,7 @@ function ArtillerySQSPlugin(script, events) {
     });
   });
 
+  //TODO: reconcile some of this code with how lambda does sqs reporting
   events.on('phaseCompleted', (phaseContext) => {
     this.unsent++;
     const body = JSON.stringify({

--- a/packages/artillery/lib/platform/aws-ecs/legacy/plugins/artillery-plugin-sqs-reporter/index.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/plugins/artillery-plugin-sqs-reporter/index.js
@@ -75,6 +75,54 @@ function ArtillerySQSPlugin(script, events) {
     });
   });
 
+  events.on('phaseStarted', (phaseContext) => {
+    this.unsent++;
+    const body = JSON.stringify({
+      event: 'phaseStarted',
+      phase: phaseContext
+    });
+
+    const params = {
+      MessageBody: body,
+      QueueUrl: this.queueUrl,
+      MessageAttributes: this.messageAttributes,
+      MessageDeduplicationId: uuid(),
+      MessageGroupId: this.testId
+    };
+
+    this.sqs.sendMessage(params, (err, data) => {
+      if (err) {
+        console.error(err);
+      }
+
+      this.unsent--;
+    });
+  });
+
+  events.on('phaseCompleted', (phaseContext) => {
+    this.unsent++;
+    const body = JSON.stringify({
+      event: 'phaseCompleted',
+      phase: phaseContext
+    });
+
+    const params = {
+      MessageBody: body,
+      QueueUrl: this.queueUrl,
+      MessageAttributes: this.messageAttributes,
+      MessageDeduplicationId: uuid(),
+      MessageGroupId: this.testId
+    };
+
+    this.sqs.sendMessage(params, (err, data) => {
+      if (err) {
+        console.error(err);
+      }
+
+      this.unsent--;
+    });
+  });
+
   events.on('done', (_stats) => {
     this.unsent++;
     const body = JSON.stringify({

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1906,6 +1906,14 @@ async function listen(context, ee) {
       ee.emit('stats', stats);
     });
 
+    r.on('phaseStarted', (phase) => {
+      global.artillery.globalEvents.emit('phaseStarted', phase);
+    });
+
+    r.on('phaseCompleted', (phase) => {
+      global.artillery.globalEvents.emit('phaseCompleted', phase);
+    });
+
     r.start();
   });
 }

--- a/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
@@ -29,6 +29,7 @@ class SqsReporter extends EventEmitter {
     this.metricsByPeriod = {}; // individual intermediates by worker
     this.mergedPeriodMetrics = []; // merged intermediates for a period
 
+    //TODO: this code is repeated from `launch-platform.js` - refactor later
     this.phaseStartedEventsSeen = {};
     this.phaseCompletedEventsSeen = {};
 
@@ -190,6 +191,7 @@ class SqsReporter extends EventEmitter {
         return;
       }
 
+      //TODO: this code is repeated from `launch-platform.js` - refactor later
       if (body.event === 'phaseStarted') {
         if (
           typeof self.phaseStartedEventsSeen[body.phase.index] === 'undefined'
@@ -201,6 +203,7 @@ class SqsReporter extends EventEmitter {
         return;
       }
 
+      //TODO: this code is repeated from `launch-platform.js` - refactor later
       if (body.event === 'phaseCompleted') {
         if (
           typeof self.phaseCompletedEventsSeen[body.phase.index] === 'undefined'

--- a/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
@@ -29,6 +29,9 @@ class SqsReporter extends EventEmitter {
     this.metricsByPeriod = {}; // individual intermediates by worker
     this.mergedPeriodMetrics = []; // merged intermediates for a period
 
+    this.phaseStartedEventsSeen = {};
+    this.phaseCompletedEventsSeen = {};
+
     // Debug info:
     this.messagesProcessed = {};
     this.metricsMessagesFromWorkers = {};
@@ -184,6 +187,28 @@ class SqsReporter extends EventEmitter {
         self.emit(body.event, body, attrs);
 
         debug(workerId, body.event);
+        return;
+      }
+
+      if (body.event === 'phaseStarted') {
+        if (
+          typeof self.phaseStartedEventsSeen[body.phase.index] === 'undefined'
+        ) {
+          self.phaseStartedEventsSeen[body.phase.index] = Date.now();
+          self.emit(body.event, body.phase);
+        }
+
+        return;
+      }
+
+      if (body.event === 'phaseCompleted') {
+        if (
+          typeof self.phaseCompletedEventsSeen[body.phase.index] === 'undefined'
+        ) {
+          self.phaseCompletedEventsSeen[body.phase.index] = Date.now();
+          self.emit(body.event, body.phase);
+        }
+
         return;
       }
 


### PR DESCRIPTION
## Description

Currently Fargate doesn't listen to these events and consume them. This PR makes the events available to the CLI command, deduplicates them [in a similar way to launch platform implementation](https://github.com/artilleryio/artillery/blob/main/packages/artillery/lib/launch-platform.js#L69-L70), and then emits the corresponding Artillery Cloud event so `phaseStarted`/`phaseCompleted` appears correctly in the Cloud.

### Testing

Has been tested against Artillery Cloud and phases appear correctly. Check screenshot:

<img width="1429" alt="Screenshot 2024-02-06 at 17 09 43" src="https://github.com/artilleryio/artillery/assets/39738771/cbe53ab3-5a23-4446-9f8b-3fc9ecbf61b2">


## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
