### PR TITLE
test(cli): add expectation to correctly have non-zero exit code

### DIFF
--- a/packages/artillery-engine-playwright/test/fargate.aws.js
+++ b/packages/artillery-engine-playwright/test/fargate.aws.js
@@ -16,11 +16,8 @@ afterEach(async () => {
 });
 
 test('playwright typescript test works and reports data', async (t) => {
-  const configOverride = JSON.stringify({
-    processor: './processor.ts'
-  });
   const output =
-    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${configOverride} --tags ${tags} --record`;
+    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --tags ${tags} --record`;
 
   t.equal(
     output.exitCode,
@@ -121,14 +118,11 @@ test('playwright typescript test fails and has correct vu count when expectation
   const scenarioOverride = JSON.stringify({
     scenarios: [
       { engine: 'playwright', testFunction: 'playwrightFunctionWithFailure' }
-    ],
-    config: {
-      processor: './processor.ts'
-    }
+    ]
   });
 
   try {
-    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${scenarioOverride} --tags ${tags} --record`;
+    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --overrides ${scenarioOverride} --tags ${tags} --record`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(
@@ -147,8 +141,14 @@ test('playwright typescript test fails and has correct vu count when expectation
       'should have 3 failed VUs'
     );
 
+    t.equal(
+      jsonReportAggregate.counters['errors.pw_failed_assertion.toBeVisible'],
+      3,
+      'should have 3 failed assertions'
+    );
+
     t.ok(
-      output.stdout.includes('"Locator:·getByText(\'gremlins·are·here!\')"'),
+      output.stderr.includes("Locator: getByText('gremlins are here!')"),
       'should have error message in stdout'
     );
   }

--- a/packages/artillery-engine-playwright/test/fargate.aws.js
+++ b/packages/artillery-engine-playwright/test/fargate.aws.js
@@ -129,6 +129,7 @@ test('playwright typescript test fails and has correct vu count when expectation
 
   try {
     await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${scenarioOverride} --tags ${tags} --record`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(
       output.exitCode,

--- a/packages/artillery-engine-playwright/test/fargate.aws.js
+++ b/packages/artillery-engine-playwright/test/fargate.aws.js
@@ -146,10 +146,5 @@ test('playwright typescript test fails and has correct vu count when expectation
       3,
       'should have 3 failed assertions'
     );
-
-    t.ok(
-      output.stderr.includes("Locator: getByText('gremlins are here!')"),
-      'should have error message in stdout'
-    );
   }
 });

--- a/packages/artillery-engine-playwright/test/fixtures/processor.ts
+++ b/packages/artillery-engine-playwright/test/fixtures/processor.ts
@@ -36,6 +36,8 @@ export async function artilleryPlaywrightFunction(
       page.getByText("What's different about Artillery?")
     ).toBeVisible();
   });
+
+  events.emit('counter', 'custom_emitter', 1);
 }
 
 export async function playwrightFunctionWithFailure(

--- a/packages/artillery-engine-playwright/test/fixtures/pw-acceptance-ts.yml
+++ b/packages/artillery-engine-playwright/test/fixtures/pw-acceptance-ts.yml
@@ -1,0 +1,17 @@
+config:
+  target: "https://www.artillery.io/"
+  phases:
+    - duration: 3
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: "./processor.ts"
+  engines:
+    playwright:
+      extendedMetrics: true
+  plugins:
+    ensure:
+      maxErrorRate: 0
+
+scenarios:
+  - engine: playwright
+    testFunction: artilleryPlaywrightFunction

--- a/packages/artillery-engine-playwright/test/fixtures/pw-acceptance.yml
+++ b/packages/artillery-engine-playwright/test/fixtures/pw-acceptance.yml
@@ -8,6 +8,9 @@ config:
   engines:
     playwright:
       extendedMetrics: true
+  plugins:
+    ensure:
+      maxErrorRate: 0
 
 scenarios:
   - engine: playwright

--- a/packages/artillery-engine-playwright/test/index.test.js
+++ b/packages/artillery-engine-playwright/test/index.test.js
@@ -121,6 +121,7 @@ test('playwright js test fails and has correct vu count when expectation fails',
 
   try {
     await $`../artillery/bin/run run ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${scenarioOverride}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(
       output.exitCode,
@@ -260,6 +261,7 @@ test('playwright typescript test fails and has correct vu count when expectation
 
   try {
     await $`../artillery/bin/run run ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${scenarioOverride}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(
       output.exitCode,

--- a/packages/artillery-engine-playwright/test/index.test.js
+++ b/packages/artillery-engine-playwright/test/index.test.js
@@ -154,7 +154,7 @@ test('playwright js test fails and has correct vu count when expectation fails',
 
 test('playwright typescript test works and reports data', async (t) => {
   const configOverride = JSON.stringify({
-    processor: './processor.ts'
+    config: { processor: './processor.ts' }
   });
   const output =
     await $`../artillery/bin/run run ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${configOverride}`;

--- a/packages/artillery-engine-playwright/test/index.test.js
+++ b/packages/artillery-engine-playwright/test/index.test.js
@@ -285,8 +285,14 @@ test('playwright typescript test fails and has correct vu count when expectation
       'should have 3 failed VUs'
     );
 
+    t.equal(
+      jsonReportAggregate.counters['errors.pw_failed_assertion.toBeVisible'],
+      3,
+      'should have 3 failed assertions'
+    );
+
     t.ok(
-      output.stdout.includes('"Locator:·getByText(\'gremlins·are·here!\')"'),
+      output.stderr.includes("Locator: getByText('gremlins are here!')"),
       'should have error message in stdout'
     );
   }

--- a/packages/artillery-engine-playwright/test/index.test.js
+++ b/packages/artillery-engine-playwright/test/index.test.js
@@ -259,14 +259,11 @@ test('playwright typescript test fails and has correct vu count when expectation
   const scenarioOverride = JSON.stringify({
     scenarios: [
       { engine: 'playwright', testFunction: 'playwrightFunctionWithFailure' }
-    ],
-    config: {
-      processor: './processor.ts'
-    }
+    ]
   });
 
   try {
-    await $`../artillery/bin/run run ./test/fixtures/pw-acceptance.yml --output ${playwrightOutput} --overrides ${scenarioOverride}`;
+    await $`../artillery/bin/run run ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --overrides ${scenarioOverride}`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(

--- a/packages/artillery-engine-playwright/test/index.test.js
+++ b/packages/artillery-engine-playwright/test/index.test.js
@@ -139,8 +139,14 @@ test('playwright js test fails and has correct vu count when expectation fails',
       'should have 3 failed VUs'
     );
 
+    t.equal(
+      jsonReportAggregate.counters['errors.pw_failed_assertion.toBeVisible'],
+      3,
+      'should have 3 failed assertions'
+    );
+
     t.ok(
-      output.stdout.includes('"Locator:·getByText(\'gremlins·are·here!\')"'),
+      output.stderr.includes("Locator: getByText('gremlins are here!')"),
       'should have error message in stdout'
     );
   }

--- a/packages/artillery-plugin-ensure/test/index.spec.js
+++ b/packages/artillery-plugin-ensure/test/index.spec.js
@@ -85,6 +85,7 @@ test('fails thresholds correctly', async (t) => {
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     //Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
@@ -152,6 +153,7 @@ test('passes and fails correctly multiple conditions and thresholds', async (t) 
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     //Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
@@ -225,6 +227,7 @@ test('works with legacy thresholds (passing and failing) together with new thres
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
@@ -261,6 +264,7 @@ test('works with legacy maxErrorRate', async (t) => {
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     // Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
@@ -289,6 +293,7 @@ test('checks are grouped in the correct order (ok first, fail after)', async (t)
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     const startIndex = output.stdout.indexOf('Checks:');
     // Get the relevant logs (the first 4 lines after the Checks: line)
@@ -349,6 +354,7 @@ test('works with custom metrics including weird characters like urls', async (t)
   try {
     //Act: run the test
     await $`../artillery/bin/run run ./test/fixtures/scenario-custom-metrics.yml --overrides ${override}`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     //Assert
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/fargate/ensure-plugin.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/ensure-plugin.test.js
@@ -20,6 +20,7 @@ beforeEach(async (t) => {
 test('Run uses ensure', async (t) => {
   try {
     await $`${A9} run:fargate ${__dirname}/fixtures/uses-ensure/with-ensure.yaml --record --tags ${baseTags} --output ${reportFilePath} --count 15`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(

--- a/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
@@ -20,6 +20,7 @@ beforeEach(async (t) => {
 test('CLI should exit with non-zero exit code when there are failed expectations in workers', async (t) => {
   try {
     await $`${A9} run-fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
 
@@ -42,6 +43,7 @@ test('Ensure (with new interface) should still run when workers exit from expect
 
   try {
     await $`${A9} run:fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect-ensure.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
     t.ok(

--- a/packages/artillery/test/cloud-e2e/fargate/memory.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/memory.test.js
@@ -14,6 +14,7 @@ const baseTags = getTestTags(['type:acceptance']);
 test('Fargate should exit with error code when workers run out of memory', async (t) => {
   try {
     await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:true --region us-east-1`;
+    t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
 


### PR DESCRIPTION
## Description

If the CLI exits with a zero exit code when it's supposed to be a `non-zero`, then it will never make it to the `catch (output)` part, and will simply pass (as it doesn't run through any of the expectations).

This fixes that for all tests that use this pattern.

Note: Also fixed a couple of other things wrong with tests that this uncovered.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
