### PR TITLE
fix(publish-metrics): fix sleep init

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/util.js
+++ b/packages/artillery-plugin-publish-metrics/lib/util.js
@@ -6,13 +6,13 @@ module.exports = {
 
 const semver = require('semver');
 
-const sleep = async function (n) {
+async function sleep(n) {
   return new Promise((resolve, _reject) => {
     setTimeout(function () {
       resolve();
     }, n);
   });
-};
+}
 
 // TODO: Extract into a utility function in Artillery itself
 function versionCheck(range) {


### PR DESCRIPTION
Fixing `sleep` function definition. Follow up to #2498 