### PR TITLE
dep(playwright): update Playwright to v1.42.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4694,23 +4694,23 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.41.2.tgz",
-      "integrity": "sha512-vzobqNg2K6cJPyXCVaUxq8uDV54l3pEJvkO58XK0CBV2nl9IBySXvEqcgwsQc8PmQ930yVDrz0oCrMR6H/Qv3A==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.42.1.tgz",
+      "integrity": "sha512-A7pcZIZQIiiafO2UCR/OEdkvGM8Hr2gsjcK0cQ7WStF28HUpPBbJiwR9qmo+rjxaEaK7c9XD1qNXOng8Q+eI0Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.41.2"
+        "playwright-core": "1.42.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.2.tgz",
-      "integrity": "sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
       "dependencies": {
-        "playwright": "1.41.2"
+        "playwright": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15304,11 +15304,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.2.tgz",
-      "integrity": "sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
       "dependencies": {
-        "playwright-core": "1.41.2"
+        "playwright-core": "1.42.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15321,9 +15321,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.41.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.2.tgz",
-      "integrity": "sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -21625,10 +21625,10 @@
       "version": "1.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@playwright/browser-chromium": "1.41.2",
-        "@playwright/test": "1.41.2",
+        "@playwright/browser-chromium": "1.42.1",
+        "@playwright/test": "1.42.1",
         "debug": "^4.3.2",
-        "playwright": "1.41.2"
+        "playwright": "1.42.1"
       },
       "devDependencies": {
         "tap": "^16.3.10",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.41.2
+FROM mcr.microsoft.com/playwright:v1.42.1
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -11,10 +11,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@playwright/browser-chromium": "1.41.2",
-    "@playwright/test": "1.41.2",
+    "@playwright/browser-chromium": "1.42.1",
+    "@playwright/test": "1.42.1",
     "debug": "^4.3.2",
-    "playwright": "1.41.2"
+    "playwright": "1.42.1"
   },
   "devDependencies": {
     "tap": "^16.3.10",

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: Version we use here needs to be kept consistent with that in
 # artillery-engine-playwright.
 # ********************************
-FROM mcr.microsoft.com/playwright:v1.41.2
+FROM mcr.microsoft.com/playwright:v1.42.1
 LABEL maintainer="team@artillery.io"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

Updating to latest Playwright version. Includes [1.42.0](https://github.com/microsoft/playwright/releases/tag/v1.42.0) and [1.42.1](https://github.com/microsoft/playwright/releases/tag/v1.42.1)

Things that were updated and could break backward compatibility apply to `@playwright/test`. `1.42.1` also includes some fixes to things broken by `1.42.0`.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
