### PR TITLE
ci(tests): pass correct ECR_IMAGE_VERSION to aws tests

### DIFF
--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -46,6 +46,12 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      ECR_IMAGE_VERSION: ${{ github.event.pull_request.head.sha || github.sha }} # the image is published with the sha of the commmit in the branch
+      ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+      ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+      GITHUB_REPO: ${{ github.repository }}
+      GITHUB_ACTOR: ${{ github.actor }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -68,17 +74,7 @@ jobs:
       - run: npm run test:aws --workspace artillery
         env:
           FORCE_COLOR: 1
-          ECR_IMAGE_VERSION: ${{ github.sha }} # the image is published with the sha of the commit within this repo
-          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
-          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_ACTOR: ${{ github.actor }}
     
       - run: npm run test:aws --workspace artillery-engine-playwright
         env:
           FORCE_COLOR: 1
-          ECR_IMAGE_VERSION: ${{ github.sha }} # the image is published with the sha of the commit within this repo
-          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
-          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
-          GITHUB_REPO: ${{ github.repository }}
-          GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2527. Also need to update `ECR_IMAGE_VERSION` that is passed to the tests to the now correct value (branch `github.event.pull_request.head.sha`).

This is why AWS tests are [failing](https://github.com/artilleryio/artillery/actions/runs/8103062515/job/22146983419) in https://github.com/artilleryio/artillery/pull/2522

## Pre-merge checklist
- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No