### PR TITLE
ci(publish): ensure correct version overrides

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -40,8 +40,9 @@ jobs:
           REPLACE_MAIN_VERSION_ONLY: true # we don't need to replace dependencies, as docker image builds using workspaces
     
       - name: Get Artillery version
-        #if main branch, we will be tagging with package.json version, otherwise it's a sha by default
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # we only want to tag with an actual version from pkg.json outside of PRs and manual dispatches
+        # NOTE: can't check for refs/head/main because of pull_request_target used in some workflows
+        if: github.event.pull_request == null && github.event_name != 'workflow_dispatch'
         run: |
             echo "WORKER_VERSION=$(node -e 'console.log(require("./packages/artillery/package.json").version)')" >> $GITHUB_ENV
 

--- a/.github/workflows/npm-publish-specific-package.yml
+++ b/.github/workflows/npm-publish-specific-package.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    with:
+      COMMIT_SHA: ${{ github.sha }}
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 


### PR DESCRIPTION
## Description

`pull_request_target` (from Run AWS workflow) makes it so that the `if: ${{ github.ref == 'refs/heads/main' }}` check doesn't work correctly. It wasn't possible to test on the previous branch, as changes have to be in the workflow first, but https://github.com/artilleryio/artillery/pull/2718 has failed workflows due to this. We can test in that branch once we merge this.

## Pre-merge checklist

- [ ] Does this require an update to the docs? NO
- [ ] Does this require a changelog entry? NO
