### PR TITLE
ci(worker): fix broken ecs worker image version push

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -19,6 +19,9 @@ permissions:
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest
+    env:
+      # From PR's this is overridden by a head ref by the caller workflow. defaults to commit sha when not passed (e.g. workflow_dispatch or call from main branch)
+      WORKER_VERSION: ${{ inputs.ref || github.sha }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -27,9 +30,10 @@ jobs:
       
       - name: Show git ref
         run: |
-          echo ${{ github.ref }}
-          echo ${{ github.event.pull_request.head.sha }}
-          echo ${{ github.sha }}
+          echo GITHUB REF ${{ github.ref }}
+          echo GITHUB PR HEAD SHA ${{ github.event.pull_request.head.sha }}
+          echo GITHUB SHA ${{ github.sha }}
+          echo WORKER_VERSION ENV ${{ env.WORKER_VERSION }}
     
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -56,8 +60,8 @@ jobs:
 
       - name: Build the Docker image
         run: |
-          docker build . --build-arg="WORKER_VERSION=${{ github.sha }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ github.sha }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          docker build . --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
     
       - name: Push Docker image
         run: |
-          docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ github.sha }}
+          docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }}

--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -41,7 +41,7 @@ jobs:
   run-tests:
     if: contains( github.event.pull_request.labels.*.name, 'run-aws-tests' )
     needs: publish-branch-image
-    timeout-minutes: 40
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Description

I just noticed that all image versions generated by AWS tests seem to be pointing to the `main` branch ref 💀 (https://github.com/artilleryio/artillery/actions/workflows/run-aws-tests.yml). I actually believe it is currently overriding the latest image in main. So the tests run against the right version of the code (which is why they pass), but the main branch image version gets overridden each time.

Important to fix ASAP.

P.S. This hasn't affected any `production` CLI release versions - fortunately there were pushes between each release and the next commit that had `run-aws-tests` each time.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
