### PR TITLE
fix(cli): log duration with time units when specified

### DIFF
--- a/packages/artillery/lib/console-reporter.js
+++ b/packages/artillery/lib/console-reporter.js
@@ -78,12 +78,16 @@ ConsoleReporter.prototype.phaseStarted = function phaseStarted(phase) {
     return this;
   }
 
+  const phaseDuration = phase.duration || phase.pause;
+  //only append s when phaseDuration is a number or number-like string (like from env variables). otherwise it's a converted unit (e.g. 5min)
+  const durationString = Number.isInteger(_.toNumber(phaseDuration)) ? `${phaseDuration}s` : `${phaseDuration}`;
+
   artillery.log(
     `Phase started: ${chalk.green(
       phase.name ? phase.name : 'unnamed'
     )} (index: ${phase.index}, duration: ${
-      phase.duration || phase.pause
-    }s) ${formatTimestamp(new Date())}\n`
+      durationString
+    }) ${formatTimestamp(new Date())}\n`
   );
 };
 
@@ -92,12 +96,16 @@ ConsoleReporter.prototype.phaseCompleted = function phaseCompleted(phase) {
     return this;
   }
 
+  const phaseDuration = phase.duration || phase.pause;
+  //only append s when phaseDuration is a number or number-like string (like from env variables). otherwise it's a converted unit (e.g. 5min)
+  const durationString = Number.isInteger(_.toNumber(phaseDuration)) ? `${phaseDuration}s` : `${phaseDuration}`;
+
   artillery.log(
     `Phase completed: ${chalk.green(
       phase.name ? phase.name : 'unnamed'
     )} (index: ${phase.index}, duration: ${
-      phase.duration || phase.pause
-    }s) ${formatTimestamp(new Date())}\n`
+      durationString
+    }) ${formatTimestamp(new Date())}\n`
   );
 
   return this;


### PR DESCRIPTION
## Description

I had tested this when implementing https://github.com/artilleryio/artillery/pull/2084, but with `1min`, so didn't notice that it appended the `s` at the end (`1mins`).

Fixed now to account for all cases.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
