### PR TITLE
ci(skytrace): temporarily remove skytrace from release automation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -24,8 +24,7 @@ jobs:
         artillery-plugin-publish-metrics,\
         commons,\
         core,\
-        artillery,\
-        skytrace"
+        artillery"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -37,8 +37,7 @@ jobs:
         artillery-plugin-publish-metrics,\
         commons,\
         core,\
-        artillery,\
-        skytrace"
+        artillery"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## Description

`skytrace` has an ongoing bug due to using an old version of oclif. This should be fixed in the npm scripts (we have a couple of workarounds for it in places now). 

Disabling it for auto releases for now and creating a ticket to address this separately.

```
> oclif readme && git add README.md
    TypeError: command.args.filter is not a function
npm ERR! code 1
npm ERR! path /home/runner/work/artillery/artillery/packages/skytrace
npm ERR! command failed
npm ERR! command sh -c oclif readme && git add README.md
```