### PR TITLE
fix: write Playwright traces to a unique directory

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -69,7 +69,9 @@ class PlaywrightEngine {
       1000 * 60 * (Math.ceil(Math.random() * 5) + 5);
 
     this.tracePaths = [];
-    this.traceOutputDir = process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR || '/tmp';
+    this.traceOutputDir =
+      process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR ||
+      `/tmp/${global.artillery.testRunId}`;
 
     return this;
   }

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -11,6 +11,7 @@ const { supportedRegions } = require('../platform/aws-ecs/legacy/util');
 const PlatformECS = require('../platform/aws-ecs/ecs');
 const { ECS_WORKER_ROLE_NAME } = require('../platform/aws/constants');
 const { Plugin: CloudPlugin } = require('../platform/cloud/cloud');
+const generateId = require('../util/generate-id');
 const dotenv = require('dotenv');
 const path = require('path');
 const fs = require('fs');
@@ -34,6 +35,9 @@ class RunCommand extends Command {
       }
       dotenv.config({ path: dotEnvPath });
     }
+
+    const testRunId = process.env.ARTILLERY_TEST_RUN_ID || generateId('t');
+    global.artillery.testRunId = testRunId;
 
     const cloud = new CloudPlugin(null, null, { flags });
     if (cloud.enabled) {

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -140,6 +140,10 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
     checkDirExists(flags.output);
   }
 
+  const testRunId = process.env.ARTILLERY_TEST_RUN_ID || generateId('t');
+  console.log('Test run id:', testRunId);
+  global.artillery.testRunId = testRunId;
+
   try {
     cloud = new CloudPlugin(null, null, { flags });
     global.artillery.cloudEnabled = cloud.enabled;
@@ -171,10 +175,6 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
         }
       }
     }
-
-    const testRunId = process.env.ARTILLERY_TEST_RUN_ID || generateId('t');
-    console.log('Test run id:', testRunId);
-    global.artillery.testRunId = testRunId;
 
     const script = await prepareTestExecutionPlan(inputFiles, flags, args);
 

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -289,9 +289,7 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
 
   context.extraSecrets = options.secret || [];
 
-  const testRunId = process.env.ARTILLERY_TEST_RUN_ID || generateId('t');
-  context.testId = testRunId;
-  global.artillery.testRunId = testRunId;
+  context.testId = global.artillery.testRunId;
 
   if (context.namedTest) {
     context.s3Prefix = options.bundle;

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -237,7 +237,8 @@ class ArtilleryCloudPlugin {
     };
 
     const watcher = chokidar.watch(
-      process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR || '/tmp',
+      process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR ||
+        `/tmp/${global.artillery.testRunId}`,
       {
         ignored: /(^|[\/\\])\../, // ignore dotfiles
         persistent: true,


### PR DESCRIPTION
## Description

- Write Playwright traces to `/tmp/$testRunId` instead of just `/tmp`
  - This should fix `ENOSPC` errors on Fargate due to running out of file watchers
- Use Chokidar's built-in API for detecting when a file is no longer changing, instead of hardcoded wait of 5 seconds

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
