### PR TITLE
fix(core): allow scenario name exact match without using regex

### DIFF
--- a/packages/artillery/test/cli/command-run.test.js
+++ b/packages/artillery/test/cli/command-run.test.js
@@ -138,20 +138,49 @@ tap.test('Can specify scenario to run by name', async (t) => {
   );
 });
 
+tap.test('Can specify scenario to run by name', async (t) => {
+  const [exitCode, output] = await execute([
+    'run',
+    '--scenario-name',
+    'Test Scenario (4)',
+    '-o',
+    `${reportFilePath}`,
+    'test/scripts/scenario-named/scenario.yml'
+  ]);
+
+  t.equal(exitCode, 0, 'CLI should exit with code 0');
+  t.ok(
+    output.stdout.includes('Successfully running scenario 4'),
+    'Should log success'
+  );
+  const json = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  t.equal(
+    json.aggregate.counters['vusers.created_by_name.Test Scenario (4)'],
+    6,
+    'Should have created 6 vusers for the right scenario'
+  );
+  t.type(
+    json.aggregate.counters['vusers.created_by_name.Test Scenario 1'],
+    'undefined',
+    'Should not have created vusers for the wrong scenario'
+  );
+});
+
 tap.test(
   'Errors correctly when specifying a non-existing scenario by name',
   async (t) => {
     const [exitCode, output] = await execute([
       'run',
       '--scenario-name',
-      'Test Scenario 4',
+      'Test Scenario 5',
       'test/scripts/scenario-named/scenario.yml'
     ]);
 
     t.equal(exitCode, 11);
     t.ok(
       output.stdout.includes(
-        'Error: Scenario Test Scenario 4 not found in script. Make sure your chosen scenario matches the one in your script exactly.'
+        'Error: Scenario Test Scenario 5 not found in script. Make sure your chosen scenario matches the one in your script exactly.'
       ),
       'Should log error when scenario not found'
     );

--- a/packages/artillery/test/scripts/scenario-named/scenario.yml
+++ b/packages/artillery/test/scripts/scenario-named/scenario.yml
@@ -14,3 +14,6 @@ scenarios:
   - name: Test Scenario 3
     flow:
       - log: "Successfully running scenario 3"
+  - name: Test Scenario (4)
+    flow:
+      - log: "Successfully running scenario 4"

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -341,7 +341,7 @@ function runScenario(script, metrics, runState, contextVars, options) {
         scenario.name
       );
       const hasScenarioByName = scenario.name === options.scenarioName;
-      const hasScenario = hasScenarioByRegex || hasScenarioByName;
+      const hasScenario = hasScenarioByName || hasScenarioByRegex;
 
       if (hasScenario) {
         foundIndex = index;

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -337,7 +337,11 @@ function runScenario(script, metrics, runState, contextVars, options) {
   if (options.scenarioName) {
     let foundIndex;
     const foundScenario = script.scenarios.filter((scenario, index) => {
-      const hasScenario = new RegExp(options.scenarioName).test(scenario.name);
+      const hasScenarioByRegex = new RegExp(options.scenarioName).test(
+        scenario.name
+      );
+      const hasScenarioByName = scenario.name === options.scenarioName;
+      const hasScenario = hasScenarioByRegex || hasScenarioByName;
 
       if (hasScenario) {
         foundIndex = index;


### PR DESCRIPTION
## Description

Addresses https://github.com/artilleryio/artillery/issues/2673 by allowing regex or exact match. I think this allows the maximum flexibility for the flag without breaking any existing workflows.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes (need to explain how the feature works - regex vs exact match)
- [ ] Does this require a changelog entry? Yes
