### PR TITLE
feat(slack): implement slack integration

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -12,7 +12,8 @@ on:
       - 'packages/artillery-plugin-expect/**'
       - 'packages/artillery-plugin-metrics-by-endpoint/**'
       - 'packages/artillery-plugin-publish-metrics/**'
-      - 'packages/artillery-plugin-fake-data/**'   
+      - 'packages/artillery-plugin-fake-data/**'
+      - 'packages/artillery-plugin-slack/**'
       - 'packages/commons/**'
       - 'packages/core/**'
       - 'packages/skytrace/**'
@@ -61,6 +62,7 @@ jobs:
       - run: npm -w artillery-engine-posthog publish --tag canary
       - run: npm -w artillery-engine-playwright publish --tag canary
       - run: npm -w artillery-plugin-fake-data publish --tag canary
+      - run: npm -w artillery-plugin-slack publish --tag canary
       - run: npm -w artillery publish --tag canary
       # Skytrace is a Typescript Package and needs to install -> build -> publish
       - run: npm install -w skytrace --ignore-scripts

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -38,6 +38,7 @@ jobs:
         artillery-plugin-ensure,\
         artillery-plugin-expect,\
         artillery-plugin-fake-data,\
+        artillery-plugin-slack,\
         artillery-plugin-metrics-by-endpoint,\
         artillery-plugin-publish-metrics,\
         commons,\
@@ -64,6 +65,7 @@ jobs:
       - run: npm -w artillery-plugin-apdex publish
       - run: npm -w artillery-engine-playwright publish
       - run: npm -w artillery-plugin-fake-data publish
+      - run: npm -w artillery-plugin-slack publish
       - run: npm -w artillery publish
       # # Skytrace is a Typescript Package and needs to install -> build -> publish
       # - run: npm install -w skytrace --ignore-scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,6 +6084,10 @@
       "resolved": "packages/artillery-plugin-publish-metrics",
       "link": true
     },
+    "node_modules/artillery-plugin-slack": {
+      "resolved": "packages/artillery-plugin-slack",
+      "link": true
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "dev": true,
@@ -10295,14 +10299,15 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -15723,6 +15728,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/ps-tree": {
       "version": "1.2.0",
@@ -22542,6 +22552,37 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/artillery-plugin-slack": {
+      "version": "1.0.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axios": "^1.6.8",
+        "debug": "^4.3.4"
+      }
+    },
+    "packages/artillery-plugin-slack/node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "packages/artillery-plugin-slack/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "packages/artillery-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15729,11 +15729,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
     "node_modules/ps-tree": {
       "version": "1.2.0",
       "dev": true,
@@ -22558,31 +22553,8 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "axios": "^1.6.8",
-        "debug": "^4.3.4"
-      }
-    },
-    "packages/artillery-plugin-slack/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "packages/artillery-plugin-slack/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "debug": "^4.3.4",
+        "got": "^11.8.5"
       }
     },
     "packages/artillery-types": {

--- a/packages/artillery-plugin-slack/LICENSE.txt
+++ b/packages/artillery-plugin-slack/LICENSE.txt
@@ -1,0 +1,353 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -48,11 +48,13 @@ class SlackPlugin {
             if (check.result !== 1) {
               this.ensureChecks.failed += 1;
               this.ensureChecks.checkList.push(
-                `🔴 ${check.original} ${check.strict ? '' : '(optional) '}`
+                `:x: ${check.original} ${check.strict ? '' : '(optional) '}`
               );
             } else {
               this.ensureChecks.passed += 1;
-              this.ensureChecks.checkList.push(`🟢 ${check.original}`);
+              this.ensureChecks.checkList.push(
+                `:white_check_mark: ${check.original}`
+              );
             }
           });
 
@@ -98,8 +100,8 @@ class SlackPlugin {
         ? true
         : false;
     const introText = passed
-      ? ':white_check_mark: Artillery test run finished'
-      : ':no_entry: Artillery test run failed';
+      ? '🟢 Artillery test run finished'
+      : '🔴 Artillery test run failed';
 
     const payloadTemplate = {
       text: introText,
@@ -110,13 +112,6 @@ class SlackPlugin {
             type: 'plain_text',
             text: introText
           }
-        },
-        {
-          type: 'section',
-          text: {
-            type: 'mrkdwn',
-            text: '*Test run id:* `' + `${global.artillery.testRunId}` + '`'
-          }
         }
       ]
     };
