### PR TITLE
fix(fargate): replace special characters in task name

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -475,7 +475,7 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     region: options.region,
     taskName: `${TASK_NAME}_${
       IS_FARGATE ? 'fargate' : ''
-    }_${clusterName}_${IMAGE_VERSION}_${Math.floor(Math.random() * 1e6)}`,
+    }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(Math.random() * 1e6)}`,
     clusterName: clusterName,
     logGroupName: LOGGROUP_NAME,
     cliOptions: options,


### PR DESCRIPTION
## Description

Fargate mainline/canary will be broken by https://github.com/artilleryio/artillery/pull/2693 with:

<img width="471" alt="Screenshot 2024-05-13 at 17 16 07" src="https://github.com/artilleryio/artillery/assets/39738771/f819bb8a-8516-4dbc-8f6a-e9a3a3a035b1">

This should solve it, it's the same we use to create the Lambda function name now. Thanks @InesNi for noticing this.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
