### PR TITLE
dep(playwright): update Playwright to v1.43.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4694,23 +4694,23 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.42.1.tgz",
-      "integrity": "sha512-A7pcZIZQIiiafO2UCR/OEdkvGM8Hr2gsjcK0cQ7WStF28HUpPBbJiwR9qmo+rjxaEaK7c9XD1qNXOng8Q+eI0Q==",
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.43.1.tgz",
+      "integrity": "sha512-CBuHhRIF/VGyUnPvK7/4IUbm0AAOZZI5huHlr+qNr5cFQpQ6TXBqOwSMef/xUz9HcjxWOxDPION7br1kOlyV/A==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.43.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
+      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
       "dependencies": {
-        "playwright": "1.42.1"
+        "playwright": "1.43.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15301,11 +15301,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
+      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.43.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15318,9 +15318,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
+      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -21624,10 +21624,10 @@
       "version": "1.6.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@playwright/browser-chromium": "1.42.1",
-        "@playwright/test": "1.42.1",
+        "@playwright/browser-chromium": "1.43.1",
+        "@playwright/test": "1.43.1",
         "debug": "^4.3.2",
-        "playwright": "1.42.1"
+        "playwright": "1.43.1"
       },
       "devDependencies": {
         "tap": "^16.3.10",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.42.1
+FROM mcr.microsoft.com/playwright:v1.43.1
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -12,10 +12,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@playwright/browser-chromium": "1.42.1",
-    "@playwright/test": "1.42.1",
+    "@playwright/browser-chromium": "1.43.1",
+    "@playwright/test": "1.43.1",
     "debug": "^4.3.2",
-    "playwright": "1.42.1"
+    "playwright": "1.43.1"
   },
   "devDependencies": {
     "tap": "^16.3.10",

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: Version we use here needs to be kept consistent with that in
 # artillery-engine-playwright.
 # ********************************
-FROM mcr.microsoft.com/playwright:v1.42.1
+FROM mcr.microsoft.com/playwright:v1.43.1
 LABEL maintainer="team@artillery.io"
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

Updating to latest Playwright version. Includes [1.43.1](https://github.com/microsoft/playwright/releases/tag/v1.43.1) and [1.43.0](https://github.com/microsoft/playwright/releases/tag/v1.43.0)

These releases don't seem to introduce breaking changes, only new API's.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
