### PR TITLE
fix(cli): remove cpu/memory flag defaults to fix launch-config override

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -99,13 +99,11 @@ RunCommand.flags = {
   }),
   cpu: Flags.string({
     description:
-      'Set task vCPU on Fargate. Value may be set as a number of vCPUs between 1-16 (e.g. 4), or as number of vCPU units (e.g. 4096)',
-    default: '4'
+      'Set task vCPU on Fargate (defaults to 4 vCPU). Value may be set as a number of vCPUs between 1-16 (e.g. 4), or as number of vCPU units (e.g. 4096).'
   }),
   memory: Flags.string({
     description:
-      'Set task memory on Fargate. Value may be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)',
-    default: '8'
+      'Set task memory on Fargate (defaults 8 GB). Value may be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)'
   }),
   packages: Flags.string({
     description:

--- a/packages/artillery/test/cloud-e2e/fargate/run-fargate.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/run-fargate.test.js
@@ -241,13 +241,31 @@ test('Run lots-of-output', async (t) => {
   t.match(output.stdout, /p99/i, 'a p99 value is reported');
 });
 
-test('Run memory hog', async (t) => {
+test('Fargate should exit with error code when workers run out of memory', async (t) => {
   try {
-    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags} --region us-east-1 --launch-config '{"cpu":"4096", "memory":"12288"}'`;
+    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:true --region us-east-1`;
   } catch (output) {
     t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
 
     t.match(output, /summary report/i, 'print summary report');
     t.match(output, /p99/i, 'a p99 value is reported');
   }
+});
+
+test('Fargate should not run out of memory when cpu and memory is increased via launch config', async (t) => {
+  const output =
+    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --launch-config '{"cpu":"4096", "memory":"12288"}'`;
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.match(output, /summary report/i, 'print summary report');
+  t.match(output, /p99/i, 'a p99 value is reported');
+});
+
+test('Fargate should not run out of memory when cpu and memory is increased via flags', async (t) => {
+  const output =
+    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --cpu 4 --memory 12`;
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.match(output, /summary report/i, 'print summary report');
+  t.match(output, /p99/i, 'a p99 value is reported');
 });


### PR DESCRIPTION
## Description

https://github.com/artilleryio/artillery/pull/2301 introduced a bug where `--launch-config` would no longer correctly set `memory` and `cpu`.

---

Funny enough, the `memory-hog` test (which was added later after that PR) was correctly catching this error, which is why it was failing - it had been wrongly modified to expect the non-zero code. #trustTheTests

I added some tests proving the fix and the feature work, leveraging the same `memory-hog` test.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
