### PR TITLE
fix(lambda): handle nonzero codes from workers

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -325,6 +325,8 @@ class PlatformLambda {
             body.id = workerId;
             this.events.emit(body.event, workerId, { phase: body.phase });
           } else if (body.event === 'workerError') {
+            global.artillery.suggestedExitCode = body.exitCode || 1;
+
             this.events.emit(body.event, workerId, {
               id: workerId,
               error: new Error(

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -156,6 +156,7 @@ async function handler(event, context) {
       await mq.send({
         event: 'workerError',
         reason: 'ArtilleryError',
+        exitCode: code,
         logs: { stdout, stderr }
       });
     }

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -1,0 +1,42 @@
+const tap = require('tap');
+const { $ } = require('zx');
+const chalk = require('chalk');
+const fs = require('fs');
+const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
+
+const tags = getTestTags(['type:acceptance']);
+let reportFilePath;
+tap.beforeEach(async (t) => {
+  reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+tap.test(
+  'CLI should exit with non-zero exit code when there are failed expectations in container workers',
+  async (t) => {
+    try {
+      await $`artillery run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
+      t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
+    } catch (output) {
+      t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+
+      const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
+      t.equal(
+        report.aggregate.counters['vusers.completed'],
+        10,
+        'Should have 10 total VUs'
+      );
+
+      t.equal(
+        report.aggregate.counters['plugins.expect.failed'],
+        10,
+        'Should have 20 failed expectations'
+      );
+
+      t.equal(
+        report.aggregate.counters['http.codes.200'],
+        10,
+        'Should have 10 "200 OK" responses'
+      );
+    }
+  }
+);


### PR DESCRIPTION
## Description

Currently errors from workers still make the main CLI process exit with 0. This is inconsistent with Local and Fargate, and can lead to incorrect behaviour in CI and Artillery Cloud (e.g. filtering). Particularly relevant for things like `expect`.

Note: this API will allow us to define specific exit codes for different types of workerErrors (e.g. TestDataSync), but right now I have just defaulted to 1 for everything. Only in the case of `ArtilleryErrors`, it will use the exitCode from the CLI in the worker.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
