### PR TITLE
feat(cli): expose dirname utility to test scripts

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -502,11 +502,15 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
 
   script1 = await checkConfig(script1, scriptPath, flags);
 
-  const script2 = await resolveConfigPath(script1, flags);
+  const script2 = await resolveConfigPath(script1, flags, scriptPath);
 
   const script3 = await addOverrides(script2, flags);
   const script4 = await addVariables(script3, flags);
-  const script5 = await resolveConfigTemplates(script4, flags);
+  const script5 = await resolveConfigTemplates(
+    script4,
+    flags,
+    script4._configPath
+  );
 
   if (!script5.config.target) {
     throw new Error('No target specified and no environment chosen');

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -8,7 +8,8 @@ const {
   addVariables,
   addDefaultPlugins,
   resolveConfigTemplates,
-  checkConfig
+  checkConfig,
+  resolveConfigPath
 } = require('../../util');
 
 const p = require('util').promisify;
@@ -490,6 +491,7 @@ function replaceProcessorIfTypescript(
 }
 
 async function prepareTestExecutionPlan(inputFiles, flags, args) {
+  const scriptPath = inputFiles[0];
   let script1 = {};
 
   for (const fn of inputFiles) {
@@ -498,40 +500,19 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
     script1 = _.merge(script1, parsedData);
   }
 
-  script1 = await checkConfig(script1, inputFiles[0], flags);
+  script1 = await checkConfig(script1, scriptPath, flags);
 
-  if (flags.config) {
-    const absoluteConfigPath = path.resolve(process.cwd(), flags.config);
+  const script2 = await resolveConfigPath(script1, flags);
 
-    if (script1.config?.processor) {
-      const newPath = path.resolve(
-        path.dirname(absoluteConfigPath),
-        script1.config.processor
-      );
+  const script3 = await addOverrides(script2, flags);
+  const script4 = await addVariables(script3, flags);
+  const script5 = await resolveConfigTemplates(script4, flags);
 
-      const stats = fs.statSync(newPath, { throwIfNoEntry: false });
-
-      if (typeof stats === 'undefined') {
-        // No file at that path - backwards compatibility mode:
-        console.log(
-          'WARNING - config.processor is now resolved relative to the config file'
-        );
-        console.log('Expected to find file at:', newPath);
-      } else {
-        script1.config.processor = newPath;
-      }
-    }
-  }
-
-  const script2 = await addOverrides(script1, flags);
-  const script3 = await addVariables(script2, flags);
-  const script4 = await resolveConfigTemplates(script3, flags);
-
-  if (!script4.config.target) {
+  if (!script5.config.target) {
     throw new Error('No target specified and no environment chosen');
   }
 
-  const validationError = validateScript(script4);
+  const validationError = validateScript(script5);
 
   if (validationError) {
     console.log(`Scenario validation error: ${validationError}`);
@@ -539,10 +520,10 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
     process.exit(1);
   }
 
-  const script5 = await readPayload(script4);
+  const script6 = await readPayload(script5);
 
-  if (typeof script5.config.phases === 'undefined' || flags.solo) {
-    script5.config.phases = [
+  if (typeof script6.config.phases === 'undefined' || flags.solo) {
+    script6.config.phases = [
       {
         duration: 1,
         arrivalCount: 1
@@ -550,17 +531,17 @@ async function prepareTestExecutionPlan(inputFiles, flags, args) {
     ];
   }
 
-  script5.config.statsInterval = script5.config.statsInterval || 30;
+  script6.config.statsInterval = script6.config.statsInterval || 30;
 
-  const script6 = addDefaultPlugins(script5);
-  const script7 = replaceProcessorIfTypescript(
-    script6,
-    inputFiles[0],
+  const script7 = addDefaultPlugins(script5);
+  const script8 = replaceProcessorIfTypescript(
+    script7,
+    scriptPath,
     flags.platform,
     flags.container
   );
 
-  return script7;
+  return script8;
 }
 
 async function readPayload(script) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -153,12 +153,14 @@ function isLocalModule(modName) {
 }
 
 function applyScriptChanges(context, next) {
-  resolveConfigTemplates(context.opts.scriptData, context.opts.flags).then(
-    (resolvedConfig) => {
-      context.opts.scriptData = resolvedConfig;
-      return next(null, context);
-    }
-  );
+  resolveConfigTemplates(
+    context.opts.scriptData,
+    context.opts.flags,
+    context.opts.absoluteScriptPath
+  ).then((resolvedConfig) => {
+    context.opts.scriptData = resolvedConfig;
+    return next(null, context);
+  });
 }
 
 function getPlugins(context, next) {

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -98,11 +98,12 @@ function addDefaultPlugins(script) {
   return finalScript;
 }
 
-async function resolveConfigTemplates(script, flags) {
+async function resolveConfigTemplates(script, flags, configPath) {
   const cliVariables = flags.variables ? JSON.parse(flags.variables) : {};
 
   script.config = engineUtil.template(script.config, {
     vars: {
+      $dirname: path.dirname(configPath),
       $testId: global.artillery.testRunId,
       $processEnvironment: process.env,
       $env: process.env,
@@ -201,12 +202,14 @@ async function checkConfig(script, scriptPath, flags) {
   return script;
 }
 
-async function resolveConfigPath(script, flags) {
+async function resolveConfigPath(script, flags, scriptPath) {
   if (!flags.config) {
+    script._configPath = scriptPath;
     return script;
   }
 
   const absoluteConfigPath = path.resolve(process.cwd(), flags.config);
+  script._configPath = absoluteConfigPath;
 
   if (!script.config.processor) {
     return script;

--- a/packages/artillery/lib/util.js
+++ b/packages/artillery/lib/util.js
@@ -22,6 +22,7 @@ module.exports = {
   addOverrides,
   addVariables,
   addDefaultPlugins,
+  resolveConfigPath,
   resolveConfigTemplates,
   checkConfig,
   renderVariables,
@@ -196,6 +197,37 @@ async function checkConfig(script, scriptPath, flags) {
     );
     payloadSpec.path = resolvedPathToPayload;
   });
+
+  return script;
+}
+
+async function resolveConfigPath(script, flags) {
+  if (!flags.config) {
+    return script;
+  }
+
+  const absoluteConfigPath = path.resolve(process.cwd(), flags.config);
+
+  if (!script.config.processor) {
+    return script;
+  }
+
+  const processorPath = path.resolve(
+    path.dirname(absoluteConfigPath),
+    script.config.processor
+  );
+
+  const stats = fs.statSync(processorPath, { throwIfNoEntry: false });
+
+  if (typeof stats === 'undefined') {
+    // No file at that path - backwards compatibility mode:
+    console.log(
+      'WARNING - config.processor is now resolved relative to the config file'
+    );
+    console.log('Expected to find file at:', processorPath);
+  } else {
+    script.config.processor = processorPath;
+  }
 
   return script;
 }

--- a/packages/artillery/test/unit/before_after_hooks.test.js
+++ b/packages/artillery/test/unit/before_after_hooks.test.js
@@ -58,7 +58,8 @@ const script = {
         }
       ]
     }
-  ]
+  ],
+  _configPath: 'fakepath.yml'
 };
 
 const authToken = 'abcdefg';

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -453,8 +453,7 @@ function createContext(script, contextVars, additionalProperties = {}) {
         $environment: script._environment,
         $processEnvironment: process.env, // TODO: deprecate
         $env: process.env,
-        $testId: global.artillery.testRunId,
-        $dirname: path.dirname(script._configPath)
+        $testId: global.artillery.testRunId
       },
       contextVars || {}
     ),
@@ -465,6 +464,10 @@ function createContext(script, contextVars, additionalProperties = {}) {
     },
     ...additionalPropertiesWithoutOverride
   };
+
+  if (script._configPath) {
+    INITIAL_CONTEXT.vars.$dirname = path.dirname(script._configPath);
+  }
 
   let result = INITIAL_CONTEXT;
 
@@ -477,6 +480,7 @@ function createContext(script, contextVars, additionalProperties = {}) {
 
   result._uid = uuidv4();
   result.vars.$uuid = result._uid;
+
   return result;
 }
 

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -453,7 +453,8 @@ function createContext(script, contextVars, additionalProperties = {}) {
         $environment: script._environment,
         $processEnvironment: process.env, // TODO: deprecate
         $env: process.env,
-        $testId: global.artillery.testRunId
+        $testId: global.artillery.testRunId,
+        $dirname: path.dirname(script._configPath)
       },
       contextVars || {}
     ),


### PR DESCRIPTION
## Description

This will be useful when it's necessary to reference a path in the test config, but it's not one we know to resolve automatically (e.g. processors and payloads). 

One known use case right now is the Playwright Engine's `storageState`. Our current [example](https://github.com/artilleryio/artillery/tree/main/examples/browser-playwright-reuse-authentication) to reuse authentication by leveraging storageState is broken, and this is one way to fix it.

Note: I first cleaned up existing logic a little bit (https://github.com/artilleryio/artillery/commit/9da818aaa852fb68bc2a2613fdb591fa324ffc26), so best to review commit by commit.

## Testing

I intend to add an automated test, but didn't have time yet. I've tested manually against Fargate and locally (using the example), and it works.