### PR TITLE
fix(lambda): convert to posix paths before sending files to s3

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/dependencies.js
+++ b/packages/artillery/lib/platform/aws-lambda/dependencies.js
@@ -240,7 +240,7 @@ async function _uploadFileToS3(item, testRunId, bucketName) {
     return;
   }
 
-  const key = prefix + '/' + item.noPrefix;
+  const key = prefix + '/' + item.noPrefixPosix;
 
   try {
     await s3

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -199,14 +199,14 @@ class PlatformLambda {
       const p = bom.files.filter(
         (x) => x.orig === this.opts.absoluteConfigPath
       )[0];
-      this.artilleryArgs.push(p.noPrefix);
+      this.artilleryArgs.push(p.noPrefixPosix);
     }
 
     // This needs to be the last argument for now:
     const p = bom.files.filter(
       (x) => x.orig === this.opts.absoluteScriptPath
     )[0];
-    this.artilleryArgs.push(p.noPrefix);
+    this.artilleryArgs.push(p.noPrefixPosix);
     // 36 is length of a UUUI v4 string
     const queueName = `${SQS_QUEUES_NAME_PREFIX}_${this.testRunId.slice(
       0,


### PR DESCRIPTION
## Description

This PR implements the fix done for Windows in https://github.com/artilleryio/artillery/pull/2431, now in Lambda containers. The rest of the change is picked up automatically since Lambda now uses Fargate's BOM.

## Testing

Has been tested using a Github Action and the `simple-bom` test against Windows.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes, together with all the Lambda fixes
