### PR TITLE
feat(publish-metrics): implement tracing for the cloudwatch reporter

### DIFF
--- a/packages/artillery-plugin-publish-metrics/index.js
+++ b/packages/artillery-plugin-publish-metrics/index.js
@@ -17,7 +17,8 @@ const REPORTERS_USING_OTEL = [
   'honeycomb',
   'newrelic',
   'datadog',
-  'dynatrace'
+  'dynatrace',
+  'cloudwatch'
 ];
 module.exports = {
   Plugin,

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ADOTSupportedTraceReporters = ['datadog'];
+const ADOTSupportedTraceReporters = ['datadog', 'cloudwatch'];
 const ADOTSupportedMetricReporters = [];
 
 // Getting the relevant reporter configurations from full publish-metrics configuration
@@ -101,6 +101,26 @@ const vendorToCollectorConfigTranslators = {
       };
     }
     return collectorConfig;
+  },
+  cloudwatch: (config) => {
+    const collectorConfig = JSON.parse(JSON.stringify(collectorConfigTemplate));
+    if (config.traces) {
+      collectorConfig.processors['batch/trace'] = {
+        timeout: '2s',
+        send_batch_max_size: 1024,
+        send_batch_size: 200
+      };
+      collectorConfig.exporters['awsxray'] = {
+        region: config.region || 'us-east-1'
+      };
+
+      collectorConfig.service.pipelines.traces = {
+        receivers: ['otlp'],
+        processors: ['batch/trace'],
+        exporters: ['awsxray']
+      };
+    }
+    return collectorConfig;
   }
 };
 
@@ -110,11 +130,13 @@ function getADOTEnvVars(adotRelevantconfigs, dotenv) {
   const envVars = {};
   try {
     adotRelevantconfigs.forEach((config) => {
-      const vendorVars = vendorSpecificEnvVarsForCollector[config.type](
-        config,
-        dotenv
-      );
-      Object.assign(envVars, vendorVars);
+      if (vendorSpecificEnvVarsForCollector[config.type]) {
+        const vendorVars = vendorSpecificEnvVarsForCollector[config.type](
+          config,
+          dotenv
+        );
+        Object.assign(envVars, vendorVars);
+      }
     });
   } catch (err) {
     // We warn here instead of throwing because in the future we will support providing these variables through secrets

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
@@ -111,7 +111,8 @@ const vendorToCollectorConfigTranslators = {
         send_batch_size: 200
       };
       collectorConfig.exporters['awsxray'] = {
-        region: config.region || 'us-east-1'
+        region: config.region || 'us-east-1',
+        index_all_attributes: 'true'
       };
 
       collectorConfig.service.pipelines.traces = {

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
@@ -72,6 +72,13 @@ const vendorTranslators = {
       newConfig.metrics.type = 'open-telemetry';
     }
     return newConfig;
+  },
+  cloudwatch: (config) => {
+    const cloudwatchTraceSettings = {
+      type: 'cloudwatch',
+      attributes: config.traces?.annotations
+    };
+    return otelTemplate(config, cloudwatchTraceSettings);
   }
 };
 

--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -209,6 +209,11 @@ async function createWorkerRole(accountId) {
           `arn:aws:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}`,
           `arn:aws:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}/*`
         ]
+      },
+      {
+        Effect: 'Allow',
+        Action: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
+        Resource: ['*']
       }
     ]
   };

--- a/packages/artillery/test/cloud-e2e/fargate/adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/adot.test.js
@@ -9,7 +9,12 @@ const {
   getTestTags
 } = require('../../cli/_helpers.js');
 
-const { getDatadogSpans, getTestId } = require('./fixtures/adot/helpers.js');
+const {
+  getDatadogSpans,
+  getTestId,
+  getXRayTraces
+} = require('./fixtures/adot/helpers.js');
+const exp = require('constants');
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
 const baseTags = getTestTags(['type:acceptance']);
