### PR TITLE
feat: remove is-builtin-module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21556,7 +21556,6 @@
         "eventemitter3": "^4.0.4",
         "fs-extra": "^10.1.0",
         "got": "^11.8.5",
-        "is-builtin-module": "^2.0.0",
         "joi": "^17.6.0",
         "js-yaml": "^3.13.1",
         "jsonwebtoken": "^9.0.1",
@@ -22668,14 +22667,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "packages/artillery/node_modules/builtin-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "packages/artillery/node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -22746,17 +22737,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "packages/artillery/node_modules/is-builtin-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-2.0.0.tgz",
-      "integrity": "sha512-G2jLHphOywpgrL/AaJKWDXpdpGR9X4V1PCkB+EwG5Z28z8EukgdWnAUFAS2wdBtIpwHhHBIiq0NBOWEbSXN0Rg==",
-      "dependencies": {
-        "builtin-modules": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "packages/artillery/node_modules/jsonfile": {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const A = require('async');
 
-const isBuiltinModule = require('is-builtin-module');
+const { isBuiltin } = require('node:module');
 const detective = require('detective-es6');
 const depTree = require('dependency-tree');
 
@@ -240,7 +240,7 @@ function getCustomJsDependencies(context, next) {
       const npmPackages = requires
         .filter(
           (requireString) =>
-            !isBuiltinModule(requireString) && !isLocalModule(requireString)
+            !isBuiltin(requireString) && !isLocalModule(requireString)
         )
         .map((requireString) => {
           return requireString.startsWith('@')

--- a/packages/artillery/lib/platform/aws-lambda/dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/dependencies.js
@@ -183,7 +183,6 @@ const createAndUploadLambdaZip = async (
       'uninstall',
       'dependency-tree',
       'detective',
-      'is-builtin-module',
       'try-require',
       'walk-sync',
       'esbuild-wasm',

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -119,7 +119,6 @@
     "eventemitter3": "^4.0.4",
     "fs-extra": "^10.1.0",
     "got": "^11.8.5",
-    "is-builtin-module": "^2.0.0",
     "joi": "^17.6.0",
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^9.0.1",


### PR DESCRIPTION
The node versions we support as per our engines constraint already have a built in function for determining if a module is built in.

This removes the dependency and uses the built in function instead.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
