### PR TITLE
refactor(publish-metrics): improve error and outlier handling in traces

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -212,12 +212,11 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
       events.emit('counter', 'plugins.publish-metrics.spans.exported', 1);
     } else {
       scenarioSpan?.recordException(err);
+      scenarioSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err.message || err
+      });
     }
-    // We set the scenario span status to error regardles of what level the error happened in (scenario or request) for easier querrying
-    scenarioSpan.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err.message || err
-    });
 
     if (this.config.smartSampling) {
       scenarioSpan.setAttributes({

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -187,7 +187,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
 
   otelTraceOnError(err, req, userContext, events, done) {
     const scenarioSpan = userContext.vars.__httpScenarioSpan;
-    const requestSpan = userContext.vars.__otlpHTTPRequestSpan;
+    const requestSpan = userContext.vars['__otlpHTTPRequestSpans']?.[req.uuid];
     if (!scenarioSpan) {
       return done();
     }

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/http.js
@@ -104,7 +104,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
 
     const scenarioSpan = userContext.vars['__httpScenarioSpan'];
     if (this.config.smartSampling) {
-      this.tagResponseOutliers(span, scenarioSpan, res, this.outlierCriteria);
+      this.tagResponseOutliers(span, res, this.outlierCriteria);
     }
 
     if (res.timings && res.timings.phases) {
@@ -216,13 +216,12 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
         code: SpanStatusCode.ERROR,
         message: err.message || err
       });
-    }
-
-    if (this.config.smartSampling) {
-      scenarioSpan.setAttributes({
-        outlier: 'true',
-        'outlier.type.error': true
-      });
+      if (this.config.smartSampling) {
+        scenarioSpan.setAttributes({
+          outlier: 'true',
+          'outlier.type.error': true
+        });
+      }
     }
 
     scenarioSpan.end();
@@ -231,7 +230,7 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
     return done();
   }
 
-  tagResponseOutliers(span, scenarioSpan, res, criteria) {
+  tagResponseOutliers(span, res, criteria) {
     const types = {};
     const details = [];
     if (res.statusCode >= this.statusAsErrorThreshold) {
@@ -254,11 +253,6 @@ class OTelHTTPTraceReporter extends OTelTraceBase {
     span.setAttributes({
       outlier: 'true',
       'outlier.details': details.join(', '),
-      ...types
-    });
-
-    scenarioSpan.setAttributes({
-      outlier: 'true',
       ...types
     });
   }


### PR DESCRIPTION
# Description

### 1. Fix: Request level spans (HTTP engine) are properly closed and exported. 
  - The change to request spans in #2628  was not reflected in the `onError` hook. Due to this request spans with errors were not appropriately closed and were therefore not exported. All the error data was still shown in the scenario span but the request span was missing
  
### 2. Errors are now recorded only on the context of the span they belong to.
   - Before when an error happens, it would be recorded on the span it belongs to and on the root span of the trace the original span belongs to. 
   - Now the error will be recorded on the root (scenario) span only when it happens during the scenario but outside of any child spans (e.g. outside any requests in a scenario but still during that scenario execution)
   - This will allow for better automatic parsing and displaying of data on observability platforms, showing a realistic number of errors that happened during a specific test run.
  

### 3. Only the spans that match the criteria for outliers will be tagged as outliers
   - Similar to 2. root spans of the traces containing outlier spans were tagged as outliers too, which is removed in this PR
   - This type of tagging was implemented before for easier querying, but with adding attributes like `test_id` and `vu_id` on all spans this is no longer necessary and can be confusing

## Testing
Tested manually.
Tests to be added in a future PR.

# Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry? 