### PR TITLE
fix(schema): make flow not required for now

### DIFF
--- a/packages/types/schema/scenario.js
+++ b/packages/types/schema/scenario.js
@@ -109,13 +109,10 @@ const ScenarioSchema = Joi.object({
     }
   );
 
-// TODO: PR in joi-to-json repo for converting deprecated and default
-//TODO: missing some descriptions (ws and socketio)
-
+//TODO: implement full schema consistent with scenario - right now it's Joi.any() on items
 const BeforeAfterSchema = Joi.object({
   flow: Joi.array()
     .items(Joi.any())
-    .required()
     .meta({ title: 'Flow object' })
     .description(
       'https://www.artillery.io/docs/reference/test-script#before-and-after-sections'


### PR DESCRIPTION
## Description

Currently, `before` with `engine: playwright` is showing as red in the VS Code Extension. As `before` is not properly typed yet, I'll temporarily remove the `required` field for `flow`. 

Long term, we will look to consolidate the `scenarios` and `before/after` section into something reusable, so that `before/after` can be properly typed.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Not right now, but we should find a more consistent way to update these