### PR TITLE
feat(cli): use correct architecture in worker images

### DIFF
--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -66,12 +66,12 @@ RunLambdaCommand.flags = {
   }),
   container: Flags.boolean({
     description: 'Use a container image for Lambda (experimental)',
-    default: false,
-    exclusive: ['architecture']
+    default: false
   }),
   architecture: Flags.string({
     description: 'Architecture of the Lambda function',
-    default: 'arm64'
+    default: 'arm64',
+    options: ['arm64', 'x86_64']
   }),
   'memory-size': Flags.string({
     description: 'Memory size of the Lambda function',

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -475,7 +475,9 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     region: options.region,
     taskName: `${TASK_NAME}_${
       IS_FARGATE ? 'fargate' : ''
-    }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(Math.random() * 1e6)}`,
+    }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(
+      Math.random() * 1e6
+    )}`,
     clusterName: clusterName,
     logGroupName: LOGGROUP_NAME,
     cliOptions: options,
@@ -1139,9 +1141,10 @@ async function ensureTaskExists(context) {
       };
     });
 
+    const defaultArchitecture = 'x86_64';
     const imageUrl =
       process.env.WORKER_IMAGE_URL ||
-      `public.ecr.aws/d8a4z9o5/artillery-worker:${IMAGE_VERSION}`;
+      `public.ecr.aws/d8a4z9o5/artillery-worker:${IMAGE_VERSION}-${defaultArchitecture}`;
 
     const secrets = [
       'NPM_TOKEN',

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -674,7 +674,7 @@ class PlatformLambda {
         Code: {
           ImageUri:
             this.ecrImageUrl ||
-            `248481025674.dkr.ecr.${this.region}.amazonaws.com/artillery-worker:${this.currentVersion}`
+            `248481025674.dkr.ecr.${this.region}.amazonaws.com/artillery-worker:${this.currentVersion}-${this.architecture}`
         },
         ImageConfig: {
           Command: ['a9-handler-index.handler'],
@@ -686,7 +686,7 @@ class PlatformLambda {
         Timeout: 900,
         Role: this.lambdaRoleArn,
         //TODO: architecture influences the entrypoint. We should review which architecture to use in the end (may impact Playwright viability)
-        Architectures: ['x86_64'],
+        Architectures: [this.architecture],
         Environment: {
           Variables: {
             S3_BUCKET_PATH: this.bucketName,

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -228,7 +228,7 @@ class PlatformLambda {
       this.functionName = `artilleryio-v${this.currentVersion.replace(
         /\./g,
         '-'
-      )}`;
+      )}-${this.architecture}`;
       shouldCreateLambda = await this.checkIfNewLambdaIsNeeded({
         memorySize: this.memorySize,
         functionName: this.functionName

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -16,7 +16,7 @@ tap.test('Run simple-bom', async (t) => {
   const scenarioPath = `${__dirname}/../fargate/fixtures/simple-bom/simple-bom.yml`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
+    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
@@ -34,7 +34,7 @@ tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
+    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -17,7 +17,7 @@ tap.test('Run dotenv test in Lambda Container', async (t) => {
   const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
+    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
@@ -15,7 +15,7 @@ tap.beforeEach(async (t) => {
 
 tap.test('Lambda Container run uses ensure', async (t) => {
   try {
-    await $`artillery run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --container --tags ${tags} --output ${reportFilePath} --count 15`;
+    await $`artillery run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --container --tags ${tags} --output ${reportFilePath} --count 15`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -16,7 +16,7 @@ tap.test(
   'CLI should exit with non-zero exit code when there are failed expectations in container workers',
   async (t) => {
     try {
-      await $`artillery run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
+      await $`artillery run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
       t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
     } catch (output) {
       t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -7,6 +7,8 @@ const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 const tags = getTestTags(['type:acceptance']);
 let reportFilePath;
 tap.beforeEach(async (t) => {
+  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
+  process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
 

--- a/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/run-lambda-container.test.js
@@ -17,7 +17,7 @@ tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
   const output =
-    await $`artillery run-lambda --count 10 --region us-east-1 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
+    await $`artillery run-lambda --count 10 --region us-east-1 --architecture x86_64 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
 
   t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 
@@ -47,7 +47,7 @@ tap.test(
     const scenarioPath = `${__dirname}/fixtures/ts-external-pkg/with-external-foreign-pkg.yml`;
 
     const output =
-      await $`artillery run-lambda ${scenarioPath} --container --record --output ${reportFilePath} --tags ${tags},typescript:true`;
+      await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --container --record --output ${reportFilePath} --tags ${tags},typescript:true`;
 
     t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 


### PR DESCRIPTION
## Description

We now build `x86_64` and `arm64` images. Fargate will use `x86_64` image by default (as it currently does), and Fargate will use `arm64` by default (as it currently does).

Notes:
- We don't test against `arm64` in PRs due to how long it takes to build. We will make some changes separately to run that in main against a canary
- Lambda functions will contain the architecture in the name to piggyback on existing name mechanism to determine if a new function is needed

## Pre-merge checklist

- [ ] Does this require an update to the docs? I don't think so, since no default behaviour was changed
- [ ] Does this require a changelog entry? It could be highlighted, yes
