### PR TITLE
fix(publish-metrics): fix sampling and response related issues

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/base.js
@@ -119,8 +119,13 @@ class OTelTraceBase {
         }
       );
 
-      userContext.vars[`__${engine}ScenarioSpan`] = span;
-      this.pendingScenarioSpans++;
+      if (span.isRecording()) {
+        userContext.vars[`__${engine}ScenarioSpan`] = span;
+        this.pendingScenarioSpans++;
+      } else {
+        span.end();
+      }
+
       if (engine === 'http') {
         next();
       } else {
@@ -132,7 +137,7 @@ class OTelTraceBase {
   endScenarioSpan(engine) {
     return function (userContext, ee, next) {
       const span = userContext.vars[`__${engine}ScenarioSpan`];
-      if (!span.endTime[0]) {
+      if (span && !span.endTime[0]) {
         span.end(Date.now());
         this.pendingScenarioSpans--;
       }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -140,19 +140,26 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
     try {
       span.setAttributes({
         [SemanticAttributes.HTTP_STATUS_CODE]: res.statusCode,
-        [SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH]:
-          res.request.options.headers['content-length'],
         [SemanticAttributes.HTTP_FLAVOR]: res.httpVersion,
-        [SemanticAttributes.HTTP_USER_AGENT]:
-          res.request.options.headers['user-agent']
+        [SemanticAttributes.HTTP_USER_AGENT]: req.headers['user-agent']
       });
-
+      if (res.headers['content-length']) {
+        span.setAttribute(
+          SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
+          res.headers['content-length']
+        );
+      }
       if (res.statusCode >= this.statusAsErrorThreshold) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
           message: res.statusMessage
         });
       }
+    } catch (err) {
+      this.debug(err);
+    }
+
+    try {
       if (!span.endTime[0]) {
         span.end(endTime || Date.now());
         this.pendingRequestSpans--;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -39,6 +39,10 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
       specName || 'Scenario execution',
       { kind: SpanKind.CLIENT },
       async (scenarioSpan) => {
+        if (!scenarioSpan.isRecording()) {
+          scenarioSpan.end();
+          return;
+        }
         scenarioSpan.setAttributes({
           'vu.uuid': vuContext.vars.$uuid,
           test_id: vuContext.vars.$testId,

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
@@ -81,7 +81,7 @@ const otelTemplate = function (config, vendorSpecificSettings) {
     otelConfig.serviceName = config.traces.serviceName || config.serviceName;
     otelConfig.traces = Object.assign(
       {
-        sampleRate: 1,
+        sampleRate: config.traces.sampleRate,
         useRequestNames: config.traces.useRequestNames,
         attributes: config.traces.attributes,
         smartSampling: config.traces.smartSampling


### PR DESCRIPTION
# Description
A fix for https://github.com/artilleryio/artillery/issues/2572 
There were two isolated bugs in the reported issue, both of which are resolved in this PR:
1. Non recording spans do not have `endTime` property and were causing `errors.Cannot read properties of undefined (reading '0')` error.
  -  **Solution:**
     - Non recording root spans are screened for at creation and are ended immediately. 
     - They are not set on the VU context in the first place so will not be propagated.
     - All hooks will return early if span is not present on VU context

2.  Request headers were being accessed in a way that does not work with Stream response format.
  - **Solution:**
     - `user-agent` header value is now accessed from `req` object as it will be present there
     - We look for the `content-length` header in the `res.headers` and set it as an attribute only if present.
     - Additionally setting attributes on spans is now wrapped in a separate `try/catch` block so that if there is error in setting attributes it does not interrupt the tracing flow and the spans are properly closed
 
## Testing
Tested manually with multiple response types and `sampleRate` settings.

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?