### PR TITLE
fix(slack): make slack work with distributed tests

### DIFF
--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -220,11 +220,14 @@ class SlackPlugin {
     if (durationInMs < 1000) {
       return `${durationInMs} miliseconds`;
     }
-
+    const miliseconds = duration.get('millisecond');
     const timeComponents = ['day', 'hour', 'minute', 'second'];
     const formatedTimeComponents = timeComponents
       .map((component) => {
-        const value = duration.get(component);
+        let value = duration.get(component);
+        if (component === 'second' && miliseconds) {
+          value += 1;
+        }
         return value
           ? `${value} ${value === 1 ? component : component + 's'}`
           : '';

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -40,6 +40,7 @@ class RunCommand extends Command {
     global.artillery.testRunId = testRunId;
 
     const cloud = new CloudPlugin(null, null, { flags });
+    global.artillery.cloudEnabled = cloud.enabled;
     if (cloud.enabled) {
       try {
         await cloud.init();

--- a/packages/artillery/lib/create-bom/built-in-plugins.js
+++ b/packages/artillery/lib/create-bom/built-in-plugins.js
@@ -7,5 +7,6 @@ module.exports = [
   'ensure',
   'publish-metrics',
   'expect',
-  'apdex'
+  'apdex',
+  'slack'
 ];

--- a/packages/artillery/lib/platform/aws-ecs/legacy/plugins.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/plugins.js
@@ -8,7 +8,8 @@ module.exports.getOfficialPlugins = function () {
     'expect',
     'metrics-by-endpoint',
     'publish-metrics',
-    'apdex'
+    'apdex',
+    'slack'
   ];
 };
 

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -14,6 +14,7 @@ const defaultOptions = require('rc')('artillery');
 const moment = require('moment');
 
 const EnsurePlugin = require('artillery-plugin-ensure');
+const SlackPlugin = require('artillery-plugin-slack');
 
 const {
   getADOTRelevantReporterConfigs,
@@ -475,7 +476,9 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     region: options.region,
     taskName: `${TASK_NAME}_${
       IS_FARGATE ? 'fargate' : ''
-    }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(Math.random() * 1e6)}`,
+    }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(
+      Math.random() * 1e6
+    )}`,
     clusterName: clusterName,
     logGroupName: LOGGROUP_NAME,
     cliOptions: options,
@@ -746,6 +749,12 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
 
       if (context.ensureSpec) {
         new EnsurePlugin.Plugin({ config: { ensure: context.ensureSpec } });
+      }
+
+      if (context.fullyResolvedConfig?.plugins?.slack) {
+        new SlackPlugin.Plugin({
+          config: context.fullyResolvedConfig
+        });
       }
 
       if (context.cliOptions.output) {

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -182,6 +182,7 @@ async function execArtillery(options) {
       SQS_QUEUE_URL: SQS_QUEUE_URL,
       SQS_REGION: SQS_REGION,
       ARTILLERY_DISABLE_ENSURE: 'true',
+      WORKER_ID: WORKER_ID,
       // Set test run ID for this Artillery process explicitly. This makes sure that $testId
       // template variable is set to the same value for all Lambda workers as the one user
       // sees on their terminal


### PR DESCRIPTION
## Description

#### **1. Enabling Slack Plugin for Fargate runs:**

- Manually instantiating the plugin  in `run-cluster.js` similar to `ensure` plugin. ( plugins are not automatically loaded in main thread for Fargate runs)
- Disabling `slack` in cloud workers to avoid sending duplicate notifications.
- Setting the `global.artillery.cloudEnabled` variable in `run-fargate`. `slack` uses this variable to check if a run URL needs to be included in the notification. It is set in `run.js` when cloud is enabled but was missing in `run-fargate`
- Adding `slack` to both official plugin lists



#### **2. Enabling Slack Plugin for Lambda runs**
- Setting the `WORKER_ID` to `process.env`
- Works with containerized Lambda (tested manually) and _**should**_ work with `.zip file`  version but can't test easily as local changes from other unreleased packages aren't reflected



#### **3. A few additional smaller changes have been added**:
-  As a tweak to `duration` - `seconds` are ceiled rather than floored so that duration in notification doesn't always appear to be 1 second less  that the `duration` set in the test script.
- A few more debug messages were added to make debugging easier

### Testing
- Manually ran multiple tests to ensure it works as expected:
    - with varied `arrivalRate`, `duration` and container `count`
    - with and without `ensure` plugin as well as with and without `failed checks`.
    - with and without `errors`
    - for tests that are recorded to Artillery Cloud and ones that are not.


## Pre-merge checklist


- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
