### PR TITLE
feat(publish-metrics): record the number of spans sent 

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -135,6 +135,7 @@ class OTelTraceBase {
       if (!span.endTime[0]) {
         span.end(Date.now());
         this.pendingScenarioSpans--;
+        ee.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
       }
       if (engine === 'http') {
         next();
@@ -148,6 +149,7 @@ class OTelTraceBase {
   otelTraceOnError(scenarioErr, req, userContext, ee, done) {
     done();
   }
+
   async waitOnPendingSpans(pendingRequests, pendingScenarios, maxWaitTime) {
     let waitedTime = 0;
     while (
@@ -176,7 +178,6 @@ class OTelTraceBase {
         5000
       );
     }
-
     this.debug('Pending traces done');
   }
 }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -127,6 +127,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
                 }
               })
               .end(res.timings[value.end]);
+            events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
           }
         }
       });
@@ -152,6 +153,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
       if (!span.endTime[0]) {
         span.end(endTime || Date.now());
         this.pendingRequestSpans--;
+        events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
       }
     } catch (err) {
       this.debug(err);
@@ -159,7 +161,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
     return done();
   }
 
-  otelTraceOnError(err, req, userContext, ee, done) {
+  otelTraceOnError(err, req, userContext, events, done) {
     const scenarioSpan = userContext.vars.__httpScenarioSpan;
     const requestSpan = userContext.vars.__otlpHTTPRequestSpan;
     // If the error happened outside the request, the request span will be handled in the afterResponse hook
@@ -180,6 +182,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
 
       requestSpan.end();
       this.pendingRequestSpans--;
+      events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
     } else {
       scenarioSpan.recordException(err);
     }
@@ -198,6 +201,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
 
     scenarioSpan.end();
     this.pendingScenarioSpans--;
+    events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
     return done();
   }
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -106,6 +106,11 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             if (pageSpan) {
               pageSpan.end();
               this.pendingPlaywrightSpans--;
+              events.emit(
+                'counter',
+                'plugins.publish-metrics.spans.exported',
+                1
+              );
             }
 
             pageSpan = this.playwrightTracer.startSpan(
@@ -148,9 +153,11 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
           if (pageSpan && !pageSpan.endTime[0]) {
             pageSpan.end();
             this.pendingPlaywrightSpans--;
+            events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
           }
           scenarioSpan.end();
           this.pendingPlaywrightScenarioSpans--;
+          events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
         }
       }
     );
@@ -189,6 +196,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
           events.emit('histogram', `browser.step.${stepName}`, difference);
           span.end();
           this.pendingPlaywrightSpans--;
+          events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
         }
       });
     };

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -592,6 +592,11 @@ async function readPayload(script) {
 }
 
 async function sendTelemetry(script, flags, extraProps) {
+  if (process.env.WORKER_ID) {
+    debug('Telemetry: Running in cloud worker, skipping test run event');
+    return;
+  }
+
   function hash(str) {
     return crypto.createHash('sha1').update(str).digest('base64');
   }

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -64,8 +64,6 @@ progress "Worker starting up, ID = $worker_id, version = ${WORKER_VERSION:-unkno
 
 declare -r DEPENDENCIES=(jq aws pwgen node npm yarn)
 
-export ARTILLERY_DISABLE_TELEMETRY=true
-
 send_message () {
     set +e
     set +o pipefail

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/index.js
@@ -149,7 +149,6 @@ async function execArtillery(options) {
       SQS_QUEUE_URL: SQS_QUEUE_URL,
       SQS_REGION: SQS_REGION,
       ARTILLERY_DISABLE_ENSURE: 'true',
-      ARTILLERY_DISABLE_TELEMETRY: 'true',
       // Set test run ID for this Artillery process explicitly. This makes sure that $testId
       // template variable is set to the same value for all Lambda workers as the one user
       // sees on their terminal


### PR DESCRIPTION
# Description

### 1. Count and record the number or spans sent (exported) via OTel reporter.

- The spans are counted with the custom `counter` event, and will show in the console reports as well as the final report under `plugin.publish-metrics.spansExported` metric name
- On `done` event span count and the destination (observability platform that spans are exported to) are sent to Posthog as an event called `otel-span-count` with `spansExported` and `destination` properties and will be aggregated on Posthog
- The destination will be either:
    -  reporter `type` if vendor specific reporters are used, 
    - a destination recognised from the `endpoint` (as one of `lightstep`, `honeycomb`, `new-relic`, `dynatrace` or `grafana`) if configured through the OTel reporter
    - `custom` if configured through the OTel reporter but not recognisable from the `endpoint` 
  
### 2. Telemetry is not disabled via env var for Fargate and Lambda , instead a more granular way of filtering events has been introduced:
Since we need telemetry to be enabled in Fargate in order to send span count from workers, (and other events might need to be sent from cloud workers in the future), it was decided that:
-  Instead of disabling telemetry via environment variable for all Fargate/Lambda, the functions handling each individual telemetry event will check requirements for capturing that particular event themselves
- `ARTILLERY_DISABLE_TELEMETRY` should be set only by user when they explicitly want to disable telemetry. 
To implement this change:
  - `ARTILLERY_DISABLE_TELEMETRY=true` is removed from  Fargate and Lambda environment, 
  - the `sendTelemetry` function that manages the `run test` Posthog event will check whether it's running in cloud worker before capturing the event.


## Testing
Manually tested:
- `otel-span-count` event shows up on Posthog with correct data when tracing is configured (locally and on Fargate runs)
- `otel-span-count` event is not sent to Posthog if `ARTILLERY_DISABLE_TELEMETRY` is set by user
- `run test` event is not sent to Posthog when running in cloud worker but sent otherwise

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?
