### PR TITLE
fix(playwright): ensure engine knows when tracing is enabled

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -11,8 +11,7 @@ class PlaywrightEngine {
     this.launchOptions = this.config.launchOptions || {};
     this.contextOptions = this.config.contextOptions || {};
 
-    this.tracing = (script.config?.plugins?.['publish-metrics'] || []).some((config) => {
-      return (config.type === 'open-telemetry') && config.traces})
+    this.tracing = global.artillery.OTEL_TRACING_ENABLED || false;
 
     this.defaultNavigationTimeout =
       (parseInt(this.config.defaultNavigationTimeout, 10) || 30) * 1000;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -68,7 +68,9 @@ class OTelReporter {
     if (!this.metricsConfig && !this.tracesConfig) {
       return this;
     }
-
+    if (this.tracesConfig) {
+      global.artillery.OTEL_TRACING_ENABLED = true;
+    }
     // Warn if traces are configured in multiple reporters
     this.warnIfDuplicateTracesConfigured(this.translatedConfigsList);
 


### PR DESCRIPTION
## Description

Fix for #2529 

Before https://github.com/artilleryio/artillery/pull/2418, Playwright tracing only worked with OTeL, but now it can work with other reports that use OTeL behind the scenes.

We now check for a `OTEL_TRACING_ENABLED` variable set by the otel reporter instead, which should be in control of whether tracing is needed (which also reduces the coupling between the PW engine and publish-metrics).

## Testing

Tested locally and with Fargate. Automated tests for this as not very easy (as it depends on platform integrations), so can be added separately.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