@@ -126,7 +121,7 @@ class SlackPlugin {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `<${this.cloudTestRunUrl}|View in Artillery Cloud>`
+          text: `<${this.cloudTestRunUrl}>`
         }
       });
     }

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -126,7 +126,7 @@ class SlackPlugin {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `<${this.cloudTestRunUrl}|View in Artillery cloud>`
+          text: `<${this.cloudTestRunUrl}|View in Artillery Cloud>`
         }
       });
     }

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const debug = require('debug')('plugin:slack');
-const axios = require('axios').default;
+const got = require('got');
 
 class SlackPlugin {
   constructor(script, events) {
@@ -184,16 +184,17 @@ class SlackPlugin {
   async sendReport(report, ensureChecks) {
     const payload = this.assembleSlackPayload(report, ensureChecks);
     try {
-      const res = await axios.post(this.config.webhookUrl, payload, {
+      const res = await got.post(this.config.webhookUrl, {
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        body: payload
       });
       debug('Slack response:', res.status, res.statusText);
       this.finished = true;
     } catch (err) {
       this.finished = true;
-      throw new SlackPluginError(`Failed to send report to Slack: ${err}`);
+      console.error(`Slack Plugin: Failed to send report to Slack: ${err}`);
     }
   }
 

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -113,6 +113,15 @@ class SlackPlugin {
             type: 'plain_text',
             text: introText
           }
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Test duration:* ${
+              report.lastMetricReported - report.firstMetricReported
+            } ms`
+          }
         }
       ]
     };

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -46,6 +46,9 @@ class SlackPlugin {
           .forEach((check) => {
             this.ensureChecks.total += 1;
             if (check.result !== 1) {
+              if (check.strict) {
+                this.exitCode = 1;
+              }
               this.ensureChecks.failed += 1;
               this.ensureChecks.checkList.push(
                 `:x: ${check.original} ${check.strict ? '' : '(optional) '}`
@@ -95,13 +98,11 @@ class SlackPlugin {
 
   assembleSlackPayload(report, ensureChecks) {
     const errorList = this.getErrors(report);
-    const passed =
-      this.exitCode === 0 && !this.ensureChecks?.failedChecks?.length > 0
-        ? true
-        : false;
-    const introText = passed
-      ? '🟢 Artillery test run finished'
-      : '🔴 Artillery test run failed';
+
+    const introText =
+      this.exitCode === 0
+        ? '🟢 Artillery test run finished'
+        : '🔴 Artillery test run failed';
 
     const payloadTemplate = {
       text: introText,

--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const debug = require('debug')('plugin:slack');
+const axios = require('axios').default;
+
+class SlackPlugin {
+  constructor(script, events) {
+    this.script = script;
+    this.events = events;
+
+    if (process.env.LOCAL_WORKER_ID) {
+      debug('Running in a worker, exiting');
+      return;
+    }
+
+    this.config = script.config.plugins.slack || {};
+    this.webhook = this.config.webhookUrl;
+
+    if (!this.config.webhookUrl) {
+      throw new SlackPluginError('Slack webhook URL not provided');
+    }
+
+    if (global.artillery && global.artillery.cloudEnabled) {
+      this.cloudEnabled = true;
+      const baseUrl =
+        process.env.ARTILLERY_CLOUD_ENDPOINT || 'https://app.artillery.io';
+      this.cloudTestRunUrl = `${baseUrl}/load-tests/${global.artillery.testRunId}`;
+    }
+
+    if (
+      this.script.config.plugins.ensure &&
+      Object.keys(this.script.config.plugins.ensure).length > 0
+    ) {
+      this.ensureEnabled = true;
+
+      global.artillery.globalEvents.on('checks', async (checkTests) => {
+        this.ensureChecks = {
+          failed: 0,
+          total: 0,
+          passed: 0,
+          checkList: []
+        };
+
+        checkTests
+          .sort((a, b) => (a.result < b.result ? 1 : -1))
+          .forEach((check) => {
+            this.ensureChecks.total += 1;
+            if (check.result !== 1) {
+              this.ensureChecks.failed += 1;
+              this.ensureChecks.checkList.push(
+                `🔴 ${check.original} ${check.strict ? '' : '(optional) '}`
+              );
+            } else {
+              this.ensureChecks.passed += 1;
+              this.ensureChecks.checkList.push(`🟢 ${check.original}`);
+            }
+          });
+
+        // When ensure is enabled, whether the beforeExit or the checks event will be triggered first will depend on the order of plugins in the test script
+        // Since we need data from both events, first event triggered will store the data and the second event will send the report
+        if (this.exitCode !== undefined && this.report && !this.reportSent) {
+          await this.sendReport(this.report, this.ensureChecks);
+          this.reportSent = true;
+        }
+      });
+    }
+
+    global.artillery.ext({
+      ext: 'beforeExit',
+      method: async (opts) => {
+        this.exitCode = global.artillery.suggestedExitCode || opts.exitCode;
+        if (this.ensureEnabled && !this.ensureChecks && !this.reportSent) {
+          this.report = opts.report;
+        } else {
+          await this.sendReport(opts.report, this.ensureChecks);
+          this.reportSent = true;
+        }
+      }
+    });
+
+    debug('Slack plugin initialised!');
+  }
+
+  getErrors(report) {
+    const errorList = [];
+    for (const [key, value] of Object.entries(report.counters).filter(
+      ([key, value]) => key.startsWith('errors.')
+    )) {
+      errorList.push(` ◌ ${key.replace('errors.', '')}:  ${value}`);
+    }
+    return errorList;
+  }
+
+  assembleSlackPayload(report, ensureChecks) {
+    const errorList = this.getErrors(report);
+    const passed =
+      this.exitCode === 0 && !this.ensureChecks?.failedChecks?.length > 0
+        ? true
+        : false;
+    const introText = passed
+      ? ':white_check_mark: Artillery test run finished'
+      : ':no_entry: Artillery test run failed';
+
+    const payloadTemplate = {
+      text: introText,
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'plain_text',
+            text: introText
+          }
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*Test run id:* `' + `${global.artillery.testRunId}` + '`'
+          }
+        }
+      ]
+    };
+
+    if (this.cloudEnabled) {
+      payloadTemplate.blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `<${this.cloudTestRunUrl}|View in Artillery cloud>`
+        }
+      });
+    }
+
+    const metricBlocks = [
+      {
+        type: 'divider'
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*${report.counters['vusers.completed']} / ${report.counters['vusers.created']}*\nVUs completed / created`
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Errors*\n${
+              errorList.length !== 0 ? errorList.join('\n') : '0'
+            }`
+          }
+        ]
+      },
+      {
+        type: 'divider'
+      }
+    ];
+
+    if (this.ensureChecks) {
+      metricBlocks.push(
+        ...[
+          {
+            type: 'section',
+            fields: [
+              {
+                type: 'mrkdwn',
+                text: `*Checks (${ensureChecks.passed} / ${
+                  ensureChecks.total
+                })*\n${this.ensureChecks.checkList.join('\n')}`
+              }
+            ]
+          },
+          {
+            type: 'divider'
+          }
+        ]
+      );
+    }
+
+    payloadTemplate.blocks = payloadTemplate.blocks.concat(metricBlocks);
+
+    return JSON.stringify(payloadTemplate);
+  }
+
+  async sendReport(report, ensureChecks) {
+    const payload = this.assembleSlackPayload(report, ensureChecks);
+    try {
+      const res = await axios.post(this.config.webhookUrl, payload, {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+      debug('Slack response:', res.status, res.statusText);
+      this.finished = true;
+    } catch (err) {
+      this.finished = true;
+      throw new SlackPluginError(`Failed to send report to Slack: ${err}`);
+    }
+  }
+
+  async cleanup(done) {
+    debug('Cleaning up');
+    done();
+  }
+}
+
+class SlackPluginError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SlackPluginError';
+  }
+}
+
+module.exports = {
+  Plugin: SlackPlugin,
+  LEGACY_METRICS_FORMAT: false
+};

--- a/packages/artillery-plugin-slack/package.json
+++ b/packages/artillery-plugin-slack/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "artillery-plugin-slack",
+  "version": "1.0.0",
+  "description": "Send Artillery.io test notifications to Slack",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "MPL-2.0",
+  "dependencies": {
+    "axios": "^1.6.8",
+    "debug": "^4.3.4"
+  }
+}

--- a/packages/artillery-plugin-slack/package.json
+++ b/packages/artillery-plugin-slack/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "license": "MPL-2.0",
   "dependencies": {
-    "axios": "^1.6.8",
-    "debug": "^4.3.4"
+    "debug": "^4.3.4",
+    "got": "^11.8.5"
   }
 }

--- a/packages/artillery-plugin-slack/package.json
+++ b/packages/artillery-plugin-slack/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "keywords": [],
   "license": "MPL-2.0",

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -702,7 +702,8 @@ async function sendTelemetry(script, flags, extraProps) {
         'fuzzer',
         'ensure',
         'memory-inspector',
-        'fake-data'
+        'fake-data',
+        'slack'
       ];
       for (const p of OFFICIAL_PLUGINS) {
         if (script.config.plugins[p]) {

--- a/packages/types/schema/config.js
+++ b/packages/types/schema/config.js
@@ -17,6 +17,7 @@ const {
   PublishMetricsPluginConfigSchema
 } = require('./plugins/publish-metrics');
 const { FakeDataPlugin } = require('./plugins/fake-data');
+const { SlackPluginConfigSchema } = require('./plugins/slack');
 const { TestPhase } = require('./config/phases');
 const { buildArtilleryKeyValue } = require('./joi.helpers');
 
@@ -72,7 +73,8 @@ const ArtilleryBuiltInPlugins = {
   apdex: ApdexPluginConfigSchema,
   'metrics-by-endpoint': MetricsByEndpointPluginConfigSchema,
   'publish-metrics': PublishMetricsPluginConfigSchema,
-  'fake-data': FakeDataPlugin
+  'fake-data': FakeDataPlugin,
+  slack: SlackPluginConfigSchema
 };
 
 const ArtilleryBuiltInPluginsInRootConfig = (({ ensure, apdex }) => ({
@@ -99,7 +101,9 @@ const ConfigSchemaWithoutEnvironments = Joi.object({
   socketio: SocketIoConfigSchema.meta({ title: 'SocketIo Configuration' }),
   processor: Joi.string()
     .meta({ title: 'Processor Function Path' })
-    .description('Path to a CommonJS (.js), ESM (.mjs) or Typescript (.ts) module to load for this test run.\nhttps://www.artillery.io/docs/reference/test-script#processor---custom-js-code'),
+    .description(
+      'Path to a CommonJS (.js), ESM (.mjs) or Typescript (.ts) module to load for this test run.\nhttps://www.artillery.io/docs/reference/test-script#processor---custom-js-code'
+    ),
   variables: Joi.object()
     .meta({ title: 'Variables' })
     .description('Map of variables to expose to the test run.'),
@@ -110,12 +114,17 @@ const ConfigSchemaWithoutEnvironments = Joi.object({
     ),
   tls: TlsConfig.meta({ title: 'TLS Settings' }),
   bundling: Joi.object({
-    external: Joi.array().items(Joi.string())
+    external: Joi.array()
+      .items(Joi.string())
       .meta({ title: 'External Packages' })
-      .description('Can be used when using Typescript (.ts) processors. List npm modules to prevent them from being bundled. Use in case there are issues with bundling certain packages.\nhttps://www.artillery.io/docs/reference/test-script#preventing-bundling-of-typescript-packages'),
+      .description(
+        'Can be used when using Typescript (.ts) processors. List npm modules to prevent them from being bundled. Use in case there are issues with bundling certain packages.\nhttps://www.artillery.io/docs/reference/test-script#preventing-bundling-of-typescript-packages'
+      )
   })
-    .meta({ title: 'Bundling'})
-    .description('Configuration for bundling the test script and its dependencies'),
+    .meta({ title: 'Bundling' })
+    .description(
+      'Configuration for bundling the test script and its dependencies'
+    ),
   plugins: Joi.object({ ...ArtilleryBuiltInPlugins })
     .meta({ title: 'Plugins' })
     .description(

--- a/packages/types/schema/plugins/slack.js
+++ b/packages/types/schema/plugins/slack.js
@@ -1,0 +1,13 @@
+const Joi = require('joi');
+
+const { artilleryNumberOrString } = require('../joi.helpers');
+
+const SlackPluginConfigSchema = Joi.object({
+  webhookUrl: artilleryNumberOrString
+})
+  .unknown(false)
+  .meta({ title: 'Slack Plugin' });
+
+module.exports = {
+  SlackPluginConfigSchema
+};


### PR DESCRIPTION
# Description

Integrating with Slack  via  `slack` plugin, allowing users to receive a Slack message with a basic test overview.

The message will contain the following information:
- Whether test has passed or failed
- Test duration
- Link to the test in Artillery Cloud if recorded
- VUs completed / created
- Errors
- `ensure` plugin checks if set

---
 _Failed test with errors and both passed and failed `ensure` checks:_

<img width="663" alt="Screenshot 2024-05-02 at 16 24 39" src="https://github.com/artilleryio/artillery/assets/39635558/9fde1124-e76b-405f-99fc-53df9a7ff47b">



---
 _Successful test with no `ensure` checks and no errors present:_

<img width="664" alt="Screenshot 2024-05-02 at 16 25 03" src="https://github.com/artilleryio/artillery/assets/39635558/42ca4935-6e25-4d5d-998d-ec22a9f90043">


## Configuration
Users need to create and provide the Slack webhook URL as shown in the first 3 steps [here](https://api.slack.com/messaging/webhooks#getting_started)

```yaml
config:
  plugins:
    slack:
      webhookUrl: "{{ $env.SLACK_WEBHOOK_URL }}"
```

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?