### PR TITLE
ci(test): add ability to parallelise aws tests

### DIFF
--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -95,6 +95,6 @@ jobs:
       - run: npm install
       - run: npm run build
       # runs the single test file from `package` workspace in the `file`, as defined in the matrix output
-      - run: npm run test:aws:parallel --workspace ${{fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].package }} -- --files ${{ fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].file }}
+      - run: npm run test:aws:ci --workspace ${{fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].package }} -- --files ${{ fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].file }}
         env:
           FORCE_COLOR: 1

--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -38,11 +38,32 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha || null }} # this should only be run with this ref if is-collaborator has been run and passed
 
+  generate-test-matrix:
+    runs-on: ubuntu-latest
+    needs: publish-branch-image
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || null }}
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - id: generate-matrix
+        run: |
+          RESULT=$(node .github/workflows/scripts/get-tests-in-package-location.js)
+          echo "matrix=$RESULT" >> $GITHUB_OUTPUT
+
   run-tests:
     if: contains( github.event.pull_request.labels.*.name, 'run-aws-tests' )
-    needs: publish-branch-image
+    needs: generate-test-matrix
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        testName: ${{fromJson(needs.generate-test-matrix.outputs.matrix).names}}
     permissions:
       contents: read
       id-token: write
@@ -73,10 +94,7 @@ jobs:
           node-version: 18.x
       - run: npm install
       - run: npm run build
-      - run: npm run test:aws --workspace artillery
-        env:
-          FORCE_COLOR: 1
-    
-      - run: npm run test:aws --workspace artillery-engine-playwright
+      # runs the single test file from `package` workspace in the `file`, as defined in the matrix output
+      - run: npm run test:aws:parallel --workspace ${{fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].package }} -- --files ${{ fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].file }}
         env:
           FORCE_COLOR: 1

--- a/.github/workflows/scripts/get-tests-in-package-location.js
+++ b/.github/workflows/scripts/get-tests-in-package-location.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * This script is used to discover all the tests in different test directories that match a specific suffix
+ * and generate a JSON file that can be used to run the tests in parallel leveraging Github Actions
+ */
+
+const testLocations = [
+  {
+    location: 'test/cloud-e2e/fargate',
+    package: 'artillery',
+    suffix: '.test.js'
+  },
+  {
+    location: 'test/cloud-e2e/lambda',
+    package: 'artillery',
+    suffix: '.test.js'
+  },
+  {
+    location: 'test',
+    package: 'artillery-engine-playwright',
+    suffix: '.aws.js'
+  }
+];
+
+const tests = {
+  names: [],
+  namesToFiles: {}
+};
+
+const addTest = (fileName, baseLocation, packageName, suffix) => {
+  if (!fileName.endsWith(suffix)) {
+    return;
+  }
+  const testName = fileName.replace(suffix, '');
+  const jobName = `${packageName}/${testName}`;
+  tests.names.push(jobName);
+  tests.namesToFiles[jobName] = {
+    file: `${baseLocation}/${fileName}`,
+    package: packageName
+  };
+};
+
+// Recursively scan a directory to find files, and add tests to the tests object
+function scanDirectory(location, baseLocation, packageName, suffix) {
+  fs.readdirSync(location).forEach((file) => {
+    const absolute = path.join(location, file);
+    if (fs.statSync(absolute).isDirectory()) {
+      scanDirectory(absolute, baseLocation, packageName, suffix);
+    } else {
+      addTest(file, baseLocation, packageName, suffix);
+    }
+  });
+}
+
+// Scan all the test locations
+for (const { package, location, suffix } of testLocations) {
+  const fullLocation = `packages/${package}/${location}`;
+  scanDirectory(fullLocation, location, package, suffix);
+}
+
+// Output the tests object as a JSON string to be used by Github Actions
+console.log(JSON.stringify(tests));

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap test/*.test.js --color --no-coverage --timeout 300",
-    "test:aws": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap test/*.aws.js --color --no-coverage --timeout 420"
+    "test:aws": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap test/*.aws.js --color --no-coverage --timeout 420",
+    "test:aws:parallel": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=420"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap test/*.test.js --color --no-coverage --timeout 300",
     "test:aws": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap test/*.aws.js --color --no-coverage --timeout 420",
-    "test:aws:parallel": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=420"
+    "test:aws:ci": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=420"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -48,7 +48,7 @@
     "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' &&  npm run test:unit && npm run test:acceptance",
     "test:windows": "set ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' & npm run test:unit && tap --no-coverage --timeout=420 --color test/cli/*.test.js",
     "test:aws": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=4200 test/cloud-e2e/**/*.test.js",
-    "test:aws:parallel": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=4200",
+    "test:aws:ci": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=4200",
     "test:aws:windows": "set ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' & tap --no-coverage --timeout=420 --color test/cloud-e2e/fargate/*.test.js --grep \"Run simple-bom\"",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "lint-fix": "npm run lint -- --fix"

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -48,6 +48,7 @@
     "test": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' &&  npm run test:unit && npm run test:acceptance",
     "test:windows": "set ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' & npm run test:unit && tap --no-coverage --timeout=420 --color test/cli/*.test.js",
     "test:aws": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=4200 test/cloud-e2e/**/*.test.js",
+    "test:aws:parallel": "export ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' && tap --no-coverage --color --timeout=4200",
     "test:aws:windows": "set ARTILLERY_TELEMETRY_DEFAULTS='{\"source\":\"test-suite\"}' & tap --no-coverage --timeout=420 --color test/cloud-e2e/fargate/*.test.js --grep \"Run simple-bom\"",
     "lint": "eslint --ext \".js,.ts,.tsx\" .",
     "lint-fix": "npm run lint -- --fix"


### PR DESCRIPTION
## Description

The current `run-aws-tests` runs take close to 40 minutes, and it will only grow. This PR adds the ability to parallelise that leveraging [Github Actions matrix jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), making each job run each test file in isolation. We use this rather than parallelising at test runner (tap) level to improve the readability and our ability to debug the output.

We accomplish this by:
- Adding the `.github/workflows/scripts/get-tests-in-package-location.js` script, where we specify a list of locations we wish to parallelise for this purpose, and it outputs the files that need to be parallelised.
- With the above setup, any new file added in a relevant location will automatically become parallelised (i.e. result in an additional job).

### Testing 
As the AWS workflow file uses `pull_request_target`, we are not able to prove this is working in the runs from this PR. Once this is merged, a new PR will be made to split the current `run-fargate` file into multiple test files, and at that point this will run.

However, I used this same code to alter the regular (non-aws) test runs in a branch as a POC. Here is a sample workflow run, showing 
how the output will look like:
https://github.com/artilleryio/artillery/actions/runs/8159150790

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
