### PR TITLE
refactor(tests): fix all pw flow funcs affected by website change

### DIFF
--- a/examples/browser-load-testing-playwright/flows.js
+++ b/examples/browser-load-testing-playwright/flows.js
@@ -15,9 +15,7 @@ async function checkOutArtilleryCoreConceptsFlow(
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page
-      .getByLabel('Main navigation')
-      .getByRole('link', { name: 'Documentation' });
+    const docs = await page.getByRole('link', { name: 'Docs' });
     await docs.click();
     await page.waitForURL('https://www.artillery.io/docs');
   });
@@ -67,8 +65,8 @@ async function multistepWithCustomMetrics(page, userContext, events, test) {
     await page.goto('https://www.artillery.io');
   });
 
-  await step('go_to_cloud_page', async () => {
-    await page.goto('https://www.artillery.io/cloud');
+  await step('go_to_blog_page', async () => {
+    await page.goto('https://www.artillery.io/blog');
   });
 
   await step('go_to_docs', async () => {

--- a/examples/browser-playwright-reuse-typescript/e2e/helpers/index.ts
+++ b/examples/browser-playwright-reuse-typescript/e2e/helpers/index.ts
@@ -6,10 +6,7 @@ export const goToDocsAndSearch = async (page: Page, step) => {
   });
 
   await step('go_to_docs', async () => {
-    await page
-      .getByLabel('Main navigation')
-      .getByRole('link', { name: 'Documentation' })
-      .click();
+    await page.getByRole('link', { name: 'Docs' }).click();
     await expect(page).toHaveURL('/docs');
     await expect(
       page.getByText("What's different about Artillery?")

--- a/packages/artillery-engine-playwright/test/fixtures/processor.js
+++ b/packages/artillery-engine-playwright/test/fixtures/processor.js
@@ -26,10 +26,7 @@ async function artilleryPlaywrightFunction(page, vuContext, events, test) {
   });
 
   await test.step('go_to_docs', async () => {
-    await page
-      .getByLabel('Main navigation')
-      .getByRole('link', { name: 'Documentation' })
-      .click();
+    await page.getByRole('link', { name: 'Docs' }).click();
     await expect(page).toHaveURL('/docs');
     await expect(
       page.getByText("What's different about Artillery?")

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
@@ -5,9 +5,7 @@ async function simpleCheck(page, userContext, events, test) {
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page
-      .getByLabel('Main navigation')
-      .getByRole('link', { name: 'Documentation' });
+    const docs = await page.getByRole('link', { name: 'Docs' });
     await docs.click();
     await page.waitForURL('https://www.artillery.io/docs');
   });


### PR DESCRIPTION
# Description

Due to recent change to Artillery.io website certain tests and examples that were using the website in their Playwright scenarios broke. This is a fix for all flows affected.

# Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?