### PR TITLE
feat(lambda): bundle dotenv file in lambda containers

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -47,6 +47,7 @@ function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
       getVariableDataFiles,
       getFileUploadPluginFiles,
       getExtraFiles,
+      getDotEnv,
       expandDirectories
     ],
 
@@ -371,6 +372,25 @@ function getExtraFiles(context, next) {
   } else {
     return next(null, context);
   }
+}
+
+function getDotEnv(context, next) {
+  const flags = context.opts.flags;
+  //TODO: For now only enabled on Lambda. Enable this for Fargate after refactoring to allow for it
+  if (!flags.dotenv || !flags.container || flags.platform !== 'aws:lambda') {
+    return next(null, context);
+  }
+
+  const dotEnvPath = path.resolve(process.cwd(), flags.dotenv);
+  try {
+    if (fs.statSync(dotEnvPath)) {
+      context.localFilePaths.push(dotEnvPath);
+    }
+  } catch (ignoredErr) {
+    console.log(`WARNING: could not find dotenv file: ${flags.dotenv}`);
+  }
+
+  return next(null, context);
 }
 
 function expandDirectories(context, next) {

--- a/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/.env-test
+++ b/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/.env-test
@@ -1,0 +1,1 @@
+FRUIT=dragonfruit

--- a/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/dotenv-test.yml
+++ b/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/dotenv-test.yml
@@ -1,0 +1,11 @@
+config:
+  target: "http://asciiart.artillery.io:8080"
+  phases:
+    - duration: 10
+      arrivalRate: 1
+      name: "Phase 1"
+  processor: "./processor.js"
+
+scenarios:
+  - flow:
+      - function: getFruit

--- a/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/processor.js
+++ b/packages/artillery/test/cloud-e2e/lambda/fixtures/dotenv/processor.js
@@ -1,0 +1,8 @@
+function getFruit(context, ee, next) {
+  ee.emit('counter', `fruit.${process.env.FRUIT}`, 1);
+  next();
+}
+
+module.exports = {
+  getFruit
+};

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -1,0 +1,37 @@
+const tap = require('tap');
+const fs = require('fs');
+const { $ } = require('zx');
+const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
+
+const tags = getTestTags(['type:acceptance']);
+
+let reportFilePath;
+tap.beforeEach(async (t) => {
+  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
+  process.env.RETAIN_LAMBDA = 'false';
+  reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+tap.test('Run dotenv test in Lambda Container', async (t) => {
+  const scenarioPath = `${__dirname}/fixtures/dotenv/dotenv-test.yml`;
+  const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
+
+  const output =
+    await $`artillery run-lambda ${scenarioPath} --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
+
+  const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+
+  t.equal(
+    report.aggregate.counters['vusers.created'],
+    50,
+    'Should have 50 vusers created'
+  );
+
+  t.equal(
+    report.aggregate.counters['fruit.dragonfruit'],
+    50,
+    'Should have custom counter for env variable fruit'
+  );
+});


### PR DESCRIPTION
## Description

Implements mechanism similar to zipfile Lambda of bundling the .env file (in this case in S3 instead of in Zip). Currently only for container Lambda, but we can make this work in Fargate as well separately if desired.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes, can be part of the updates for Lambda