### PR TITLE
fix(publish-metrics): adjust adot settings for datadog

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/translators/vendor-adot.js
@@ -82,13 +82,12 @@ const vendorToCollectorConfigTranslators = {
     const collectorConfig = JSON.parse(JSON.stringify(collectorConfigTemplate));
     if (config.traces) {
       collectorConfig.processors['batch/trace'] = {
-        timeout: '10s',
-        send_batch_max_size: 1024,
+        timeout: '2s',
         send_batch_size: 200
       };
       collectorConfig.exporters['datadog/api'] = {
         traces: {
-          trace_buffer: 100
+          trace_buffer: 200
         },
         api: {
           key: '${env:DD_API_KEY}'


### PR DESCRIPTION
# Description
Tweaking the ADOT config settings for the Datadog reporter.
## Context
- At times, when sending traces to Datadog in Fargate test runs, some traces would not reach Datadog. (Discovered through intermittently failing Datadog-ADOT e2e test)
- The spans reach the ADOT container but the last batch does not seem to get exported with the Datadog exporter.

- This seems to happen due to the Fargate task being terminated before the `batch` processors `timeout` interval has passed, causing the last batch of data to be dropped.

## Solution
- Changing the `batch` processors `timeout` interval from `10s` to `2s` seems to fix the issue, as the `2s` seems short enough for batch to be sent to the exporter, and exported before the `terminate` signal is sent to ADOT.


## Testing
- The solution was tested by running the original e2e test on a loop (50), along with manually testing other configurations, including both engines and different `duration` and  `arrivalRate` settings.

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?