### PR TITLE
fix(publish-metrics): adjust tests to reflect adot changes

### DIFF
--- a/packages/artillery-plugin-publish-metrics/test/unit/adot-translators.js
+++ b/packages/artillery-plugin-publish-metrics/test/unit/adot-translators.js
@@ -201,15 +201,14 @@ test('when vendorToCollectorConfigTranslators is called with a datadog config, i
     },
     processors: {
       'batch/trace': {
-        timeout: '10s',
-        send_batch_max_size: 1024,
+        timeout: '2s',
         send_batch_size: 200
       }
     },
     exporters: {
       'datadog/api': {
         traces: {
-          trace_buffer: 100
+          trace_buffer: 200
         },
         api: {
           key: '${env:DD_API_KEY}'
@@ -304,15 +303,14 @@ test('when getADOTConfig is called with a list of adotRelevantConfigs, it return
     },
     processors: {
       'batch/trace': {
-        timeout: '10s',
-        send_batch_max_size: 1024,
+        timeout: '2s',
         send_batch_size: 200
       }
     },
     exporters: {
       'datadog/api': {
         traces: {
-          trace_buffer: 100
+          trace_buffer: 200
         },
         api: {
           key: '${env:DD_API_KEY}'
@@ -367,15 +365,14 @@ test('when resolveADOTConfigSettings is called with a configList and a dotenv ob
       },
       processors: {
         'batch/trace': {
-          timeout: '10s',
-          send_batch_max_size: 1024,
+          timeout: '2s',
           send_batch_size: 200
         }
       },
       exporters: {
         'datadog/api': {
           traces: {
-            trace_buffer: 100
+            trace_buffer: 200
           },
           api: {
             key: '${env:DD_API_KEY}'


### PR DESCRIPTION
# Description

A fix for `adot-translators` unit tests.

- Change made in https://github.com/artilleryio/artillery/pull/2610 needs to be reflected in the unit tests. No errors happened when this PR was merged due to tests not being connected properly at the time. 
- Tests were connected properly in https://github.com/artilleryio/artillery/pull/2607. This PR caused errors to show only [on merging](https://github.com/artilleryio/artillery/actions/runs/8521256202/job/23339036592), as the initial pre merge tests ran prior to the other (datadog-adot fix) PR being merged.

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?