### PR TITLE
feat(publish-metrics): add test id to all traces and metrics

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
@@ -50,7 +50,10 @@ class OTelMetricsReporter {
       meterName: config.meterName || 'Artillery.io_metrics',
       includeOnly: config.includeOnly || [],
       exclude: config.exclude || [],
-      attributes: config.attributes || {}
+      attributes: {
+        ...(config.attributes || {}),
+        test_id: global.artillery.testRunId
+      }
     };
 
     this.meterProvider = new MeterProvider({

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -112,6 +112,7 @@ class OTelTraceBase {
           kind: SpanKind.CLIENT,
           attributes: {
             'vu.uuid': userContext.vars.$uuid,
+            test_id: userContext.vars.$testId,
             [SemanticAttributes.PEER_SERVICE]: this.config.serviceName
           }
         }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -68,6 +68,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
         kind: SpanKind.CLIENT,
         attributes: {
           'vu.uuid': userContext.vars.$uuid,
+          test_id: userContext.vars.$testId,
           [SemanticAttributes.HTTP_URL]: parsedUrl || url.href,
           // We set the port if it is specified, if not we set to a default port based on the protocol
           [SemanticAttributes.HTTP_SCHEME]:
@@ -121,7 +122,10 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
               .startSpan(name, {
                 kind: SpanKind.CLIENT,
                 startTime: res.timings[value.start],
-                attributes: { 'vu.uuid': userContext.vars.$uuid }
+                attributes: {
+                  'vu.uuid': userContext.vars.$uuid,
+                  test_id: userContext.vars.$testId
+                }
               })
               .end(res.timings[value.end]);
           }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -42,6 +42,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
       async (scenarioSpan) => {
         scenarioSpan.setAttributes({
           'vu.uuid': vuContext.vars.$uuid,
+          test_id: vuContext.vars.$testId,
           ...(this.config.attributes || {})
         });
         this.pendingPlaywrightScenarioSpans++;
@@ -115,6 +116,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             );
             pageSpan.setAttributes({
               'vu.uuid': vuContext.vars.$uuid,
+              test_id: vuContext.vars.$testId,
               ...(this.config.attributes || {})
             });
             lastPageUrl = pageUrl;
@@ -170,6 +172,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
         try {
           span.setAttributes({
             'vu.uuid': vuContext.vars.$uuid,
+            test_id: vuContext.vars.$testId,
             ...(this.config.attributes || {})
           });
 


### PR DESCRIPTION
# Description

Adding the `test_id` attribute to all traces and metrics exported via OTel reporter.

Note:
- Only added to the `opentelemetry` reporter as it is the simplest. Can add in other reporters in another PR

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?