### PR TITLE
ci(docker): build docker image in single line command

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -79,11 +79,7 @@ jobs:
       
       - name: Build the Docker image (public and private)
         run: |
-          docker build . \ 
-            --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" \
-            --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }} \
-            --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.WORKER_VERSION }} \
-            -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          docker build . --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.WORKER_VERSION }} --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.WORKER_VERSION }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
     
       - name: Push Docker image (Public - Fargate)
         run: |


### PR DESCRIPTION
## Description

Still broken after https://github.com/artilleryio/artillery/pull/2730, just making this a single line like before, as this is hard to test.