### PR TITLE
fix(lambda): make lambda containers handle dependencies like fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/dependencies.js
@@ -79,7 +79,11 @@ const createAndUploadLambdaZip = async (
   debug({ dirname, zipfile });
 
   artillery.log('- Bundling test data');
-  const bom = await _createLambdaBom(absoluteScriptPath, absoluteConfigPath);
+  const bom = await _createLambdaBom(
+    absoluteScriptPath,
+    absoluteConfigPath,
+    flags
+  );
 
   for (const f of bom.files) {
     artillery.log('  -', f.noPrefix);

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -142,7 +142,7 @@ class PlatformLambda {
         this.testRunId,
         this.opts.absoluteScriptPath,
         this.opts.absoluteConfigPath,
-        this.platformOpts.cliArgs.dotenv
+        this.platformOpts.cliArgs
       );
       bom = result.bom;
       s3Path = result.s3Path;
@@ -152,7 +152,7 @@ class PlatformLambda {
         this.bucketName,
         this.opts.absoluteScriptPath,
         this.opts.absoluteConfigPath,
-        this.platformOpts.cliArgs.dotenv
+        this.platformOpts.cliArgs
       );
       bom = result.bom;
       s3Path = result.s3Path;

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -9,6 +9,7 @@ const {
   syncTestData,
   installNpmDependencies
 } = require('./a9-handler-dependencies');
+const path = require('path');
 
 const TIMEOUT_THRESHOLD_MSEC = 20 * 1000;
 
@@ -210,10 +211,15 @@ async function execArtillery(options) {
     ARTILLERY_BINARY_PATH || './node_modules/artillery/bin/run';
 
   if (IS_CONTAINER_LAMBDA) {
-    ARTILLERY_PATH = '/artillery/node_modules/artillery/bin/run';
+    const TEST_DATA_NODE_MODULES = `${TEST_DATA_LOCATION}/node_modules`;
+    const ARTILLERY_NODE_MODULES = '/artillery/node_modules';
 
-    env.ARTILLERY_PLUGIN_PATH = `${TEST_DATA_LOCATION}/node_modules/`;
+    ARTILLERY_PATH = `${ARTILLERY_NODE_MODULES}/artillery/bin/run`;
+    env.ARTILLERY_PLUGIN_PATH = TEST_DATA_NODE_MODULES;
     env.HOME = '/tmp';
+    env.NODE_PATH = ['/artillery/node_modules', TEST_DATA_NODE_MODULES].join(
+      path.delimiter
+    );
   }
 
   return runProcess(

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -12,6 +12,23 @@ tap.beforeEach(async (t) => {
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
 
+tap.test('Run simple-bom', async (t) => {
+  const scenarioPath = `${__dirname}/../fargate/fixtures/simple-bom/simple-bom.yml`;
+
+  const output =
+    await $`artillery run-lambda ${scenarioPath} -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+
+  t.match(output.stdout, /summary report/i, 'print summary report');
+  t.match(output.stdout, /p99/i, 'a p99 value is reported');
+  t.match(
+    output.stdout,
+    /created:.+510/i,
+    'expected number of vusers is reported'
+  );
+});
+
 tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const scenarioPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/scenarios/mixed-hierarchy-dino.yml`;
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;


### PR DESCRIPTION
## Description

This PR implements the Fargate `simple-bom` test for Lambda. This uncovered a couple of issues due to not running some of the bom functions (e.g. `expandDirectories`).

- https://github.com/artilleryio/artillery/commit/ac92d7a12ebe417d110b4bddaa9a2d105f18dec4 makes Lambda use Fargate's bom. As it turns out we can now actually just use Fargate BOM's directly, simplifying things further.
- In addition to that, the `simple-bom` test relies on using packages like `js-yaml` and `uuid` that aren't installed as dependencies but exist as Artillery deps. In Lambda that was erroring, so https://github.com/artilleryio/artillery/commit/674edca532a19af8a4837fbb6a3627c15292f3f4 fixes the `NODE_PATH` to work similar to Fargate (accounts for both locations).

Note: the old BOM implementation was kept for zipfiles so tests won't fail in the PR. We can remove it completely (or move the Fargate implementation elsewhere) in the PR that deprecates zipfiles.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
