### PR TITLE
feat: add ability to track errors by URL with metrics-by-endpoint

### DIFF
--- a/packages/artillery-plugin-metrics-by-endpoint/index.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/index.js
@@ -53,10 +53,9 @@ function MetricsByEndpoint(script, events) {
   });
 }
 
-function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
-  const targetUrl =
-    userContext.vars.target && url.parse(userContext.vars.target);
-  const requestUrl = url.parse(req.url);
+function getReqName(target, originalRequestUrl, requestName) {
+  const targetUrl = target && url.parse(target);
+  const requestUrl = url.parse(originalRequestUrl);
 
   let baseUrl = '';
   if (
@@ -72,13 +71,18 @@ function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
   baseUrl += stripQueryString ? requestUrl.pathname : requestUrl.path;
 
   let reqName = '';
-  if (useOnlyRequestNames && req.name) {
-    reqName += req.name;
-  } else if (req.name) {
-    reqName += `${baseUrl} (${req.name})`;
+  if (useOnlyRequestNames && requestName) {
+    reqName += requestName;
+  } else if (requestName) {
+    reqName += `${baseUrl} (${requestName})`;
   } else if (!ignoreUnnamedRequests) {
     reqName += baseUrl;
   }
+
+  return reqName;
+}
+function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
+  const reqName = getReqName(userContext.vars.target, req.url, req.name);
 
   if (reqName === '') {
     return done();


### PR DESCRIPTION
Extend `metrics-by-endpoint` to track errors such as `ETIMEOUT` by request URL.

Example hello-world run:

![CleanShot 2024-03-13 at 15 02 51](https://github.com/artilleryio/artillery/assets/1490/e68a4231-f819-4a69-a1f1-e49434edef2d)
