### PR TITLE
build(publish): tag with ref when canary version

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -26,6 +26,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    with:
+      ref: ${{ github.sha }}
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2693. It's working but it published the image as 2.0.11, rather than including the sha. Need to send the ref when canary, so it will know to replace it.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
