### PR TITLE
Change artillery probe to skytrace probe in README.md

### DIFF
--- a/examples/multiple-scenario-specs/README.md
+++ b/examples/multiple-scenario-specs/README.md
@@ -33,7 +33,7 @@ We're testing a simple service that returns ASCII pictures of various animals.
 For example, to see a picture of an armadillo, send a GET request to http://asciizoo.artillery.io:8080/armadillo:
 
 ```sh
-artillery probe http://asciizoo.artillery.io:8080/armadillo -b
+skytrace probe http://asciizoo.artillery.io:8080/armadillo -b
 ```
 
 ![armadillo](./artillery-probe.png)


### PR DESCRIPTION
The command "artillery probe" doesn't seem to exist, but "skytrace probe" does and produces the pictured output.