### PR TITLE
fix(lambda): make Lambda containers work with hierarchical deps

### DIFF
--- a/packages/artillery/lib/create-bom/create-bom.js
+++ b/packages/artillery/lib/create-bom/create-bom.js
@@ -10,6 +10,7 @@ const A = require('async');
 const debug = require('debug')('bom');
 const _ = require('lodash');
 const Table = require('cli-table3');
+const { getCustomJsDependencies } = require('../platform/aws-ecs/legacy/bom');
 
 const { readScript, parseScript } = require('../util');
 
@@ -163,25 +164,6 @@ function getCustomEngines(context, next) {
   context.npmModules = context.npmModules.concat(enginePackages);
 
   return next(null, context);
-}
-
-function getCustomJsDependencies(context, next) {
-  if (
-    context.opts.scriptData.config &&
-    context.opts.scriptData.config.processor
-  ) {
-    const procPath = path.resolve(
-      path.dirname(context.opts.absoluteScriptPath),
-      context.opts.scriptData.config.processor
-    );
-    context.localFilePaths.push(procPath);
-
-    debug('got custom JS dependencies');
-    return next(null, context);
-  } else {
-    debug('no custom JS dependencies');
-    return next(null, context);
-  }
 }
 
 function getVariableDataFiles(context, next) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -474,4 +474,10 @@ function prettyPrint(manifest) {
   artillery.log();
 }
 
-module.exports = { createBOM, commonPrefix, prettyPrint, applyScriptChanges };
+module.exports = {
+  createBOM,
+  commonPrefix,
+  prettyPrint,
+  applyScriptChanges,
+  getCustomJsDependencies
+};

--- a/packages/artillery/lib/platform/aws-lambda/dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/dependencies.js
@@ -181,10 +181,7 @@ const createAndUploadLambdaZip = async (
     'npm',
     [
       'uninstall',
-      'dependency-tree',
-      'detective',
       'try-require',
-      'walk-sync',
       'esbuild-wasm',
       'artillery-plugin-publish-metrics'
     ],
@@ -199,7 +196,6 @@ const createAndUploadLambdaZip = async (
   }
 
   fs.removeSync(path.join(dirname, 'node_modules', 'aws-sdk'));
-  fs.removeSync(path.join(a9cwd, 'node_modules', 'typescript'));
   fs.removeSync(path.join(a9cwd, 'node_modules', 'tap'));
   fs.removeSync(path.join(a9cwd, 'node_modules', 'prettier'));
 

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-dependencies.js
@@ -16,7 +16,10 @@ const syncTestData = async (bucketName, testRunId) => {
     ['s3', 'sync', REMOTE_TEST_DATA_PATH, LOCAL_TEST_DATA_PATH],
     { log: true }
   );
-  console.log(result);
+
+  if (result.code != 0 || result.stderr) {
+    throw new Error(`Failed to sync test data:\n ${result.stderr}`);
+  }
 
   //TODO: should we introduce the "leader" concept and optimise using the install of node_modules?
   //how relevant is it really? Only on larger dependency trees I suppose?

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-dependencies.js
@@ -27,7 +27,9 @@ const syncTestData = async (bucketName, testRunId) => {
   const metadataJson = fs.readFileSync(
     path.join(LOCAL_TEST_DATA_PATH, 'metadata.json')
   );
-  const localFiles = fs.readdirSync(LOCAL_TEST_DATA_PATH);
+  const localFiles = fs
+    .readdirSync(LOCAL_TEST_DATA_PATH, { recursive: true, withFileTypes: true })
+    .filter((file) => !file.isDirectory());
 
   const metadataFileCount = JSON.parse(metadataJson).fileCount + 1; //include metadata json too;
   if (metadataFileCount != localFiles.length) {

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -73,7 +73,12 @@ async function handler(event, context) {
       await mq.send({
         event: 'workerError',
         reason: 'TestDataSyncFailure',
-        logs: { err }
+        logs: {
+          err: {
+            message: err.message,
+            stack: err.stack
+          }
+        }
       });
     }
 
@@ -83,7 +88,12 @@ async function handler(event, context) {
       await mq.send({
         event: 'workerError',
         reason: 'InstallDependenciesFailure',
-        logs: { err }
+        logs: {
+          err: {
+            message: err.message,
+            stack: err.stack
+          }
+        }
       });
     }
   }
@@ -154,7 +164,12 @@ async function handler(event, context) {
     await mq.send({
       event: 'workerError',
       reason: 'StartupFailure',
-      logs: { err }
+      logs: {
+        err: {
+          message: err.message,
+          stack: err.stack
+        }
+      }
     });
   }
 }

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml
@@ -1,0 +1,19 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  processor: "../code/functions.js"
+  environments:
+    main:
+      phases:
+        - duration: 20
+          arrivalRate: 1
+      payload:
+        - path: "../data/variables.csv" # this is resolved relative to the main script for now, NOT this file
+          fields: ["username", "email"]
+      plugins:
+        metrics-by-endpoint: {}
+    stage:
+      plugins:
+        datadog: {}
+  plugins:
+    publish-metrics:
+      - type: statsd

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -1,0 +1,36 @@
+const tap = require('tap');
+const fs = require('fs');
+const { $ } = require('zx');
+const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
+
+const tags = getTestTags(['type:acceptance']);
+
+let reportFilePath;
+tap.beforeEach(async (t) => {
+  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
+  process.env.RETAIN_LAMBDA = 'false';
+  reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
+  const scenarioPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/scenarios/mixed-hierarchy-dino.yml`;
+  const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
+
+  const output =
+    await $`artillery run-lambda ${scenarioPath} --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --container`;
+
+  const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+
+  t.equal(
+    report.aggregate.counters['vusers.completed'],
+    20,
+    'Should have 20 total VUs'
+  );
+  t.equal(
+    report.aggregate.counters['http.codes.200'],
+    20,
+    'Should have 20 "200 OK" responses'
+  );
+});

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -17,7 +17,7 @@ tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --container`;
+    await $`artillery run-lambda ${scenarioPath} --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 


### PR DESCRIPTION
## Description

This copies over a Fargate test, then fixes the issue it uncovered. There's a few small things it solves to improve the experience overall:

- https://github.com/artilleryio/artillery/pull/2750/commits/50ba526ed0bd47027762e9ef21c6fdce273ec13e : Adds the test
- https://github.com/artilleryio/artillery/pull/2750/commits/86d2efae3c75569d31597f7aea431bd24d1e8356 : Adds dependency tree logic from Fargate
- https://github.com/artilleryio/artillery/pull/2750/commits/17a20593dc294b32b8bdb5e59753e02c11100882 : Appropriately catch errors from S3 sync - currently it would continue without any user feedback
- https://github.com/artilleryio/artillery/pull/2750/commits/4e70e1e0cb8ea99590beccc05d8d20455e65892c : look for files recursively when doing the file count check (files uploaded == files available on worker)
- https://github.com/artilleryio/artillery/pull/2750/commits/6823644345e370f843caaa4e65b6fcba27b53243 : start sending message and stack explicitly in errors. When sending the full error object a JSON.stringify is done which results in the error object being empty. This way the user now has clear feedback as originally intended.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? No
