### PR TITLE
ci(docker): add workflow dispatch to docker publish

### DIFF
--- a/.github/workflows/docker-publish-artillery.yml
+++ b/.github/workflows/docker-publish-artillery.yml
@@ -1,6 +1,12 @@
 name: Publish Docker image for Artillery
 
 on:
+  workflow_dispatch:
+    inputs:
+      COMMIT_SHA:
+        description: 'Commit SHA'
+        required: true
+        type: string
   workflow_call:
     inputs:
       COMMIT_SHA:
@@ -17,7 +23,9 @@ on:
 
 jobs:
   push_to_registry:
-    if: "contains(github.event.head_commit.message, 'ci: release v')"
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.message, 'ci: release v')
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-publish-artillery.yml
+++ b/.github/workflows/docker-publish-artillery.yml
@@ -23,9 +23,6 @@ on:
 
 jobs:
   push_to_registry:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.head_commit.message, 'ci: release v')
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2651 to allow workflow to be triggered from a `workflow_dispatch` (either directly here, or from another workflow that was workflow_dispatch and calls this one)