### PR TITLE
fix(example): make custom plugin work when adding a processor

### DIFF
--- a/examples/artillery-plugin-hello-world/index.js
+++ b/examples/artillery-plugin-hello-world/index.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
-
 const debug = require('debug')('plugin:hello-world');
 
 module.exports.Plugin = ArtilleryHelloWorldPlugin;

--- a/examples/artillery-plugin-hello-world/test.yml
+++ b/examples/artillery-plugin-hello-world/test.yml
@@ -1,5 +1,5 @@
 config:
-  target: "https://artillery.io"
+  target: "http://asciiart.artillery.io:8080"
   phases:
     - arrivalRate: 1
       duration: 10


### PR DESCRIPTION
## Description

This was happening due to the usage of `strict`, which would run into this [`TypeError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_assign_to_property). 

Solution was either to remove `strict` or change the processor line to something like
```js
script.config.processor = script.config.processor ? new String(script.config.processor) : {};
```

To prevent additional overhead for those writing a plugin, went with removing strict.