### PR TITLE
ci(docker): use official docker action with qemu to build arm64

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -30,11 +30,32 @@ jobs:
       matrix:
         platform: [ linux/amd64 , linux/arm64 ]
         registry: [ public, private ]
+        include:
+          # sets platform_name to match AWS convention
+          - platform: linux/amd64
+            registry: public
+            platform_name: x86_64
+          - platform: linux/amd64
+            registry: private
+            platform_name: x86_64
+          - platform: linux/arm64
+            registry: public
+            platform_name: arm64
+          - platform: linux/arm64
+            registry: private
+            platform_name: arm64
+
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.WORKER_VERSION }}
           fetch-depth: 0
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       
       - name: Replace actual platform name
         run: |
@@ -64,14 +85,6 @@ jobs:
           echo GITHUB PR HEAD SHA ${{ github.event.pull_request.head.sha }}
           echo GITHUB SHA ${{ github.sha }}
           echo WORKER_VERSION ENV ${{ env.WORKER_VERSION }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: public.ecr.aws/d8a4z9o5/artillery-worker
-          tags: |
-            type=semver,pattern={{version}}
       
       - name: Configure AWS Credentials (Public ECR)
         if: matrix.registry == 'public'
@@ -90,19 +103,19 @@ jobs:
         with:
           registry-type: public
       
-      - name: Build the Docker image (Public ECR)
+      - name: Build and push Docker image (Public ECR)
         if: matrix.registry == 'public'
-        run: |
-          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_IMAGE_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+        uses: docker/build-push-action@v4
         env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ env.PLATFORM_NAME }}
-    
-      - name: Push Docker image (Public - Fargate)
-        if: matrix.registry == 'public'
-        run: |
-          docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
-        env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ env.PLATFORM_NAME }}
+          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        with:
+          context: .
+          file: ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          push: true
+          tags: public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            WORKER_VERSION=${{ env.WORKER_VERSION }}
 
       - name: Configure AWS Credentials (Private ECR)
         if: matrix.registry == 'private'
@@ -118,18 +131,19 @@ jobs:
         if: matrix.registry == 'private'
         id: login-ecr-private
         uses: aws-actions/amazon-ecr-login@v1
-      
-      - name: Build the Docker image (Private ECR)
+    
+      - name: Build and push Docker image (Private ECR)
         if: matrix.registry == 'private'
-        run: |
-          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_IMAGE_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+        uses: docker/build-push-action@v4
         env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ env.PLATFORM_NAME }}
-
-      - name: Push Docker image (Private - Lambda)
-        if: matrix.registry == 'private'
-        run: |
-          docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
-        env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ env.PLATFORM_NAME }}
+          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        with:
+          context: .
+          file: ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          push: true
+          tags: 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            WORKER_VERSION=${{ env.WORKER_VERSION }}
+        
       

--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -57,14 +57,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
-      - name: Replace actual platform name
-        run: |
-          if [[ ${{ matrix.platform }} == 'linux/amd64' ]]; then
-            echo "PLATFORM_NAME=x86_64" >> $GITHUB_ENV
-          else
-            echo "PLATFORM_NAME=arm64" >> $GITHUB_ENV
-          fi
-      
       - name: Replace package version
         if: ${{ inputs.USE_COMMIT_SHA_IN_VERSION || false }}
         run: node .github/workflows/scripts/replace-package-versions.js


### PR DESCRIPTION
## Description

Follow up of https://github.com/artilleryio/artillery/pull/2772 . `arm64` can't build in ubuntu without emulation (QEMU).

### Testing

Can't test in this branch, will have to be tested in https://github.com/artilleryio/artillery/pull/2773 after merging to main.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
