### PR TITLE
fix(publish-metrics): route debug correctly for publish metrics reporters

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const vendorTranslators = require('./vendor-translators');
 const {
   diag,
@@ -47,11 +46,21 @@ class OTelReporter {
       // Setting traces to first traces configured
       if (translatedConfig.traces && !this.tracesConfig) {
         this.tracesConfig = translatedConfig.traces;
+
+        // Setting debug for traces
+        this.traceDebug = require('debug')(
+          `plugin:publish-metrics:${this.tracesConfig.type}`
+        );
       }
 
       // Setting metrics to first metrics configured
       if (translatedConfig.metrics && !this.metricsConfig) {
         this.metricsConfig = translatedConfig.metrics;
+
+        // Setting debug for metrics
+        this.metricDebug = require('debug')(
+          `plugin:publish-metrics:${this.metricsConfig.type}`
+        );
       }
       return translatedConfig;
     });
@@ -112,6 +121,14 @@ class OTelReporter {
       }
     }
   }
+  debug(msg) {
+    if (this.traceDebug) {
+      this.traceDebug(msg);
+    }
+    if (this.metricDebug) {
+      this.metricDebug(msg);
+    }
+  }
   warnIfDuplicateTracesConfigured(configList) {
     const tracesConfigs = configList.filter((config) => config.traces);
     if (tracesConfigs.length > 1) {
@@ -133,7 +150,7 @@ class OTelReporter {
   }
 
   async cleanup(done) {
-    debug('Cleaning up');
+    this.debug('Cleaning up');
     if (!this.metricsConfig && !this.tracesConfig) {
       return done();
     }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -24,7 +24,7 @@ context.setGlobalContextManager(contextManager);
 // DEBUGGING SETUP - setting the OpenTelemetry's internal diagnostic handler here to run when debug is enabled
 if (
   process.env.DEBUG &&
-  process.env.DEBUG === 'plugin:publish-metrics:open-telemetry'
+  process.env.DEBUG.includes('plugin:publish-metrics:')
 ) {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
 }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const {
   AggregationTemporality,
   MeterProvider,
@@ -45,6 +44,7 @@ class OTelMetricsReporter {
   }
 
   configure(config) {
+    this.debug = require('debug')(`plugin:publish-metrics:${this.config.type}`);
     this.config = {
       exporter: config.exporter || 'otlp-http',
       meterName: config.meterName || 'Artillery.io_metrics',
@@ -60,7 +60,7 @@ class OTelMetricsReporter {
       resource: this.resource
     });
 
-    debug('Configuring Metric Exporter');
+    this.debug('Configuring Metric Exporter');
 
     // Setting configuration options for exporter
     this.exporterOpts = {
@@ -163,13 +163,13 @@ class OTelMetricsReporter {
 
   async cleanup() {
     while (this.pendingRequests > 0) {
-      debug('Waiting for pending metric request ...');
+      this.debug('Waiting for pending metric request ...');
       await sleep(500);
     }
-    debug('Pending metric requests done');
-    debug('Shutting the Reader down');
+    this.debug('Pending metric requests done');
+    this.debug('Shutting the Reader down');
     await this.theReader.shutdown();
-    debug('Shut down sucessfull');
+    this.debug('Shut down sucessfull');
   }
 }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const { attachScenarioHooks } = require('../../util');
 const { OTelTraceBase } = require('./base');
 
@@ -155,7 +154,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
         this.pendingRequestSpans--;
       }
     } catch (err) {
-      debug(err);
+      this.debug(err);
     }
     return done();
   }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const debug = require('debug')('plugin:publish-metrics:open-telemetry');
 const { attachScenarioHooks } = require('../../util');
 const { OTelTraceBase } = require('./base');
 
@@ -183,7 +182,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             code: SpanStatusCode.ERROR,
             message: err.message
           });
-          debug('There has been an error during step execution:');
+          this.debug('There has been an error during step execution:');
           throw err;
         } finally {
           const difference = Date.now() - startTime;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/vendor-translators.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/vendor-translators.js
@@ -64,11 +64,14 @@ const vendorTranslators = {
     return otelTemplate(config, dynatraceTraceSettings);
   },
   'open-telemetry': (config) => {
-    let tracesConfig = config;
+    let newConfig = config;
     if (config.traces) {
-      tracesConfig.traces.type = 'otel';
+      newConfig.traces.type = 'open-telemetry';
     }
-    return tracesConfig;
+    if (config.metrics) {
+      newConfig.metrics.type = 'open-telemetry';
+    }
+    return newConfig;
   }
 };
 


### PR DESCRIPTION
# Description

When `DEBUG` is set to a vendor-specific reporter (from `publish-metrics`) if that reporter is using OTel in the background we want to log OTel reporters debug logs as well.

e.g. When user uses the Datadog reporter for tracing and sets `DEBUG=plugin:publish-metrics:datadog`, we want to log debug logs from OTel reporter as well as OTel is the one running the tracing.

## Implementation
- OpenTelemetry's internal diagnostic handler will run if `DEBUG` is set to any reporter, not just `open-telemetry`
- Artillery's `debug` will be dynamically set for metrics and traces, using the `type` property from config set to the reporters name.

In config translator functions `type` is set on both `traces` and `metrics` part of config so that classes responsible for metrics and traces can set the debug accordingly.  

## Testing
Tested manually, running multiple reporters and types of errors to trigger all debug logs and make sure the output is correct.

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?