### PR TITLE
feat(publish-metrics): map request spans to req ids

### DIFF
--- a/packages/artillery-plugin-expect/test/parallel.yml
+++ b/packages/artillery-plugin-expect/test/parallel.yml
@@ -1,0 +1,23 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 2
+      arrivalRate: 2
+  plugins:
+    expect: {}
+
+scenarios:
+  - flow:
+      - parallel:
+        - get:
+            url: "/dino"
+            expect:
+              - statusCode: 200
+        - get:
+            url: "/pony"
+            expect:
+              - statusCode: 200
+        - get:
+            url: "/armadillo"
+            expect:
+              - statusCode: 404

--- a/packages/artillery-plugin-metrics-by-endpoint/test/fixtures/scenario-parallel.yml
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/fixtures/scenario-parallel.yml
@@ -1,0 +1,17 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 2
+      arrivalRate: 2
+  plugins:
+    metrics-by-endpoint: {}
+
+scenarios:
+  - flow:
+      - parallel:
+          - get:
+              url: "/dino"
+          - get:
+              url: "/pony"
+          - get:
+              url: "/armadillo"

--- a/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
@@ -44,3 +44,37 @@ test('reports in console and json report correctly', async (t) => {
     )
   );
 });
+
+test("Reports correctly when 'parallel' is used", async (t) => {
+  const expectedVus = 4;
+  const expectedVusFailed = 0;
+  const requestPaths = ['/dino', '/pony', '/armadillo'];
+
+  const reportPath =
+    os.tmpdir() + '/artillery-plugin-metrics-by-endpoint-parallel-test.json';
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario-parallel.yml -o ${reportPath}`;
+
+  const report = require(reportPath);
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.equal(
+    report.aggregate.counters['vusers.created'],
+    expectedVus,
+    `${expectedVus} VUs should have been created`
+  );
+  t.equal(
+    report.aggregate.counters['vusers.failed'],
+    expectedVusFailed,
+    `${expectedVusFailed} VUs should have failed`
+  );
+  for (const path of requestPaths) {
+    t.equal(
+      report.aggregate.counters[
+        `plugins.metrics-by-endpoint.${path}.codes.200`
+      ],
+      expectedVus,
+      `${expectedVus} requests to ${path} should have returned 200`
+    );
+  }
+});

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -86,15 +86,16 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
           ...(this.config.attributes || {})
         }
       });
-
-      userContext.vars['__otlpHTTPRequestSpan'] = span;
+      const spanMap = userContext.vars['__otlpHTTPRequestSpans'] || {};
+      spanMap[req.uuid] = span;
+      userContext.vars['__otlpHTTPRequestSpans'] = spanMap;
       this.pendingRequestSpans++;
     });
     return done();
   }
 
   endHTTPRequestSpan(req, res, userContext, events, done) {
-    const span = userContext.vars['__otlpHTTPRequestSpan'];
+    const span = userContext.vars['__otlpHTTPRequestSpans']?.[req.uuid];
     if (!span) {
       return done();
     }

--- a/packages/artillery/test/scripts/scenario-with-parallel/processor.js
+++ b/packages/artillery/test/scripts/scenario-with-parallel/processor.js
@@ -1,0 +1,16 @@
+function beforeReqInParallel(req, context, ee, next) {
+  ee.emit('counter', `beforeRequestHook.${req.name}`, 1);
+  context.vars[req.name] = req.uuid;
+  next();
+}
+
+function afterReqInParallel(req, res, context, ee, next) {
+  ee.emit('counter', `afterRequestHook.${req.name}`, 1);
+  console.log(`${req.name}=${context.vars[req.name] === req.uuid}`);
+  next();
+}
+
+module.exports = {
+  beforeReqInParallel,
+  afterReqInParallel
+};

--- a/packages/artillery/test/scripts/scenario-with-parallel/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-with-parallel/scenario.yml
@@ -1,0 +1,22 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 2
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: ./processor.js
+scenarios:
+  - name: "Load some ASCII animals"
+    beforeRequest: beforeReqInParallel
+    afterResponse: afterReqInParallel
+    flow:
+      - parallel:
+          - get:
+              url: "/dino"
+              name: "Dinosaur"
+          - get:
+              url: "/pony"
+              name: "Pony"
+          - get:
+              url: "/armadillo"
+              name: "Armadillo"

--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -691,7 +691,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         requestParams.retry = 0; // disable retries - ignored when using streams
 
         let totalDownloaded = 0;
-        request(requestParams)
+        request(_.omit(requestParams, ['uuid']))
           .on('request', function (req) {
             ee.emit('trace:http:request', requestParams, requestParams.uuid);
 

--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -290,7 +290,8 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     const requestParams = _.extend(_.clone(params), {
       url: maybePrependBase(params.url || params.uri, config), // *NOT* templating here
       method: method,
-      timeout: timeout * 1000
+      timeout: timeout * 1000,
+      uuid: crypto.randomUUID()
     });
 
     if (context._enableCookieJar) {
@@ -562,7 +563,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               let haveFailedCaptures = false;
 
               if (result !== null) {
-                ee.emit('trace:http:capture', result, uuid);
+                ee.emit('trace:http:capture', result, requestParams.uuid);
                 if (
                   Object.keys(result.matches).length > 0 ||
                   Object.keys(result.captures).length > 0
@@ -689,11 +690,10 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
         requestParams.retry = 0; // disable retries - ignored when using streams
 
-        const uuid = crypto.randomUUID();
         let totalDownloaded = 0;
         request(requestParams)
           .on('request', function (req) {
-            ee.emit('trace:http:request', requestParams, uuid);
+            ee.emit('trace:http:request', requestParams, requestParams.uuid);
 
             debugRequests('request start: %s', req.path);
             ee.emit('counter', 'http.requests', 1);
@@ -702,7 +702,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               res.on('end', () => {
                 ee.emit('counter', 'http.downloaded_bytes', totalDownloaded);
               });
-              ee.emit('trace:http:response', res, uuid);
+              ee.emit('trace:http:response', res, requestParams.uuid);
               self._handleResponse(
                 requestParams,
                 res,
@@ -717,7 +717,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             totalDownloaded = progress.total;
           })
           .on('error', function (err, body, res) {
-            ee.emit('trace:http:error', err, uuid);
+            ee.emit('trace:http:error', err, requestParams.uuid);
             if (err.name === 'HTTPError') {
               return;
             }


### PR DESCRIPTION
# Description
- To make `publish-metrics` tracing work correctly with the `parallel` scenario setting, we map request level spans to request id's so we are able to appropriately manage them.

- To be able to accomplish this request `uuid` has been made available to all request hooks through `requestParams`

## Context (publish-metrics)

- Request level spans are opened and set on the `vuContext` in the `beforeRequest` hook, and then pulled from the `vuContext` and closed in the `afterResponse` hook.

- The change in this PR will ensure that:
     - The request span set on `vuContext` will not get overriden  in parallel runs (where multiple `beforeRequest` hooks run before the `afterRequest` hooks are triggered)
     - The appropriate request span is accessed for closing in the `afterResponse` hook


## Implementation
**CLI**
- Request `uuid` variable is created earlier in the `engine_http.js` and set on the `requestParams` so that it is available to all request hooks through `requestParams.uuid`.

**Publish-metrics**
- The request level spans, when created in the `beforeRequest` hook are now mapped to the request `uuid` when set on the `vuContext`.

## Testing
- Tested manually:
   - Traces arrive to the platform correctly
   - `uuid` is present and correct in all hooks 
   - Everything seems to work correctly when `parallel` is set 

- Added tests:
   - CLI
   - `expect` plugin
   - `metrics-by-endpoint` plugin

- TBA:
   - Tests for `publish-metrics` will be added in a separate PR

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?
