### PR TITLE
feat: make test run id available as $testId template variable

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -32,8 +32,10 @@ const telemetry = require('../telemetry').init();
 const validateScript = require('../util/validate-script');
 const { Plugin: CloudPlugin } = require('../platform/cloud/cloud');
 
-const { customAlphabet } = require('nanoid');
 const parseTagString = require('../util/parse-tag-string');
+
+const generateId = require('../util/generate-id');
+
 class RunCommand extends Command {
   static aliases = ['run'];
   // Enable multiple args:
@@ -143,6 +145,10 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
   }
 
   try {
+    const testRunId = process.env.ARTILLERY_TEST_RUN_ID || generateId('t');
+    console.log('Test run id:', testRunId);
+    global.artillery.testRunId = testRunId;
+
     const script = await prepareTestExecutionPlan(inputFiles, flags, args);
 
     const runnerOpts = {
@@ -182,11 +188,6 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
         platformConfig[k] = v;
       }
     }
-
-    const idf = customAlphabet('3456789abcdefghjkmnpqrtwxyz');
-    const testRunId = `t${idf(4)}_${idf(29)}_${idf(4)}`;
-
-    console.log('Test run id:', testRunId);
 
     const launcherOpts = {
       platform: flags.platform,

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1407,6 +1407,10 @@ async function generateTaskOverrides(context) {
           {
             name: 'AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE',
             value: '1'
+          },
+          {
+            name: 'ARTILLERY_TEST_RUN_ID',
+            value: global.artillery.testRunId,
           }
         ]
       },

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -88,7 +88,7 @@ class PlatformLambda {
 
     this.memorySize = platformConfig['memory-size'] || 4096;
 
-    this.testRunId = platformOpts.testRunId || randomUUID();
+    this.testRunId = platformOpts.testRunId;
     this.lambdaRoleArn =
       platformConfig['lambda-role-arn'] || platformConfig['lambdaRoleArn'];
 

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/index.js
@@ -149,7 +149,11 @@ async function execArtillery(options) {
       SQS_QUEUE_URL: SQS_QUEUE_URL,
       SQS_REGION: SQS_REGION,
       ARTILLERY_DISABLE_ENSURE: 'true',
-      ARTILLERY_DISABLE_TELEMETRY: 'true'
+      ARTILLERY_DISABLE_TELEMETRY: 'true',
+      // Set test run ID for this Artillery process explicitly. This makes sure that $testId
+      // template variable is set to the same value for all Lambda workers as the one user
+      // sees on their terminal
+      ARTILLERY_TEST_RUN_ID: TEST_RUN_ID,
       // SHIP_LOGS: 'true',
     },
     ENV

--- a/packages/artillery/lib/platform/local/artillery-worker-local.js
+++ b/packages/artillery/lib/platform/local/artillery-worker-local.js
@@ -106,7 +106,7 @@ class ArtilleryWorker {
     const { script, payload, options } = opts;
     this.worker.postMessage({
       command: 'prepare',
-      opts: { script, payload, options }
+      opts: { script, payload, options, testRunId: global.artillery.testRunId }
     });
 
     await awaitOnEE(this.workerEvents, 'readyWaiting', 50);

--- a/packages/artillery/lib/platform/local/worker.js
+++ b/packages/artillery/lib/platform/local/worker.js
@@ -108,6 +108,8 @@ async function prepare(opts) {
   const { script: _script, payload, options } = opts;
   const script = loadProcessor(_script, options);
 
+  global.artillery.testRunId = opts.testRunId;
+
   //
   // load plugins
   //

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -100,6 +100,7 @@ async function resolveConfigTemplates(script, flags) {
 
   script.config = engineUtil.template(script.config, {
     vars: {
+      $testId: global.artillery.testRunId,
       $processEnvironment: process.env,
       $env: process.env,
       $environment: flags.environment,

--- a/packages/artillery/lib/util/generate-id.js
+++ b/packages/artillery/lib/util/generate-id.js
@@ -1,0 +1,9 @@
+const { customAlphabet } = require('nanoid');
+
+function generateId(prefix) {
+  const idf = customAlphabet('3456789abcdefghjkmnpqrtwxyz');
+  const testRunId = `${prefix}${idf(4)}_${idf(29)}_${idf(4)}`;  
+  return testRunId;
+}
+
+module.exports = generateId;

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -438,7 +438,8 @@ function createContext(script, contextVars, additionalProperties = {}) {
         target: script.config.target,
         $environment: script._environment,
         $processEnvironment: process.env, // TODO: deprecate
-        $env: process.env
+        $env: process.env,
+        $testId: global.artillery.testRunId,
       },
       contextVars || {}
     ),


### PR DESCRIPTION
This PR makes the test run ID of the current test run available as `$testId` template variable. The variable can be used in:

- `config` section as `{{ $testId }}`
- in scenarios as `{{ $testId }}`
- custom JS code as `vuContext.vars.$testId`

Works locally, and in cloud tests (AWS Lambda and AWS Fargate).