### PR TITLE
feat(cli): send target url to cloud

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -326,7 +326,8 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
         launchType: flags.platform,
         artilleryVersion: {
           core: global.artillery.version
-        }
+        },
+        targetUrl: script.config.target
       }
     });
 


### PR DESCRIPTION
# Description

Sending target URL to Cloud  by adding it to `test:init` events `metadata` in `run.js`.

`ArtilleryCloudPlugin` will then take the metadata and send it to Cloud in its `testrun:init` event as seen [here](https://github.com/artilleryio/artillery/blob/main/packages/artillery/lib/platform/cloud/cloud.js#L51)

**Note**
- The target URL is pulled from a final script version that already went through all parsing and templating so that it works with any available way to provide the target URL and any overrides


**Testing:**

Tested manually with:
-  `--target` flag override, 
- target value as a variable
- target value as env var
- using `environments`

- Logged the metadata object sent in `testrun:init` event from `cloud.js`

Correct target was sent every time

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?

