### PR TITLE
feat(publish-metrics): implement replaceSpanNameRegex setting

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -34,6 +34,12 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
     userFlowFunction,
     specName
   ) {
+    if (this.config.replaceSpanNameRegex) {
+      specName = this.replaceSpanNameRegex(
+        specName,
+        this.config.replaceSpanNameRegex
+      );
+    }
     // Start scenarioSpan as a root span for the trace and set it as active context
     return await this.playwrightTracer.startActiveSpan(
       specName || 'Scenario execution',
@@ -107,9 +113,15 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
               pageSpan.end();
               this.pendingPlaywrightSpans--;
             }
-
+            let spanName = 'Page: ' + pageUrl;
+            if (this.config.replaceSpanNameRegex) {
+              spanName = this.replaceSpanNameRegex(
+                spanName,
+                this.config.replaceSpanNameRegex
+              );
+            }
             pageSpan = this.playwrightTracer.startSpan(
-              'Page: ' + pageUrl,
+              spanName,
               { kind: SpanKind.CLIENT },
               ctx
             );
@@ -160,6 +172,12 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
     return async function (stepName, callback) {
       // Set the parent context to be scenarioSpan and within it we create step spans
       return context.with(trace.setSpan(context.active(), parent), async () => {
+        if (this.config.replaceSpanNameRegex) {
+          stepName = this.replaceSpanNameRegex(
+            stepName,
+            this.config.replaceSpanNameRegex
+          );
+        }
         const span = tracer.startSpan(
           stepName,
           { kind: SpanKind.CLIENT },

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-otel.js
@@ -84,7 +84,8 @@ const otelTemplate = function (config, vendorSpecificSettings) {
         sampleRate: 1,
         useRequestNames: config.traces.useRequestNames,
         attributes: config.traces.attributes,
-        smartSampling: config.traces.smartSampling
+        smartSampling: config.traces.smartSampling,
+        replaceSpanNameRegex: config.traces.replaceSpanNameRegex
       },
       vendorSpecificSettings
     );

--- a/packages/artillery-plugin-publish-metrics/package.json
+++ b/packages/artillery-plugin-publish-metrics/package.json
@@ -4,7 +4,8 @@
   "description": "Publish metrics from your Artillery.io tests to external monitoring & observability systems",
   "main": "index.js",
   "scripts": {
-    "test": "tap test/index.js --no-coverage --color"
+    "test": "tap test/index.js --no-coverage --color && npm run test:unit",
+    "test:unit": "tap test/unit/*.js --no-coverage --color"
   },
   "repository": {
     "type": "git",

--- a/packages/artillery-plugin-publish-metrics/test/unit/tracing.js
+++ b/packages/artillery-plugin-publish-metrics/test/unit/tracing.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { test } = require('tap');
+const { OTelTraceBase } = require('../../lib/open-telemetry/tracing/base');
+
+test('replaceSpanNameRegex', (t) => {
+  const spanNames = [
+    'Page: https://artillery.io/ahdufrgtcjdge',
+    'https://artillery.io/874747924374937'
+  ];
+  const replacementArray = [
+    {
+      pattern: '[0-9]+',
+      as: '$id'
+    },
+    {
+      pattern: 'Page: https://artillery.io/[a-zA-Z]+',
+      as: 'https://artillery.io/$id'
+    }
+  ];
+  const otelTraceBase = new OTelTraceBase({}, {});
+
+  spanNames.forEach((spanName) => {
+    console.log(spanName);
+    const result = otelTraceBase.replaceSpanNameRegex(
+      spanName,
+      replacementArray
+    );
+    t.equal(
+      result,
+      'https://artillery.io/$id',
+      'Matches and replaces the regex pattern in span name correctly.'
+    );
+  });
+  t.end();
+});

--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -32,7 +32,13 @@ const CloudwatchReporterSchema = Joi.object({
         firstByte: artilleryNumberOrString,
         total: artilleryNumberOrString
       })
-    })
+    }),
+    replaceSpanNameRegex: Joi.array().items(
+      Joi.object({
+        pattern: Joi.string().required(),
+        as: Joi.string().required()
+      })
+    )
   })
 })
   .unknown(false)
@@ -66,7 +72,13 @@ const DatadogReporterSchema = Joi.object({
         firstByte: artilleryNumberOrString,
         total: artilleryNumberOrString
       })
-    })
+    }),
+    replaceSpanNameRegex: Joi.array().items(
+      Joi.object({
+        pattern: Joi.string().required(),
+        as: Joi.string().required()
+      })
+    )
   })
 })
   .unknown(false)
@@ -97,7 +109,13 @@ const NewRelicReporterSchema = Joi.object({
         firstByte: artilleryNumberOrString,
         total: artilleryNumberOrString
       })
-    })
+    }),
+    replaceSpanNameRegex: Joi.array().items(
+      Joi.object({
+        pattern: Joi.string().required(),
+        as: Joi.string().required()
+      })
+    )
   })
 })
   .unknown(false)
@@ -155,7 +173,13 @@ const DynatraceReporterSchema = Joi.object({
         firstByte: artilleryNumberOrString,
         total: artilleryNumberOrString
       })
-    })
+    }),
+    replaceSpanNameRegex: Joi.array().items(
+      Joi.object({
+        pattern: Joi.string().required(),
+        as: Joi.string().required()
+      })
+    )
   })
 })
   .unknown(false)
@@ -175,7 +199,13 @@ const HoneycombReporterSchema = Joi.object({
       firstByte: artilleryNumberOrString,
       total: artilleryNumberOrString
     })
-  })
+  }),
+  replaceSpanNameRegex: Joi.array().items(
+    Joi.object({
+      pattern: Joi.string().required(),
+      as: Joi.string().required()
+    })
+  )
 })
   .unknown(false)
   .meta({ title: 'Honeycomb (Tracing) Reporter' });
@@ -248,7 +278,13 @@ const OpenTelemetryReporterSchema = Joi.object({
         firstByte: artilleryNumberOrString,
         total: artilleryNumberOrString
       })
-    })
+    }),
+    replaceSpanNameRegex: Joi.array().items(
+      Joi.object({
+        pattern: Joi.string().required(),
+        as: Joi.string().required()
+      })
+    )
   })
 })
   .unknown(false)


### PR DESCRIPTION
# Description

- Based on discussion [here](https://github.com/artilleryio/artillery/discussions/2592).

- Implementing `replaceSpanNameRegex` config option in tracing for all reporters that will allow replacing patterns in span names by specifying the regex pattern and the replacements string.

- This is mostly provided for the purpose of quantization, allowing users to group spans that contain randomised patterns but are, for the purpose of analysis, essentially the same.

## Configuration

```yaml
  plugins:
    publish-metrics:
      - type: honeycomb
        apiKey: "{{ $env.HC_API_KEY }}"
        dataset: "my-service"
        replaceSpanNameRegex:
          - pattern: get_user_[a-zA-Z0-9]+
            as: get_user_id
```

- In the example above page span in Playwright tracing `Page: https://get_user_jd83rh47fhfaAjh7snjqh` would be changed to `Page: https://get_user_id`.

## Implementation
- `replaceSpanNameRegex` method is added to the `OTelTraceBase` class making it available for both HTTP and Playwright engine tracing.
- Upon each span creation if `replaceSpanNameRegex` is set in config, the span name will be modified if pattern is found.
- The schema for every reporter using OTel tracing has been updated

## Testing
- A unit test has been added for the `replaceSpanNameRegex`
- Manually tested with both engines and spans on all levels

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?