### PR TITLE
feat: improve error handling & messages when recording to Artillery Cloud

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -150,7 +150,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
 
     const script = await prepareTestExecutionPlan(inputFiles, flags, args);
 
-    const runnerOpts = {
+    var runnerOpts = {
       environment: flags.environment,
       // This is used in the worker to resolve
       // the path to the processor module
@@ -197,7 +197,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       testRunId
     };
 
-    let launcher = await createLauncher(
+    var launcher = await createLauncher(
       script,
       script.config.payload,
       runnerOpts,
@@ -212,7 +212,7 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       metricsToSuppress
     });
 
-    let reporters = [consoleReporter];
+    var reporters = [consoleReporter];
     if (process.env.CUSTOM_REPORTERS) {
       const customReporterNames = process.env.CUSTOM_REPORTERS.split(',');
       customReporterNames.forEach(function (name) {
@@ -306,8 +306,8 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
 
     launcher.run();
 
-    let finalReport = {};
-    let shuttingDown = false;
+    var finalReport = {};
+    var shuttingDown = false;
     process.on('SIGINT', async () => {
       gracefulShutdown({ earlyStop: true });
     });
@@ -353,16 +353,23 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
       }
       await Promise.allSettled(ps2);
 
-      await telemetry.shutdown();
+      if (telemetry) {
+        await telemetry.shutdown();
+      }
 
-      await launcher.shutdown();
+      if (launcher) {
+        await launcher.shutdown();
+      }
+
       await (async function () {
-        for (const r of reporters) {
-          if (r.cleanup) {
-            try {
-              await p(r.cleanup.bind(r))();
-            } catch (cleanupErr) {
-              debug(cleanupErr);
+        if (reporters) {
+          for (const r of reporters) {
+            if (r.cleanup) {
+              try {
+                await p(r.cleanup.bind(r))();
+              } catch (cleanupErr) {
+                debug(cleanupErr);
+              }
             }
           }
         }

--- a/packages/artillery/test/cli/errors-and-warnings.test.js
+++ b/packages/artillery/test/cli/errors-and-warnings.test.js
@@ -55,6 +55,35 @@ tap.test('Suggest similar commands if unknown command is used', async (t) => {
   );
 });
 
+tap.test('Exit early if Artillery Cloud API is not valid', async (t) => {
+  const [exitCode, output] = await execute([
+    'run',
+    '--record',
+    '--key',
+    '123',
+    'test/scripts/gh_215_add_token.json'
+  ]);
+
+  t.equal(exitCode, 7);
+  t.ok(output.stderr.includes('API key is not recognized'));
+});
+
+tap.test(
+  'Exit early if Artillery Cloud API is not valid - on Fargate',
+  async (t) => {
+    const [exitCode, output] = await execute([
+      'run-fargate',
+      '--record',
+      '--key',
+      '123',
+      'test/scripts/gh_215_add_token.json'
+    ]);
+
+    t.equal(exitCode, 7);
+    t.ok(output.stderr.includes('API key is not recognized'));
+  }
+);
+
 /*
  @test "Running a script that uses XPath capture when libxmljs is not installed produces a warning" {
      if [[ ! -z `find . -name "artillery-xml-capture" -type d` ]]; then


### PR DESCRIPTION
This PR improves error handling & reporting when a test is recorded to Artillery Cloud.

The CLI will print more specific error messages when API key is not provided, or is invalid, and when Artillery Cloud can't be reached.

The CLI will stop the test run early now if the API key is missing or is invalid. 