### PR TITLE
feat: initial Playwright tracing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5844,7 +5844,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -6401,7 +6400,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11463,7 +11461,6 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -16067,7 +16064,6 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -21541,6 +21537,7 @@
         "async": "^2.6.4",
         "aws-sdk": "^2.1338.0",
         "chalk": "^2.4.2",
+        "chokidar": "^3.6.0",
         "ci-info": "^3.8.0",
         "cli-table3": "^0.6.0",
         "cross-spawn": "^7.0.3",
@@ -22664,6 +22661,29 @@
         "node": ">=4"
       }
     },
+    "packages/artillery/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "packages/artillery/node_modules/cli-table3": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
@@ -22700,6 +22720,17 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "packages/artillery/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "packages/artillery/node_modules/is-builtin-module": {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -235,6 +235,17 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     context.dotenv = dotenv.parse(contents);
   }
 
+  // Explicitly make ARTILLERY_CLOUD_API_KEY available to workers (if set)
+  // Relying on the fact that contents of context.dotenv gets passed onto workers
+  // for it
+  if (process.env.ARTILLERY_CLOUD_API_KEY) {
+    if (!context.dotenv) {
+      context.dotenv = {};
+    }
+    context.dotenv.ARTILLERY_CLOUD_API_KEY =
+      process.env.ARTILLERY_CLOUD_API_KEY;
+  }
+
   if (options.bundle) {
     context.namedTest = true;
   }

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -43,6 +43,10 @@ class ArtilleryCloudPlugin {
 
     let testEndInfo = {};
 
+    // This value is available in cloud workers only. With interactive use, it'll be set
+    // in the test:init event handler.
+    this.testRunId = process.env.ARTILLERY_TEST_RUN_ID;
+
     if (isInteractiveUse) {
       global.artillery.globalEvents.on('test:init', async (testInfo) => {
         debug('test:init', testInfo);

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -105,6 +105,7 @@
     "async": "^2.6.4",
     "aws-sdk": "^2.1338.0",
     "chalk": "^2.4.2",
+    "chokidar": "^3.6.0",
     "ci-info": "^3.8.0",
     "cli-table3": "^0.6.0",
     "cross-spawn": "^7.0.3",


### PR DESCRIPTION
This PR adds the following:

* Capture Playwright traces for failing VUs and store them on the filesystem (locally or in Fargate workers)
* Upload them to Artillery Cloud (an account with an API key is required)

This is early experimental support for it and not something ready for production use yet.