### PR TITLE
fix(playwright): add back showing errors and stack trace in console

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -346,6 +346,7 @@ class PlaywrightEngine {
         }
         return initialContext;
       } catch (err) {
+        console.error(err);
         if (initialContext.vars.isRecording) {
           if (
             Date.now() - self.lastTraceRecordedTime >


### PR DESCRIPTION
## Description

This was probably mistakenly removed in https://github.com/artilleryio/artillery/commit/51886179a997f50786237dcdb73619de0710476c

Stack traces are very useful in Playwright tests (due to usage of expect, etc), so this brings that functionality back, regardless of using extended tracing or not.


## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes