### PR TITLE
feat(playwright): emit errors

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -356,13 +356,18 @@ class PlaywrightEngine {
           if (!error.matcherResult) {
             return cleanMsg;
           }
+          // If the error is a Playwright failed assertion, we return the expectation name (e.g. toHaveText)
 
           const expectation =
+            // First we try to get the name from the `name` property of the matcherResult
             error.matcherResult.name ||
+            // If the name property is not available, we try to extract it from the error message that usually contains the expect function called e.g. expect(locator).toHaveContent('text') or expect(locator).not.toHaveContent('text'))
+            // The expectation name returned will not have the "not." prefix if the expectation is negated as Playwright also doesn't include it in the name.
             cleanMsg
               .match(/\).(not.)?to[a-zA-Z]+/)[0]
               ?.slice(2)
               .replace('not.', '');
+          // If the expectation name is not available, we return the error message
           return expectation ? `pw_failed_assertion.${expectation}` : cleanMsg;
         }
         console.error(err);


### PR DESCRIPTION
# Description

Emitting errors from the Playwright engine. This means that errors will show up in reports, and (for recorded tests) on Artillery Cloud dashboard as well.

For simplicity errors are divided in 2 groups:
-  `Assertion` errors caused by `expect` will be recorded as `pw_failed_assertion.{expectation}`
- Any other errors will be recorded as `{error.message}`

<img width="721" alt="Screenshot 2024-04-26 at 18 54 39" src="https://github.com/artilleryio/artillery/assets/39635558/579b8172-7e33-4978-a595-536b59cbb213">


<img width="513" alt="Screenshot 2024-04-26 at 18 52 39" src="https://github.com/artilleryio/artillery/assets/39635558/6670d5d5-380d-44d4-b93e-a353e8ab5119">

<img width="509" alt="Screenshot 2024-04-26 at 19 00 44" src="https://github.com/artilleryio/artillery/assets/39635558/7fe26359-fff6-498b-9939-8b5b0b0ad5fc">


The error messages have been cleaned by removing any ANSI codes as well as any additional lines - just the first line is used

**Testing:**
Tested manually by causing multiple different failed assertions and errors types.

**Note:**
- Error handling logic of the Playwright engine in general should be reexamined and addressed in a separate PR in necessary.


# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
