### PR TITLE
ci(publish): explicitly set ecs worker image overrides

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch: 
   workflow_call:
     inputs:
-      ref:
+      COMMIT_SHA:
         description: 'Branch ref to checkout. Needed for pull_request_target to be able to pull correct ref.'
         type: string
+        required: true
+      USE_COMMIT_SHA_IN_VERSION:
+        description: 'Whether to use the commit sha in building the pkg version of the image.'
+        type: boolean
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN:
         description: 'ARN of the IAM role to assume to push the image to ECR.'
@@ -20,27 +24,26 @@ jobs:
   build_docker_image:
     runs-on: ubuntu-latest
     env:
-      # From PR's this is overridden by a head ref by the caller workflow. defaults to commit sha when not passed (e.g. workflow_dispatch)
-      WORKER_VERSION: ${{ inputs.ref || github.sha }}
+      # Set by the caller workflow, defaults to github.sha when not passed (e.g. workflow_dispatch against a branch)
+      WORKER_VERSION: ${{ inputs.COMMIT_SHA || github.sha }}
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || null }}
+          ref: ${{ env.WORKER_VERSION }}
           fetch-depth: 0
       
-      - name: Replace package versions
+      - name: Replace package version
+        if: ${{ inputs.USE_COMMIT_SHA_IN_VERSION || false }}
         run: node .github/workflows/scripts/replace-package-versions.js
         env:
-          COMMIT_SHA: ${{ inputs.ref || null }}
-          REPLACE_MAIN_VERSION_ONLY: true # we don't need to replace depenencies, as docker image builds using workspaces
-      
+          COMMIT_SHA: ${{ env.WORKER_VERSION }}
+          REPLACE_MAIN_VERSION_ONLY: true # we don't need to replace dependencies, as docker image builds using workspaces
+    
       - name: Get Artillery version
-        #if main branch, and with no ref override, it's a release (canary or mainline), so we get the version from package.json
+        #if main branch, we will be tagging with package.json version, otherwise it's a sha by default
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          if [ -z "${{ inputs.ref }}" ]; then
             echo "WORKER_VERSION=$(node -e 'console.log(require("./packages/artillery/package.json").version)')" >> $GITHUB_ENV
-          fi
 
       - name: Show git ref
         run: |

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -27,7 +27,8 @@ jobs:
       contents: read
       id-token: write
     with:
-      ref: ${{ github.sha }}
+      COMMIT_SHA: ${{ github.sha }}
+      USE_COMMIT_SHA_IN_VERSION: true
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    with:
+      COMMIT_SHA: ${{ github.sha }}
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 

--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -36,7 +36,7 @@ jobs:
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
     with:
-      ref: ${{ github.event.pull_request.head.sha || null }} # this should only be run with this ref if is-collaborator has been run and passed
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha || null }} # this should only be run with this ref if is-collaborator has been run and passed
 
   generate-test-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2693 and https://github.com/artilleryio/artillery/pull/2708, since there was still a bug. 

Simplifies the logic by making things explicit. In the previous iteration it was too hard to figure out when the commit sha would be used or not, and also which sha. Now the caller workflows determine that, making it easier to follow. 

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
