### PR TITLE
fix: reduce likelihood of incomplete uploads

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -177,7 +177,7 @@ class ArtilleryCloudPlugin {
           );
         }
 
-        await this.waitOnUnprocessedLogs(20 * 1000); //just waiting for ee is not enough, as the api call takes time
+        await this.waitOnUnprocessedLogs(30 * 1000); //just waiting for ee is not enough, as the api call takes time
 
         if (isInteractiveUse) {
           await this._event('testrun:end', {
@@ -248,7 +248,9 @@ class ArtilleryCloudPlugin {
 
     watcher.on('add', (fp) => {
       if (path.basename(fp).startsWith('trace-') && fp.endsWith('.zip')) {
-        this._uploadAsset(fp);
+        setTimeout(() => {
+          this._uploadAsset(fp);
+        }, 10 * 1000);
       }
     });
   }


### PR DESCRIPTION
A bit of a bruteforce solution but seems to work well.

* Wait for 10s before attempting to upload a new trace file
* Wait for up to 30s for all in-flight uploads to be completed