### PR TITLE
refactor(publish-metrics): create sleep utility for publish-metrics

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/cloudwatch.js
+++ b/packages/artillery-plugin-publish-metrics/lib/cloudwatch.js
@@ -8,6 +8,8 @@ const {
 } = require('@aws-sdk/client-cloudwatch');
 const debug = require('debug')('plugin:publish-metrics:cloudwatch');
 
+const { sleep } = require('./util');
+
 const COUNTERS_STATS = 'counters'; // counters stats
 const RATES_STATS = 'rates'; // rates stats
 const SUMMARIES_STATS = 'summaries'; // summaries stats
@@ -177,7 +179,7 @@ class CloudWatchReporter {
   async waitingForRequest() {
     do {
       debug('Waiting for pending request ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     } while (this.pendingRequests > 0);
 
     debug('Pending requests done');

--- a/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/dynatrace/index.js
@@ -3,6 +3,7 @@
 const got = require('got');
 const debug = require('debug')('plugin:publish-metrics:dynatrace');
 const path = require('path');
+const { sleep } = require('../util');
 
 class DynatraceReporter {
   constructor(config, events, script) {
@@ -294,7 +295,7 @@ class DynatraceReporter {
   async waitingForRequest() {
     while (this.pendingRequests > 0) {
       debug('Waiting for pending request ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     }
 
     debug('Pending requests done');

--- a/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/newrelic/index.js
@@ -1,4 +1,5 @@
 const got = require('got');
+const { sleep } = require('../util');
 const debug = require('debug')('plugin:publish-metrics:newrelic');
 
 class NewRelicReporter {
@@ -270,7 +271,7 @@ class NewRelicReporter {
   async waitingForRequest() {
     while (this.pendingRequests > 0) {
       debug('Waiting for pending request...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     }
 
     debug('Pending requests done');

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
@@ -9,6 +9,7 @@ const {
 const grpc = require('@grpc/grpc-js');
 const { metricExporters, validateExporter } = require('./exporters');
 const { metrics } = require('@opentelemetry/api');
+const { sleep } = require('../util');
 
 class OTelMetricsReporter {
   constructor(config, events, resource) {
@@ -160,7 +161,7 @@ class OTelMetricsReporter {
   async cleanup() {
     while (this.pendingRequests > 0) {
       debug('Waiting for pending metric request ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     }
     debug('Pending metric requests done');
     debug('Shutting the Reader down');

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -15,6 +15,7 @@ const {
   BatchSpanProcessor
 } = require('@opentelemetry/sdk-trace-base');
 const { SpanKind, trace } = require('@opentelemetry/api');
+const { sleep } = require('../../util');
 
 class OTelTraceConfig {
   constructor(config, resource) {
@@ -152,7 +153,7 @@ class OTelTraceBase {
       waitedTime < maxWaitTime
     ) {
       debug('Waiting for pending traces ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
       waitedTime += 500;
     }
     return true;
@@ -176,7 +177,7 @@ class OTelTraceBase {
 
     debug('Pending traces done');
     debug('Waiting for flush period to complete');
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await sleep(5000);
   }
 }
 

--- a/packages/artillery-plugin-publish-metrics/lib/prometheus.js
+++ b/packages/artillery-plugin-publish-metrics/lib/prometheus.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const PromClient = require('prom-client');
 const uuid = require('uuid');
 const debug = require('debug')('plugin:publish-metrics:prometheus');
+const { sleep } = require('./util');
 
 const COUNTERS_STATS = 'counters', // counters stats
   RATES_STATS = 'rates', // rates stats
@@ -163,7 +164,7 @@ class PrometheusReporter {
   async waitingForRequest() {
     do {
       debug('Waiting for pending request ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     } while (this.hasPendingRequest);
 
     debug('Pending requests done');

--- a/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/splunk/index.js
@@ -1,4 +1,5 @@
 const got = require('got');
+const { sleep } = require('../util');
 const debug = require('debug')('plugin:publish-metrics:splunk');
 
 class SplunkReporter {
@@ -212,7 +213,7 @@ class SplunkReporter {
   async waitingForRequest() {
     while (this.pendingRequests > 0) {
       debug('Waiting for pending request ...');
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     }
 
     debug('Pending requests done');

--- a/packages/artillery-plugin-publish-metrics/lib/util.js
+++ b/packages/artillery-plugin-publish-metrics/lib/util.js
@@ -1,9 +1,18 @@
 module.exports = {
   attachScenarioHooks,
-  versionCheck
+  versionCheck,
+  sleep
 };
 
 const semver = require('semver');
+
+const sleep = async function (n) {
+  return new Promise((resolve, _reject) => {
+    setTimeout(function () {
+      resolve();
+    }, n);
+  });
+};
 
 // TODO: Extract into a utility function in Artillery itself
 function versionCheck(range) {


### PR DESCRIPTION
# Description

Create `sleep` utility and use it throughout the plugin for all intentional delays

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?