### PR TITLE
ci: release v0.11.0 @artilleryio/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23391,7 +23391,7 @@
     },
     "packages/types": {
       "name": "@artilleryio/types",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MPL-2.0",
       "dependencies": {
         "artillery-plugin-fake-data": "*"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artilleryio/types",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "files": [
     "./definitions.ts",
     "./schema.json"


### PR DESCRIPTION
## Description

There was a CI bug when publishing https://github.com/artilleryio/artillery/pull/2744, so upping the version again, as this is internally used only anyway.

Includes:
- https://github.com/artilleryio/artillery/pull/2658
- https://github.com/artilleryio/artillery/pull/2688

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
