### PR TITLE
feat: Playwright tracing configuration

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -421,7 +421,14 @@ class PlaywrightEngine {
         if (initialContext.vars.isRecording) {
           self.vusRecording--;
           // This VU was recording but completed successfully, drop the recording
-          await context.tracing.stop();
+          // unless recordSuccessfulVUs is set
+          if (self.tracingConfig.recordSuccessfulVUs) {
+            await context.tracing.stop({
+              path: initialContext.vars.__tracePath
+            });
+          } else {
+            await context.tracing.stop();
+          }
         }
 
         await context.close();

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -50,10 +50,20 @@ class PlaywrightEngine {
     this.tracesRecordedCount = 0; // total count of traces recorded so far
     this.MAX_TRACE_RECORDINGS = 5; // total limit on traces we'll record
 
-    this.enablePlaywrightTracing = false;
-    if (typeof this.config.trace !== 'undefined') {
-      this.enablePlaywrightTracing = this.config.trace !== false;
+    // Playwright tracing is disabled if:
+    // - trace is not set
+    // - trace is set to false
+    // - trace is set to an object with enabled = false
+    this.tracingConfig =
+      typeof this.config.trace === 'object'
+        ? this.config.trace
+        : {
+            enabled: false
+          };
+    if (typeof this.config.trace === 'boolean') {
+      this.tracingConfig.enabled = this.config.trace;
     }
+    this.enablePlaywrightTracing = this.tracingConfig.enabled !== false;
 
     // We use this to make sure only one VU is recording at one time:
     this.playwrightRecordTraceForNextVU = this.enablePlaywrightTracing;

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -403,12 +403,10 @@ class PlaywrightEngine {
             await context.tracing.stop({
               path: initialContext.vars.__tracePath
             });
-            events.emit('counter', 'browser.traces_recorded', 1);
+            events.emit('counter', 'browser.traces_collected', 1);
             self.lastTraceRecordedTime = Date.now();
             self.tracesRecordedCount++;
             initialContext.vars.isRecording = false; // for finally{} block
-          } else {
-            events.emit('counter', 'browser.traces_discarded', 1);
           }
         }
 
@@ -426,8 +424,10 @@ class PlaywrightEngine {
             await context.tracing.stop({
               path: initialContext.vars.__tracePath
             });
+            events.emit('counter', 'browser.traces_collected', 1);
           } else {
             await context.tracing.stop();
+            events.emit('counter', 'browser.traces_discarded', 1);
           }
         }
 

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -47,8 +47,6 @@ class PlaywrightEngine {
     // Tracing:
     // Note that these variables are shared across VUs *within* a single worker thread, as each
     // worker creates its own instance of the engine.
-    this.tracesRecordedCount = 0; // total count of traces recorded so far
-    this.MAX_TRACE_RECORDINGS = 5; // total limit on traces we'll record
 
     // Playwright tracing is disabled if:
     // - trace is not set
@@ -65,8 +63,13 @@ class PlaywrightEngine {
     }
     this.enablePlaywrightTracing = this.tracingConfig.enabled !== false;
 
+    this.tracesRecordedCount = 0; // total count of traces recorded so far
+    this.MAX_TRACE_RECORDINGS = this.tracingConfig.maxTraceRecordings || 360; // total limit on traces we'll record
+
     // We use this to make sure only one VU is recording at one time:
-    this.playwrightRecordTraceForNextVU = this.enablePlaywrightTracing;
+    this.MAX_CONCURRENT_RECORDINGS =
+      this.tracingConfig.maxConcurrentRecordings || 3; // maximum number of VUs that can record at the same time
+    this.vusRecording = 0; // number of VUs currently recording
 
     //
     // We use this to limit the number of recordings that we save:
@@ -78,11 +81,9 @@ class PlaywrightEngine {
     this.TRACE_RECORDING_INTERVAL_MSEC =
       1000 * 60 * (Math.ceil(Math.random() * 5) + 5);
 
-    this.tracePaths = [];
     this.traceOutputDir =
       process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR ||
       `/tmp/${global.artillery.testRunId}`;
-
     return this;
   }
 
@@ -151,9 +152,17 @@ class PlaywrightEngine {
 
       const context = await browser.newContext(contextOptions);
 
-      if (self.playwrightRecordTraceForNextVU) {
-        self.playwrightRecordTraceForNextVU = false;
+      if (
+        self.vusRecording < self.MAX_CONCURRENT_RECORDINGS &&
+        self.enablePlaywrightTracing &&
+        self.tracesRecordedCount < self.MAX_TRACE_RECORDINGS
+      ) {
+        self.vusRecording++;
         initialContext.vars.isRecording = true; // used by the VU to discard the trace if needed
+        const tracePath = `${self.traceOutputDir}/trace-${
+          initialContext.vars.$testId
+        }-${initialContext.vars.$uuid}-${Date.now()}.zip`;
+        initialContext.vars.__tracePath = tracePath;
         await context.tracing.start({ screenshots: true, snapshots: true });
       }
 
@@ -390,13 +399,11 @@ class PlaywrightEngine {
             Date.now() - self.lastTraceRecordedTime >
             self.TRACE_RECORDING_INTERVAL_MSEC
           ) {
-            const tracePath = `${self.traceOutputDir}/trace-${
-              initialContext.vars.$testId
-            }-${initialContext.vars.$uuid}-${Date.now()}.zip`;
-            await context.tracing.stop({ path: tracePath });
+            await context.tracing.stop({
+              path: initialContext.vars.__tracePath
+            });
             self.lastTraceRecordedTime = Date.now();
             self.tracesRecordedCount++;
-            self.tracePaths.push(tracePath);
             initialContext.vars.isRecording = false; // for finally{} block
           }
         }
@@ -407,14 +414,8 @@ class PlaywrightEngine {
           throw err;
         }
       } finally {
-        if (
-          self.enablePlaywrightTracing &&
-          self.tracesRecordedCount < self.MAX_TRACE_RECORDINGS
-        ) {
-          self.playwrightRecordTraceForNextVU = true;
-        }
-
         if (initialContext.vars.isRecording) {
+          self.vusRecording--;
           // This VU was recording but completed successfully, drop the recording
           await context.tracing.stop();
         }

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -403,9 +403,12 @@ class PlaywrightEngine {
             await context.tracing.stop({
               path: initialContext.vars.__tracePath
             });
+            events.emit('counter', 'browser.traces_recorded', 1);
             self.lastTraceRecordedTime = Date.now();
             self.tracesRecordedCount++;
             initialContext.vars.isRecording = false; // for finally{} block
+          } else {
+            events.emit('counter', 'browser.traces_discarded', 1);
           }
         }
 

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -77,9 +77,10 @@ class PlaywrightEngine {
     this.lastTraceRecordedTime = 0; // timestamp of last saved recording
     // Minimum interval between saving new recordings. Add randomness to avoid multiple workers
     // saving multiple recordings at around the same time which would likely be redundant.
-    // Interval is between 5 and 10 minutes.
+    // Interval is between 1-5 minutes
     this.TRACE_RECORDING_INTERVAL_MSEC =
-      1000 * 60 * (Math.ceil(Math.random() * 5) + 5);
+      this.tracingConfig.recordingIntervalSec * 1000 ||
+      1000 * 60 * Math.ceil(Math.random() * 5);
 
     this.traceOutputDir =
       process.env.PLAYWRIGHT_TRACING_OUTPUT_DIR ||

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -58,11 +58,6 @@ class ArtilleryCloudPlugin {
 
         this.getLoadTestEndpoint = `${this.baseUrl}/api/load-tests/${this.testRunId}/status`;
 
-        console.log(
-          'Artillery Cloud reporting is configured for this test run'
-        );
-        console.log(`Run URL: ${testRunUrl}`);
-
         await this._event('testrun:init', {
           metadata: testInfo.metadata
         });
@@ -230,6 +225,11 @@ class ArtilleryCloudPlugin {
       this.off = true;
       throw err;
     }
+
+    console.log('Artillery Cloud reporting is configured for this test run');
+    console.log(
+      `Run URL: ${this.baseUrl}/load-tests/${global.artillery.testRunId}`
+    );
 
     this.user = {
       id: body.id,


### PR DESCRIPTION
## Description

- Reduce the cooldown period for collecting recordings to 1-5m (down from 5-10m)
- Increase the number of VUs that may be recording concurrently to 3 (up from 1)
- Track collected/discarded recordings with `browser.traces_collected` and `browser.traces_discarded` metrics
- Allow customization of tracing behavior (**internal use only ⚠️ - may change without notice**)


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
