### PR TITLE
feat(lambda): use artillery-hosted ECR image

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -671,7 +671,7 @@ class PlatformLambda {
         Code: {
           ImageUri:
             this.ecrImageUrl ||
-            `301676560329.dkr.ecr.${this.region}.amazonaws.com/artillery-worker:${this.currentVersion}`
+            `248481025674.dkr.ecr.${this.region}.amazonaws.com/artillery-worker:${this.currentVersion}`
         },
         ImageConfig: {
           Command: ['a9-handler-index.handler'],

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -225,7 +225,7 @@ class PlatformLambda {
 
     let shouldCreateLambda;
     if (this.isContainerLambda) {
-      this.functionName = `artillery-worker-v${this.currentVersion.replace(
+      this.functionName = `artilleryio-v${this.currentVersion.replace(
         /\./g,
         '-'
       )}`;

--- a/packages/artillery/test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/blitz.yml
+++ b/packages/artillery/test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/blitz.yml
@@ -1,5 +1,6 @@
 scenarios:
-  - flow:
+  - beforeScenario: emitCsvCounters
+    flow:
       - loop:
           - get:
               url: "/dino"

--- a/packages/artillery/test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/helpers.js
+++ b/packages/artillery/test/cloud-e2e/lambda/fixtures/quick-loop-with-csv/helpers.js
@@ -1,4 +1,4 @@
-module.exports = { maybeSleep };
+module.exports = { maybeSleep, emitCsvCounters };
 
 function maybeSleep(req, context, events, done) {
   if (Math.random() < 0.7) {
@@ -8,4 +8,16 @@ function maybeSleep(req, context, events, done) {
   setTimeout(() => {
     return done();
   }, Math.random() * 1000);
+}
+
+function emitCsvCounters(context, events, done) {
+  if (context.vars.number) {
+    events.emit('counter', `csv_number_${context.vars.number}`, 1);
+  }
+
+  if (context.vars.name) {
+    events.emit('counter', `csv_name_${context.vars.name}`, 1);
+  }
+
+  return done();
 }

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
@@ -2,13 +2,18 @@ const tap = require('tap');
 const { $ } = require('zx');
 const { getTestTags } = require('../../cli/_helpers.js');
 
-tap.test('Run a test on AWS Lambda', async (t) => {
+tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const tags = getTestTags(['type:acceptance']);
   const configPath = `${__dirname}/fixtures/quick-loop-with-csv/config.yml`;
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
+  // TODO: override with created image once we have the workflow in place
+  process.env.WORKER_IMAGE_URL =
+    '377705245354.dkr.ecr.us-east-1.amazonaws.com/artillery-worker:2.0.11-2a2f7a1';
+  process.env.LAMBDA_IMAGE_VERSION = '2.0.11-2a2f7a1';
+
   const output =
-    await $`artillery run-lambda --count 10 --region eu-west-1 --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
+    await $`artillery run-lambda --count 10 --region us-east-1 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
 
   t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
@@ -7,10 +7,7 @@ tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const configPath = `${__dirname}/fixtures/quick-loop-with-csv/config.yml`;
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
-  // TODO: override with created image once we have the workflow in place
-  process.env.WORKER_IMAGE_URL =
-    '377705245354.dkr.ecr.us-east-1.amazonaws.com/artillery-worker:2.0.11-2a2f7a1';
-  process.env.LAMBDA_IMAGE_VERSION = '2.0.11-2a2f7a1';
+  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
 
   const output =
     await $`artillery run-lambda --count 10 --region us-east-1 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2674. We have a way to host private ECR image and make it accessible to others.

This will need a workflow to create one for CI (tests will be improved then), and the ECR repo will need the right permissions.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