@@ -118,5 +123,110 @@ test('traces succesfully arrive to datadog', async (t) => {
     requestSpans[0]?.attributes?.custom[tag.key],
     tag.value,
     'Request span should have the correct tag value set from reporters config'
+  );
+});
+
+test('traces succesfully arrive to cloudwatch', async (t) => {
+  // Arrange:
+
+  const expectedTotalSpans = 28; // 4 VUs * (1 scenario root span + 3 pageSpans + 3 stepSpans )
+  const expectedVus = 4;
+  const expectedSpansPerVu = 7;
+  const expectedStepSpansPerVu = 3;
+  const expectedPageSpansPerVu = 3;
+  const annotation = { testType: 'e2e' };
+  const scenarioName = 'adot-e2e';
+  const expectedVusFailed = 0;
+
+  // Act:
+  const output =
+    await $`artillery run-fargate ${__dirname}/fixtures/adot/adot-cloudwatch.yml --record --tags ${baseTags} --output ${reportFilePath}`;
+
+  const testId = getTestId(output.stdout);
+  const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  let traceMap;
+  try {
+    traceMap = await getXRayTraces(testId);
+  } catch (err) {
+    t.fail('Error getting spans from Cloudwatch: ' + err);
+  }
+
+  const fullSpanObjects = [];
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.equal(
+    traceMap.reduce((acc, trace) => acc + trace.length, 0),
+    expectedTotalSpans,
+    'Total num of spans in AWS XRay should match expected Total Spans'
+  );
+  t.equal(
+    traceMap.length,
+    report.aggregate.counters['vusers.created'],
+    'Num of traces arrived to AWS XRay should match num of vusers created in report'
+  );
+  t.equal(
+    report.aggregate.counters['vusers.created'],
+    expectedVus,
+    `${expectedVus} VUs should have been created`
+  );
+
+  traceMap.forEach((trace) => {
+    fullSpanObjects.push(trace.filter((span) => span.name === scenarioName)[0]);
+    fullSpanObjects.concat(
+      trace.filter((span) => span.name === scenarioName)[0]?.subsegments
+    );
+    t.equal(
+      trace.length,
+      expectedSpansPerVu,
+      `Each trace should have ${expectedSpansPerVu} spans total`
+    );
+    t.equal(
+      trace.filter((span) => span.name === scenarioName).length,
+      1,
+      'Each trace should have one scenario span'
+    );
+    t.equal(
+      trace.filter((span) => span.name.includes('Page: ')).length,
+      expectedPageSpansPerVu,
+      'Each trace should have 3 page spans'
+    );
+    t.equal(
+      trace.filter((span) => !span.name.includes('Page: ')).length - 1,
+      expectedStepSpansPerVu,
+      'Each trace should have 3 step spans'
+    );
+    t.equal(
+      trace.filter((span) => !!span.error).length,
+      expectedVusFailed,
+      'Each trace should have 0 failed VUs'
+    );
+    t.equal(
+      trace.filter((span) => span.parent_id).length,
+      trace.filter((span) => span.name === scenarioName)[0]?.subsegments
+        ?.length,
+      'All page and step spans should be nested under scenario span'
+    );
+  });
+
+  t.ok(
+    fullSpanObjects.every(
+      (span) => span?.annotations?.testType === annotation.testType
+    ),
+    'All spans should have the correct annotation set from test script'
+  );
+  t.ok(
+    fullSpanObjects.every((span) => span?.annotations?.test_id === testId),
+    'All spans should have the correct test id annotation set'
+  );
+  t.equal(
+    report.aggregate.counters['vusers.failed'],
+    expectedVusFailed,
+    'Should have 0 failed VUs'
+  );
+  t.equal(
+    traceMap.filter((trace) => trace.some((span) => !!span.error)).length,
+    report.aggregate.counters['vusers.failed'],
+    'Num of traces with error should match failed VUs in report'
   );
 });

--- a/packages/artillery/test/cloud-e2e/fargate/cw-adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/cw-adot.test.js
@@ -9,14 +9,9 @@ const {
   getTestTags
 } = require('../../cli/_helpers.js');
 
-const {
-  getDatadogSpans,
-  getTestId,
-  getXRayTraces
-} = require('./fixtures/adot/helpers.js');
-const exp = require('constants');
+const { getTestId, getXRayTraces } = require('./fixtures/adot/helpers.js');
 
