### PR TITLE
fix(lambda): use the architecture we build in CI for containers

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -724,7 +724,7 @@ class PlatformLambda {
         Timeout: 900,
         Role: this.lambdaRoleArn,
         //TODO: review architecture needed. Right now it's hardcoded to arm64. How will this affect users having to push their own docker image?
-        Architectures: ['arm64'],
+        Architectures: ['x86_64'],
         Environment: {
           Variables: {
             S3_BUCKET_PATH: this.bucketName,


### PR DESCRIPTION
## Description

I was testing this locally with `arm64`, but we build with a different architecture on CI.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No, feature is not out yet
