### PR TITLE
fix(schema): fix attribute types for nr and dynatrace reporters

### DIFF
--- a/packages/types/schema/plugins/publish-metrics.js
+++ b/packages/types/schema/plugins/publish-metrics.js
@@ -103,7 +103,7 @@ const NewRelicReporterSchema = Joi.object({
     serviceName: Joi.string(),
     sampleRate: artilleryNumberOrString,
     useRequestNames: artilleryBooleanOrString,
-    attributes: Joi.object().unknown(),
+    attributes: Joi.array().items(Joi.string()),
     smartSampling: Joi.object({
       thresholds: Joi.object({
         firstByte: artilleryNumberOrString,
@@ -167,7 +167,7 @@ const DynatraceReporterSchema = Joi.object({
     serviceName: Joi.string(),
     sampleRate: artilleryNumberOrString,
     useRequestNames: artilleryBooleanOrString,
-    attributes: Joi.object().unknown(),
+    attributes: Joi.array().items(Joi.string()),
     smartSampling: Joi.object({
       thresholds: Joi.object({
         firstByte: artilleryNumberOrString,


### PR DESCRIPTION
# Description

New Relic and Dynatrace reporters had wrong type specified for `attributes` in VS code extension

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?