### PR TITLE
ci(publish): fix official docker img publish

### DIFF
--- a/.github/workflows/docker-publish-artillery.yml
+++ b/.github/workflows/docker-publish-artillery.yml
@@ -2,6 +2,7 @@ name: Publish Docker image for Artillery
 
 on:
   workflow_dispatch:
+    # this will override the latest image, so only trigger when you want to publish a new version
     inputs:
       COMMIT_SHA:
         description: 'Commit SHA'
@@ -28,12 +29,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
-      - name: Replace package versions
-        run: node .github/workflows/scripts/replace-package-versions.js
-        env:
-          COMMIT_SHA: ${{ inputs.COMMIT_SHA || null }}
-          REPLACE_MAIN_VERSION_ONLY: true
+        with:
+          ref: ${{ inputs.COMMIT_SHA || null }}
+          fetch-depth: 0
 
       - name: Get Artillery version
         run: |


### PR DESCRIPTION
## Description

Bug introduced in https://github.com/artilleryio/artillery/pull/2693 caused latest image to tagged with the incorrect version. Affects Fargate/Lambda tests that get triggered by GH Action/Official Docker image, as they won't have the correct worker image set either.

This workflow doesn't need to override the image version with the `COMMIT_SHA`, because we don't currently build this docker image against canaries. It can be changed to do that, but then we'd need to not tag as `latest`, so leaving that for a future improvement and just fixing the current bug.

Note: I will trigger this workflow manually and it should resolve the bug.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
