### PR TITLE
fix(fargate): improve cloudwatch retention policy user facing logs

### DIFF
--- a/packages/artillery/lib/platform/aws/aws-cloudwatch.js
+++ b/packages/artillery/lib/platform/aws/aws-cloudwatch.js
@@ -23,7 +23,7 @@ function setCloudwatchRetention(
 ) {
   if (!allowedRetentionDays.includes(retentionInDays)) {
     console.log(
-      `WARNING: Skipping setting Cloudwatch retention, as invalid value specified: ${retentionInDays}. Allowed values are: ${allowedRetentionDays.join(
+      `WARNING: Skipping setting CloudWatch retention, as invalid value specified: ${retentionInDays}. Allowed values are: ${allowedRetentionDays.join(
         ', '
       )}`
     );
@@ -33,7 +33,7 @@ function setCloudwatchRetention(
   const interval = setInterval(
     async (opts) => {
       debug(
-        `Trying to set Cloudwatch Log group ${logGroupName} retention policy to ${retentionInDays} days`
+        `Trying to set CloudWatch Log group ${logGroupName} retention policy to ${retentionInDays} days`
       );
       opts.incr = (opts.incr || 0) + 1;
 
@@ -43,7 +43,7 @@ function setCloudwatchRetention(
           retentionInDays
         );
         debug(
-          `Successfully set Cloudwatch Logs retention policy to ${retentionInDays} days`
+          `Successfully set CloudWatch Logs retention policy to ${retentionInDays} days`
         );
         clearInterval(interval);
       } catch (error) {
@@ -52,7 +52,7 @@ function setCloudwatchRetention(
         if (error?.code == 'AccessDeniedException') {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Missing logs:PutRetentionPolicy permission to set Cloudwatch retention policy. Please ensure the IAM role has the necessary permissions:\nhttps://www.artillery.io/docs/load-testing-at-scale/aws-fargate#iam-permissions'
+            '\nWARNING: Missing logs:PutRetentionPolicy permission to set CloudWatch retention policy. Please ensure the IAM role has the necessary permissions:\nhttps://www.artillery.io/docs/load-testing-at-scale/aws-fargate#iam-permissions'
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);
@@ -62,7 +62,7 @@ function setCloudwatchRetention(
         if (error?.code != 'ResourceNotFoundException') {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Unexpected error setting Cloudwatch retention policy\n'
+            '\nWARNING: Unexpected error setting CloudWatch retention policy\n'
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);
@@ -72,7 +72,7 @@ function setCloudwatchRetention(
         if (opts.incr >= opts.maxRetries) {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Cannot find logs group. Max retries exceeded setting Cloudwatch retention policy:\n'
+            '\nWARNING: Cannot find logs group. Max retries exceeded setting CloudWatch retention policy:\n'
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);

--- a/packages/artillery/lib/platform/aws/aws-cloudwatch.js
+++ b/packages/artillery/lib/platform/aws/aws-cloudwatch.js
@@ -47,16 +47,36 @@ function setCloudwatchRetention(
         );
         clearInterval(interval);
       } catch (error) {
-        if (error & (error.code != 'ResourceNotFoundException')) {
-          console.log('WARNING: Unexpected error setting retention policy:');
-          console.log(error);
+        const resumeTestMessage =
+          'The test will resume without setting the retention policy.';
+        if (error?.code == 'AccessDeniedException') {
+          console.log(`\n${error.message}`);
+          console.log(
+            '\nWARNING: Missing logs:PutRetentionPolicy permission to set Cloudwatch retention policy. Please ensure the IAM role has the necessary permissions:\nhttps://www.artillery.io/docs/load-testing-at-scale/aws-fargate#iam-permissions'
+          );
+          console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);
+          return;
+        }
+
+        if (error?.code != 'ResourceNotFoundException') {
+          console.log(`\n${error.message}`);
+          console.log(
+            '\nWARNING: Unexpected error setting Cloudwatch retention policy\n'
+          );
+          console.log(`${resumeTestMessage}\n`);
+          clearInterval(interval);
+          return;
         }
 
         if (opts.incr >= opts.maxRetries) {
-          console.log('WARNING: Max retries exceeded setting retention policy');
-          console.log(error);
+          console.log(`\n${error.message}`);
+          console.log(
+            '\nWARNING: Cannot find logs group. Max retries exceeded setting Cloudwatch retention policy:\n'
+          );
+          console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);
+          return;
         }
       }
     },

--- a/packages/artillery/lib/platform/aws/aws-cloudwatch.js
+++ b/packages/artillery/lib/platform/aws/aws-cloudwatch.js
@@ -48,11 +48,11 @@ function setCloudwatchRetention(
         clearInterval(interval);
       } catch (error) {
         const resumeTestMessage =
-          'The test will resume without setting the retention policy.';
+          'The test will continue without setting the retention policy.';
         if (error?.code == 'AccessDeniedException') {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Missing logs:PutRetentionPolicy permission to set CloudWatch retention policy. Please ensure the IAM role has the necessary permissions:\nhttps://www.artillery.io/docs/load-testing-at-scale/aws-fargate#iam-permissions'
+            '\nWARNING: Missing logs:PutRetentionPolicy permission to set CloudWatch retention policy. Please ensure the IAM role has the necessary permissions:\nhttps://docs.art/fargate#iam-permissions'
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);
@@ -72,7 +72,7 @@ function setCloudwatchRetention(
         if (opts.incr >= opts.maxRetries) {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Cannot find logs group. Max retries exceeded setting CloudWatch retention policy:\n'
+            '\nWARNING: Cannot find log group. Max retries exceeded setting CloudWatch retention policy:\n'
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);


### PR DESCRIPTION
## Description

As seen in https://github.com/artilleryio/artillery/issues/2486, there might be missing permissions in the role being used to run artillery CLI, which would cause a confusing `warning` with a stack trace, despite the test continuing to run. This makes the `warning` message more easy to understanding.

The `warning` will look something like this now:
```
Launching workers... [11:58:44]
Waiting for Fargate... [11:58:45]
⠇ 
User: arn:aws:sts::ACCOUNT_ID:assumed-role/ROLE_NAME/SESSION_NAME is not authorized to perform: logs:PutRetentionPolicy on resource: arn:aws:logs:us-east-1:ACCOUNT_ID:log-group:artilleryio-log-group/artilleryio-cluster:log-stream: because no identity-based policy allows the logs:PutRetentionPolicy action

WARNING: Missing logs:PutRetentionPolicy permission to set Cloudwatch retention policy. Please ensure the IAM role has the necessary permissions:
https://www.artillery.io/docs/load-testing-at-scale/aws-fargate#iam-permissions
The test will resume without setting the retention policy.

Waiting for workers to start: pending: 1 [11:59:16]
Waiting for workers to start: pending: 1 [11:59:27]
```

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
