### PR TITLE
fix: load values from a dotenv file earlier

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -11,6 +11,9 @@ const { supportedRegions } = require('../platform/aws-ecs/legacy/util');
 const PlatformECS = require('../platform/aws-ecs/ecs');
 const { ECS_WORKER_ROLE_NAME } = require('../platform/aws/constants');
 const { Plugin: CloudPlugin } = require('../platform/cloud/cloud');
+const dotenv = require('dotenv');
+const path = require('path');
+const fs = require('fs');
 class RunCommand extends Command {
   static aliases = ['run:fargate'];
   // Enable multiple args:
@@ -21,6 +24,16 @@ class RunCommand extends Command {
     flags['platform-opt'] = [`region=${flags.region}`];
 
     flags.platform = 'aws:ecs';
+
+    if (flags.dotenv) {
+      const dotEnvPath = path.resolve(process.cwd(), flags.dotenv);
+      try {
+        fs.statSync(dotEnvPath);
+      } catch (err) {
+        console.log(`WARNING: could not read dotenv file: ${flags.dotenv}`);
+      }
+      dotenv.config({ path: dotEnvPath });
+    }
 
     const cloud = new CloudPlugin(null, null, { flags });
     if (cloud.enabled) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -231,8 +231,6 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
 
   if (options.dotenv) {
     const dotEnvPath = path.resolve(process.cwd(), options.dotenv);
-    dotenv.config({ path: dotEnvPath });
-
     const contents = fs.readFileSync(dotEnvPath);
     context.dotenv = dotenv.parse(contents);
   }


### PR DESCRIPTION
Make values available as early as possible for any code that may need them.

Fixes #2582