-//NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
+// NOTE: This test reports to Artillery Dashboard to dogfood and improve visibility
 const baseTags = getTestTags(['type:acceptance']);
 
 let reportFilePath;
@@ -28,107 +23,8 @@ afterEach(async (t) => {
   deleteFile(reportFilePath);
 });
 
-test('traces succesfully arrive to datadog', async (t) => {
-  // Arrange:
-  const apiKey = process.env.DD_TESTS_API_KEY;
-  const appKey = process.env.DD_TESTS_APP_KEY;
-
-  if (!apiKey || !appKey) {
-    // Skipping test in case of running locally without DD keys
-    t.skip('Skipping test, missing Datadog API key or App key');
-  }
-
-  /// Expected values
-  const expectedTotalSpans = 52; // 4 VUs * (1 scenario root span + 2 requests + 10 timing zone spans (5 per request))
-  const expectedVus = 4;
-  const expectedRequests = 8;
-  const expectedStatusCode200 = 8;
-  const expectedVusFailed = 0;
-  const tag = { key: 'testType', value: 'e2e' };
-
-  // Act:
-  const output =
-    await $`artillery run-fargate ${__dirname}/fixtures/adot/adot-dd-pass.yml --record --tags ${baseTags} --output ${reportFilePath}`;
-
-  const testId = getTestId(output.stdout);
-  const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
-
-  let spanList;
-  try {
-    spanList = await getDatadogSpans(
-      apiKey,
-      appKey,
-      testId,
-      expectedTotalSpans
-    );
-  } catch (err) {
-    t.fail('Error getting spans from Datadog: ' + err);
-  }
-
-  const vuSpans = spanList.filter((span) => span.attributes.parent_id === '0');
-  const requestSpans = spanList.filter(
-    (span) => span?.attributes?.resource_name === ('GET' || 'POST')
-  );
-
-  // Assert
-  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
-  t.equal(
-    spanList.length,
-    expectedTotalSpans,
-    `${expectedTotalSpans} spans in total should have arrived to Datadog`
-  );
-  t.equal(
-    report.aggregate.counters['vusers.created'],
-    expectedVus,
-    `${expectedVus} VUs should have been created`
-  );
-  t.equal(
-    vuSpans.length,
-    report.aggregate.counters['vusers.created'],
-    'Num of traces (root spans) in Datadog should match num of vusers created in report'
-  );
-  t.equal(
-    requestSpans.length,
-    expectedRequests,
-    `${expectedRequests} request spans should have arrived to Datadog`
-  );
-  t.equal(
-    report.aggregate.counters['http.codes.200'],
-    expectedStatusCode200,
-    `Should have ${expectedStatusCode200} "200 OK" responses`
-  );
-  t.equal(
-    requestSpans.filter(
-      (span) => span?.attributes?.custom?.http?.status_code === '200'
-    ).length,
-    report.aggregate.counters['http.codes.200'],
-    'Num of request spans with status_code 200 in Datadog should match num of 200 OK responses in report'
-  );
-  t.equal(
-    report.aggregate.counters['vusers.failed'],
-    expectedVusFailed,
-    `Should have ${expectedVusFailed} failed VUs`
-  );
-  t.equal(
-    vuSpans.filter((span) => span.attributes.custom.error).length,
-    expectedVusFailed,
-    'Num of traces with error should match failed VUs in report'
-  );
-  t.hasProp(
-    requestSpans[0]?.attributes?.custom,
-    tag.key,
-    'Request span should have the correct tag set from reporters config'
-  );
-  t.equal(
-    requestSpans[0]?.attributes?.custom[tag.key],
-    tag.value,
-    'Request span should have the correct tag value set from reporters config'
-  );
-});
-
 test('traces succesfully arrive to cloudwatch', async (t) => {
   // Arrange:
-
   const expectedTotalSpans = 28; // 4 VUs * (1 scenario root span + 3 pageSpans + 3 stepSpans )
   const expectedVus = 4;
   const expectedSpansPerVu = 7;
@@ -147,7 +43,7 @@ test('traces succesfully arrive to cloudwatch', async (t) => {
 
   let traceMap;
   try {
-    traceMap = await getXRayTraces(testId);
+    traceMap = await getXRayTraces(testId, expectedVus);
   } catch (err) {
     t.fail('Error getting spans from Cloudwatch: ' + err);
   }

--- a/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { test, afterEach, beforeEach } = require('tap');
+const { $ } = require('zx');
+const fs = require('fs');
+const {
+  generateTmpReportPath,
+  deleteFile,
+  getTestTags
+} = require('../../cli/_helpers.js');
+
+const { getDatadogSpans, getTestId } = require('./fixtures/adot/helpers.js');
+
+//NOTE: This test reports to Artillery Dashboard to dogfood and improve visibility
+const baseTags = getTestTags(['type:acceptance']);
+
+let reportFilePath;
+beforeEach(async (t) => {
+  reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+afterEach(async (t) => {
+  deleteFile(reportFilePath);
+});
+
+test('traces succesfully arrive to datadog', async (t) => {
+  // Arrange:
+  const apiKey = process.env.DD_TESTS_API_KEY;
+  const appKey = process.env.DD_TESTS_APP_KEY;
+
+  if (!apiKey || !appKey) {
+    // Skipping test in case of running locally without DD keys
+    t.skip('Skipping test, missing Datadog API key or App key');
+  }
+
+  /// Expected values
+  const expectedTotalSpans = 52; // 4 VUs * (1 scenario root span + 2 requests + 10 timing zone spans (5 per request))
+  const expectedVus = 4;
+  const expectedRequests = 8;
+  const expectedStatusCode200 = 8;
+  const expectedVusFailed = 0;
+  const tag = { key: 'testType', value: 'e2e' };
+
+  // Act:
+  const output =
+    await $`artillery run-fargate ${__dirname}/fixtures/adot/adot-dd-pass.yml --record --tags ${baseTags} --output ${reportFilePath}`;
+
+  const testId = getTestId(output.stdout);
+  const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  let spanList;
+  try {
+    spanList = await getDatadogSpans(
+      apiKey,
+      appKey,
+      testId,
+      expectedTotalSpans
+    );
+  } catch (err) {
+    t.fail('Error getting spans from Datadog: ' + err);
+  }
+
+  const vuSpans = spanList.filter((span) => span.attributes.parent_id === '0');
+  const requestSpans = spanList.filter(
+    (span) => span?.attributes?.resource_name === ('GET' || 'POST')
+  );
+
+  // Assert
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.equal(
+    spanList.length,
+    expectedTotalSpans,
+    `${expectedTotalSpans} spans in total should have arrived to Datadog`
+  );
+  t.equal(
+    report.aggregate.counters['vusers.created'],
+    expectedVus,
+    `${expectedVus} VUs should have been created`
+  );
+  t.equal(
+    vuSpans.length,
+    report.aggregate.counters['vusers.created'],
+    'Num of traces (root spans) in Datadog should match num of vusers created in report'
+  );
+  t.equal(
+    requestSpans.length,
+    expectedRequests,
+    `${expectedRequests} request spans should have arrived to Datadog`
+  );
+  t.equal(
+    report.aggregate.counters['http.codes.200'],
+    expectedStatusCode200,
+    `Should have ${expectedStatusCode200} "200 OK" responses`
+  );
+  t.equal(
+    requestSpans.filter(
+      (span) => span?.attributes?.custom?.http?.status_code === '200'
+    ).length,
+    report.aggregate.counters['http.codes.200'],
+    'Num of request spans with status_code 200 in Datadog should match num of 200 OK responses in report'
+  );
+  t.equal(
+    report.aggregate.counters['vusers.failed'],
+    expectedVusFailed,
+    `Should have ${expectedVusFailed} failed VUs`
+  );
+  t.equal(
+    vuSpans.filter((span) => span.attributes.custom.error).length,
+    expectedVusFailed,
+    'Num of traces with error should match failed VUs in report'
+  );
+  t.hasProp(
+    requestSpans[0]?.attributes?.custom,
+    tag.key,
+    'Request span should have the correct tag set from reporters config'
+  );
+  t.equal(
+    requestSpans[0]?.attributes?.custom[tag.key],
+    tag.value,
+    'Request span should have the correct tag value set from reporters config'
+  );
+});

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/adot-cloudwatch.yml
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/adot-cloudwatch.yml
@@ -1,0 +1,22 @@
+config:
+  target: "https://artillery.io"
+  phases:
+    - duration: 2
+      arrivalRate: 2
+      name: "Phase 1"
+  engines:
+    playwright: {}
+  processor: "./flow.js"
+  plugins:
+    publish-metrics:
+      - type: cloudwatch
+        traces:
+          serviceName: "Artillery-adot"
+          annotations: 
+            testType: e2e
+
+
+scenarios:
+  - engine: playwright
+    name: "adot-e2e"
+    flowFunction: "simpleCheck"

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
@@ -1,0 +1,28 @@
+async function simpleCheck(page, userContext, events, test) {
+  await test.step('Go to Artillery', async () => {
+    const requestPromise = page.waitForRequest('https://artillery.io/');
+    await page.goto('https://artillery.io/');
+    const req = await requestPromise;
+  });
+  await test.step('Go to cloud', async () => {
+    const cloud = await page
+      .getByLabel('Main navigation')
+      .getByRole('link', { name: 'Cloud' });
+    await cloud.click();
+    await page.waitForURL('https://www.artillery.io/cloud');
+  });
+
+  await test.step('Click on Join button', async () => {
+    await page
+      .getByRole('button', {
+        name: 'Join Artillery Cloud early access waitlist'
+      })
+      .click();
+
+    await page.waitForURL('https://www.artillery.io/cloud?tf=1');
+  });
+}
+
+module.exports = {
+  simpleCheck
+};

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -19,7 +19,21 @@ const CloudwatchReporterSchema = Joi.object({
     })
   ),
   includeOnly: Joi.array().items(Joi.string()),
-  excluded: Joi.array().items(Joi.string())
+  excluded: Joi.array().items(Joi.string()),
+  sendOnlyTraces: artilleryBooleanOrString,
+  traces: Joi.object({
+    serviceName: Joi.string(),
+    sampleRate: artilleryNumberOrString,
+    useRequestNames: artilleryBooleanOrString,
+    annotations: Joi.object().unknown(),
+    // smartSampling is still technically configured in the reporters so I am adding it here, even though there is an ongoing discussion to move this to the engine level.
+    smartSampling: Joi.object({
+      thresholds: Joi.object({
+        firstByte: artilleryNumberOrString,
+        total: artilleryNumberOrString
+      })
+    })
+  })
 })
   .unknown(false)
   .meta({ title: 'Cloudwatch Reporter' });


### PR DESCRIPTION
# Description

Implementing tracing support for the Cloudwatch reporter. The reporter will use OpenTelemetry reporter in the background for tracing, and traces will be exported to AWS X-Ray.

## Configuration
Cloudwatch agent (or ADOT) installation  is required for local runs, but for Fargate runs the ADOT sidecar will be dynamically configured to send traces to AWS X-Ray.

```yaml
  plugins:
    publish-metrics:
      - type: cloudwatch
        sendOnlyTraces: true
        traces: 
          sampleRate: 0.5
          useRequestNames: true
          annotations:
            tool: "artillery"
```
<img width="1136" alt="Screenshot 2024-02-08 at 16 25 56" src="https://github.com/artilleryio/artillery/assets/39635558/a1cfe7f6-dc06-4756-8023-4fe31dac6d54">

<img width="1452" alt="Screenshot 2024-02-08 at 17 11 09" src="https://github.com/artilleryio/artillery/assets/39635558/e2ec1b9c-cb40-4394-85ca-ea02c72dac12">

# Testing
Unit tests added on `publish-metrics` side and an e2e test added on the `cli` side

# Notes
- **Important:** Users that wish to use this feature with Fargate runs and had already ran Artillery tests on Fargate in the past will need to **delete the `'artilleryio-ecs-worker-role'` IAM role and the `'artilleryio-ecs-worker-policy'` IAM policy** from their account prior to running tests in order for this feature to work. This is needed because the role will have to be recreated with the necessary permissions to send traces to AWS X-Ray

- This is a new clean branch for #2487 


# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?
