### PR TITLE
fix(cli): make --task-role-name work on fargate

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -71,8 +71,7 @@ class RunCommand extends Command {
       { testRunId: 'foo', region: flags.region }
     );
     await ECS.init();
-
-    flags.taskRoleName = ECS_WORKER_ROLE_NAME;
+    flags.taskRoleName = flags['task-role-name'] || ECS_WORKER_ROLE_NAME;
     process.env.USE_NOOP_BACKEND_STORE = 'true';
 
     telemetry.capture('run:fargate', {


### PR DESCRIPTION
# Description

Fixes [`--task-role-name` flag](https://www.artillery.io/docs/reference/cli/run-fargate#fargate-specific-flags).
![image](https://github.com/artilleryio/artillery/assets/64775694/7751b051-4a7b-4266-831d-80eab6ac8295)

Solves https://github.com/artilleryio/artillery/pull/1937#discussion_r1540962905


# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?