### PR TITLE
feat(lambda): allow tearing down of lambda container via env var

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -526,8 +526,9 @@ class PlatformLambda {
         .promise();
 
       if (
-        typeof process.env.RETAIN_LAMBDA === 'undefined' &&
-        !this.isContainerLambda
+        (typeof process.env.RETAIN_LAMBDA === 'undefined' &&
+          !this.isContainerLambda) ||
+        process.env.RETAIN_LAMBDA === 'false'
       ) {
         await lambda
           .deleteFunction({

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
@@ -8,6 +8,7 @@ const tags = getTestTags(['type:acceptance']);
 let reportFilePath;
 tap.beforeEach(async (t) => {
   process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
+  process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
 


### PR DESCRIPTION
## Description

This will predominantly be used for internal purposes, allowing us to teardown the function immediately after testing. Tests have been modified to do that, although when we add more tests we may want to also test keeping the function between runs.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
