### PR TITLE
ci(publish): publish to ecr private in addition to public

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -76,10 +76,33 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
 
-      - name: Build the Docker image
+      
+      - name: Build the Docker image (public and private)
         run: |
-          docker build . --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          docker build \ 
+            --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" \
+            --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }} \
+            --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.WORKER_VERSION }} \
+            -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile \
+            .
     
-      - name: Push Docker image
+      - name: Push Docker image (Public - Fargate)
         run: |
           docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-1
+          audience: sts.amazonaws.com
+          role-to-assume: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
+          role-session-name: OIDCSession
+          mask-aws-account-id: true
+  
+      - name: Login to Amazon ECR Public
+        id: login-ecr-private
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Push Docker image (Private - Lambda)
+        run: |
+          docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.WORKER_VERSION }}


### PR DESCRIPTION
## Description

Needed for https://github.com/artilleryio/artillery/pull/2724 . We'll start publishing to ECR Private in addition to Public, for Lambda usage.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
