### PR TITLE
feat(playwright): use target as baseURL by default

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -76,7 +76,10 @@ class PlaywrightEngine {
         }
       }
 
-      const contextOptions = self.contextOptions || {};
+      const contextOptions = {
+        baseURL: self.target,
+        ...self.contextOptions
+      }
 
       let browser;
       if (self.useSeparateBrowserPerVU) {

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -84,7 +84,7 @@ const ConfigSchemaWithoutEnvironments = Joi.object({
   target: Joi.string()
     .meta({ title: 'Target' })
     .description(
-      'Endpoint of the system under test, such as a hostname, IP address or a URI.\nhttps://www.artillery.io/docs/reference/test-script#target---target-service'
+      'Endpoint of the system under test, such as a hostname, IP address or a URI.\nIn Playwright tests, this will be used as the baseURL by default.\n\nhttps://www.artillery.io/docs/reference/test-script#target---target-service'
     )
     .example('https://example.com')
     .example('ws://127.0.0.1'),


### PR DESCRIPTION
## Description

`target` will now be used as `baseURL` by default. This change makes `artillery-engine-playwright` more consistent with Playwright (which allows the `baseURL` config option), and simplifies the job of transitioning from a Playwright codebase to an Artillery one, as you can simply set the `target` as the `baseURL` option from your Playwright tests, and keep the test scripts the same.

## Testing

- Tested existing test scripts from examples - they work as normal with the full URL, and work when we pass just the path (e.g. `await page.goto('/docs')`).

_Note: I'll change some of the examples to leverage this when a new CLI version contains the change._

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
