### PR TITLE
fix(cli): add apdex to official plugins for telemetry

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -691,6 +691,7 @@ async function sendTelemetry(script, flags, extraProps) {
       properties.plugins = true;
       properties.officialPlugins = [];
       const OFFICIAL_PLUGINS = [
+        'apdex',
         'expect',
         'publish-metrics',
         'metrics-by-endpoint',


### PR DESCRIPTION
# Description

Adding `apdex` to the list of official plugins in `sendTelemetry` as it was missing.

# Pre-merge checklist

- [ ] Does this require an update to the docs? 
- [ ] Does this require a changelog entry? 