### PR TITLE
fix(cli): set ip override to truthy value

### DIFF
--- a/packages/artillery/lib/telemetry.js
+++ b/packages/artillery/lib/telemetry.js
@@ -52,7 +52,10 @@ const init = () => {
       if (telemetryDisabled) {
         eventPayload = {
           event,
-          distinctId: 'artillery-core'
+          distinctId: 'artillery-core',
+          properties: {
+            $ip: 'not-collected'
+          }
         };
       } else {
         eventPayload = {
@@ -63,7 +66,7 @@ const init = () => {
             version: artilleryVersion,
             os: process.platform,
             isCi: isCI,
-            $ip: null
+            $ip: 'not-collected'
           }
         };
 

--- a/packages/artillery/test/lib/test_telemetry.js
+++ b/packages/artillery/test/lib/test_telemetry.js
@@ -49,7 +49,7 @@ test('Telemetry', function (t) {
       version: artilleryVersion,
       os: process.platform,
       isCi: ci.isCI,
-      $ip: null,
+      $ip: 'not-collected',
       source: 'test-suite'
     }
   };
@@ -83,7 +83,7 @@ test('Telemetry with defaults env var', function (t) {
       version: artilleryVersion,
       os: process.platform,
       isCi: ci.isCI,
-      $ip: null,
+      $ip: 'not-collected',
       default1: 'value1',
       default2: 2
     }
@@ -111,7 +111,10 @@ test('Telemetry - disable user info through environment variable', function (t) 
   const callArg = captureSpy.args[0][0];
   const expectedEvent = {
     event: 'test event',
-    distinctId: 'artillery-core'
+    distinctId: 'artillery-core',
+    properties: {
+      $ip: 'not-collected'
+    }
   };
 
   t.same(callArg, expectedEvent, 'Only basic ping is sent if user opted out');

--- a/packages/skytrace/src/telemetry.ts
+++ b/packages/skytrace/src/telemetry.ts
@@ -48,7 +48,10 @@
        if (telemetryDisabled) {
          eventPayload = {
            event,
-           distinctId: 'skytrace'
+           distinctId: 'skytrace',
+           properties: {
+             $ip: 'not-collected',
+           }
          };
        } else {
          eventPayload = {
@@ -59,7 +62,7 @@
              version: skytraceVersion,
              os: process.platform,
              isCi: isCI,
-             $ip: null
+             $ip: 'not-collected'
            }
          };
  


### PR DESCRIPTION
# Description

Posthog captures the IP Address by default and there is no direct setting for disabling this, however an override can be set for the IP address by providing $ip property, which is what we have in our code:

```yaml
... 
        eventPayload = {
          event,
          distinctId: data.distinctId || 'artillery-core',
          properties: {
            ...data,
            version: artilleryVersion,
            os: process.platform,
            isCi: isCI,
            $ip: null,
          }
        };
...
```
 
However it seems that Posthog evaluates the `null` as if no `$ip` property override is provided and therefore captures and sets it. 

Changing the value to a truthy value fixes this. 

PR Template

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
