### PR TITLE
ci(test): make datadog keys available to test runs

### DIFF
--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -50,6 +50,8 @@ jobs:
       ECR_IMAGE_VERSION: ${{ github.event.pull_request.head.sha || github.sha }} # the image is published with the sha of the commmit in the branch
       ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
       ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+      DD_TESTS_API_KEY: ${{ secrets.DD_TESTS_API_KEY }}
+      DD_TESTS_APP_KEY: ${{ secrets.DD_TESTS_APP_KEY }}
       GITHUB_REPO: ${{ github.repository }}
       GITHUB_ACTOR: ${{ github.actor }}
     steps:


### PR DESCRIPTION
## Description

Needed for https://github.com/artilleryio/artillery/pull/2481

Spoke with @bernardobridge and he mentioned these need to be in `main` before the workflow in my branch has access to it, as changes to this particular workflow won't be reflected unless in `main` first