### PR TITLE
feat(examples): add example for reusing pw typescript tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /packages/types
 /packages/artillery-engine-playwright/test/**/*.ts
+/examples/browser-playwright-reuse-typescript/**/*.ts

--- a/examples/browser-playwright-reuse-typescript/README.md
+++ b/examples/browser-playwright-reuse-typescript/README.md
@@ -4,7 +4,7 @@ This example shows you how you can reuse a pure Playwright codebase written in T
 
 The `e2e/` folder contains the Playwright test (`e2e/tests/get-issues.spec.ts`). The logic in that test has been abstracted to a helper in `e2e/helpers/index.ts`.
 
-The `performance` folder contains the Artillery/Playwright test. Using the same helper, we can construct an Artillery test by importing it in our processor file (`./performance/processor.ts`) and calling it as the `testFunction` in our test (`./performance/search-for-ts-doc.yml`).
+The `performance` folder contains the Artillery/Playwright test. Using the same helper, we can construct an Artillery test by importing it in our processor file (`./performance/processor.ts`) and calling it as the `testFunction` in our test (`./performance/search-for-ts-doc.yml`). The `target` used matches the `baseURL` from the playwright config in `e2e/playwright.config.ts`.
 
 ## Running the tests
 

--- a/examples/browser-playwright-reuse-typescript/README.md
+++ b/examples/browser-playwright-reuse-typescript/README.md
@@ -1,0 +1,25 @@
+# Reusing Typescript Playwright code as Artillery code
+
+This example shows you how you can reuse a pure Playwright codebase written in Typescript as Artillery tests.
+
+The `e2e/` folder contains the Playwright test (`e2e/tests/get-issues.spec.ts`). The logic in that test has been abstracted to a helper in `e2e/helpers/index.ts`.
+
+The `performance` folder contains the Artillery/Playwright test. Using the same helper, we can construct an Artillery test by importing it in our processor file (`./performance/processor.ts`) and calling it as the `testFunction` in our test (`./performance/search-for-ts-doc.yml`).
+
+## Running the tests
+
+To run the pure Playwright example:
+`cd e2e && npx playwright run`
+
+To run the same test as an Artillery test:
+`cd performance && npx artillery run search-for-ts-doc.yml`
+
+## Using a Page Object Model
+
+In this example we didn't use a [Page Object Model](https://playwright.dev/docs/pom). However, similar concepts can be applied. You can have a centralised Page Object Model with methods for most UI actions, or even specific user flows, and then just call those as appropriate in both Playwright and Artillery tests.
+
+## Playwright Version Compatibility
+
+It's important to note that Artillery uses specific versions of Playwright, which are listed in our [documentation](https://www.artillery.io/docs/reference/engines/playwright#playwright-compatibility).
+
+Your regular Playwright tests must use features that are compatible with the versions used by Artillery.

--- a/examples/browser-playwright-reuse-typescript/test/e2e/.gitignore
+++ b/examples/browser-playwright-reuse-typescript/test/e2e/.gitignore
@@ -1,0 +1,2 @@
+playwright-report/
+test-results/

--- a/examples/browser-playwright-reuse-typescript/test/e2e/helpers/index.ts
+++ b/examples/browser-playwright-reuse-typescript/test/e2e/helpers/index.ts
@@ -1,0 +1,29 @@
+import { Page, expect } from '@playwright/test';
+
+export const goToDocsAndSearch = async (page: Page, step) => {
+  await step('go_to_artillery_io', async () => {
+    await page.goto('/');
+  });
+
+  await step('go_to_docs', async () => {
+    await page
+      .getByLabel('Main navigation')
+      .getByRole('link', { name: 'Documentation' })
+      .click();
+    await expect(page).toHaveURL('/docs');
+    await expect(
+      page.getByText("What's different about Artillery?")
+    ).toBeVisible();
+  });
+
+  await step('search_for_ts_doc_and_goto', async () => {
+    await page
+      .getByRole('searchbox', { name: 'Search documentation…' })
+      .click();
+    await page.keyboard.type('typescript', { delay: 100 });
+    await page
+      .getByRole('link', { name: 'processor - custom JS code' })
+      .click();
+    await expect(page.getByText('processor - custom JS code')).toBeVisible();
+  });
+};

--- a/examples/browser-playwright-reuse-typescript/test/e2e/playwright.config.ts
+++ b/examples/browser-playwright-reuse-typescript/test/e2e/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  reporter: 'html',
+  use: {
+    baseURL: 'https://www.artillery.io/'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/examples/browser-playwright-reuse-typescript/test/e2e/tests/get-issues.spec.ts
+++ b/examples/browser-playwright-reuse-typescript/test/e2e/tests/get-issues.spec.ts
@@ -1,0 +1,6 @@
+import { goToDocsAndSearch } from '../helpers';
+import { test } from '@playwright/test';
+
+test('search and go to doc page', async ({ page }) => {
+  await goToDocsAndSearch(page, test);
+});

--- a/examples/browser-playwright-reuse-typescript/test/performance/processor.ts
+++ b/examples/browser-playwright-reuse-typescript/test/performance/processor.ts
@@ -1,0 +1,7 @@
+import { goToDocsAndSearch } from '../e2e/helpers';
+
+export async function playwrightTest(page, vuContext, events, test) {
+  const { step } = test;
+
+  await goToDocsAndSearch(page, step);
+}

--- a/examples/browser-playwright-reuse-typescript/test/performance/search-for-ts-doc.yml
+++ b/examples/browser-playwright-reuse-typescript/test/performance/search-for-ts-doc.yml
@@ -1,0 +1,13 @@
+config:
+  target: "https://www.artillery.io/"
+  phases:
+    - duration: 1
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: "./processor.ts"
+  engines:
+    playwright: {}
+
+scenarios:
+  - engine: playwright
+    testFunction: "playwrightTest"


### PR DESCRIPTION
## Description

Adds an example for reusing a Playwright+Typescript codebase as Artillery tests.

The example also makes use of target as `baseURL`.