### PR TITLE
fix(lambda): revert console log to debug log

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/dependencies.js
@@ -66,7 +66,7 @@ const createAndUploadLambdaZip = async (
 ) => {
   const dirname = temp.mkdirSync(); // TODO: May want a way to override this by the user
   const zipfile = temp.path({ suffix: '.zip' });
-  console.log({ dirname, zipfile });
+  debug({ dirname, zipfile });
 
   artillery.log('- Bundling test data');
   const bom = await _createLambdaBom(absoluteScriptPath, absoluteConfigPath);


### PR DESCRIPTION
## Description

Quick fix, bug introduced in https://github.com/artilleryio/artillery/pull/2674 . Fixing this in case we keep zip file for now and it gets forgotten.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
