### PR TITLE
ci(test): stop failing fast on matrix aws jobs

### DIFF
--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -62,6 +62,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         testName: ${{fromJson(needs.generate-test-matrix.outputs.matrix).names}}
     permissions:


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2544.

If one of the tests fail, it's still valuable to see whether others pass, rather than cancel them (especially now that they are running in parallel). 