### PR TITLE
refactor(expect): log msg when unsupported expectation is used

### DIFF
--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -123,15 +123,21 @@ function expectationsPluginCheckExpectations(
   _.each(expectations, (ex) => {
     const checker = Object.keys(ex)[0];
     debug(`checker: ${checker}`);
-    let result = EXPECTATIONS[checker]?.call(
-      this,
-      ex,
-      body,
-      req,
-      res,
-      userContext
-    );
-    results.push(result);
+
+    let result;
+    if (EXPECTATIONS[checker]) {
+      result = EXPECTATIONS[checker].call(
+        this,
+        ex,
+        body,
+        req,
+        res,
+        userContext
+      );
+      results.push(result);
+    } else {
+      console.log(`Expect Plugin: Expectation '${checker}' is not supported`);
+    }
   });
 
   userContext.expectations = [].concat(userContext.expectations || []);


### PR DESCRIPTION
# Description

Expect plugin scenario level configuration is meant for expectations only. If an unsupported expectation is used, the following error will appear:

<img width="1067" alt="Screenshot 2024-04-24 at 15 42 01" src="https://github.com/artilleryio/artillery/assets/39635558/862788e1-d8fd-428e-a5fe-569a36aa7e88">

With this PR a helpful message is logged instead:  `Expect Plugin: Expectation <name> is not supported`, and only valid expectations are added to `results` preventing the error. 

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?