### PR TITLE
fix(examples): use dirname to fully resolve storageState in example

### DIFF
--- a/examples/browser-playwright-reuse-authentication/README.md
+++ b/examples/browser-playwright-reuse-authentication/README.md
@@ -16,7 +16,7 @@ npm install artillery
 
 The example leverages [`storageState`] similarly to [Playwright documentation](https://playwright.dev/docs/auth#basic-shared-account-in-all-tests). It's simple to set this up with Artillery, but there are some small differences:
 
-* You set the `storageState` path in [`config.engines.playwright.contextOptions`](https://www.artillery.io/docs/reference/engines/playwright#configuration), instead of a Playwright config file. 
+* You set the `storageState` path in [`config.engines.playwright.contextOptions`](https://www.artillery.io/docs/reference/engines/playwright#configuration), instead of a Playwright config file. Note that the [`$dirname` utility](https://www.artillery.io/docs/reference/test-script#test-level-variables) is needed to resolve the full path for Playwright.
 * A [before hook](https://www.artillery.io/docs/reference/test-script#before-and-after-sections) will run the setup function (`loginUserAndSaveStorage` in this example), rather than referencing it as a Playwright project.
 * You will need to create the storageState JSON (`storage.json` in this example) file first as an empty object (`{}`), in the same directory where you run the test from. This is because the first time Artillery runs, it will run the `before` hook, and the file referenced in `config` won't be available.
 

--- a/examples/browser-playwright-reuse-authentication/flow.js
+++ b/examples/browser-playwright-reuse-authentication/flow.js
@@ -2,7 +2,10 @@ const { expect } = require('@playwright/test');
 const fs = require('fs');
 
 async function loginUserAndSaveStorage(page, context) {
-  const storageState = JSON.parse(fs.readFileSync('./storage.json', 'utf8'));
+  // NOTE: we use the $dirname utility so Playwright can resolve the full path
+  const storageState = JSON.parse(
+    fs.readFileSync(`${context.vars.$dirname}/storage.json`, 'utf8')
+  );
   if (Object.keys(storageState).length > 0) {
     console.log('Already logged in. Skipping login.');
     return;
@@ -25,7 +28,10 @@ async function loginUserAndSaveStorage(page, context) {
   await expect(page.getByText('Your GitHub profile')).toBeVisible();
 
   //5. save iron session cookie to storage.json
-  await page.context().storageState({ path: './storage.json' });
+  // NOTE: we use the $dirname utility so Playwright can resolve the full path
+  await page
+    .context()
+    .storageState({ path: `${context.vars.$dirname}/storage.json` });
 }
 
 async function goToProfilePageAndLogout(page, context, events, test) {

--- a/examples/browser-playwright-reuse-authentication/scenario.yml
+++ b/examples/browser-playwright-reuse-authentication/scenario.yml
@@ -8,7 +8,8 @@ config:
       launchOptions:
         headless: false
       contextOptions:
-        storageState: './storage.json'
+        # NOTE: we use the $dirname utility so Playwright can resolve the full path
+        storageState: "{{ $dirname }}/storage.json"
   processor: ./flow.js
   variables:
     githubUsername: "bernardobridge"


### PR DESCRIPTION
## Description

Use `$dirname` introduced in https://github.com/artilleryio/artillery/pull/2614 to properly resolve the `storageState` path in local and distributed runs, fixing the example.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
