### PR TITLE
fix(aws-lambda): wait a little longer for the lambda when using a VPC

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -84,6 +84,8 @@ class PlatformLambda {
       platformConfig['security-group-ids']?.split(',') || [];
     this.subnetIds = platformConfig['subnet-ids']?.split(',') || [];
 
+    this.useVPC = this.securityGroupIds.length > 0 && this.subnetIds.length > 0;
+
     this.memorySize = platformConfig['memory-size'] || 4096;
 
     this.testRunId = platformOpts.testRunId;
@@ -450,9 +452,10 @@ class PlatformLambda {
     const payload = JSON.stringify(event);
 
     // Wait for the function to be invocable:
+    const timeout = this.useVPC ? 240e3 : 120e3;
     let waited = 0;
     let ok = false;
-    while (waited < 120 * 1000) {
+    while (waited < timeout) {
       try {
         var state = (
           await lambda
@@ -714,7 +717,7 @@ class PlatformLambda {
       };
     }
 
-    if (this.securityGroupIds.length > 0 && this.subnetIds.length > 0) {
+    if (this.useVPC) {
       lambdaConfig.VpcConfig = {
         SecurityGroupIds: this.securityGroupIds,
         SubnetIds: this.subnetIds


### PR DESCRIPTION
## Description

When using the aws-lambda platform for running tests and using a VPC, it often takes a little longer for the function to become ready that it does when creating the lambda without a VPC. When the lambda doesn't get created in time that leaves things in an inconsistent state, as the lambda is also never cleaned up. To avoid changing the behaviour when not using a VPC, this change adds a check before starting the wait for lambda flow. If the lambda is going to be connected to a VPC it sets the wait timeout to 4 minutes, otherwise it sets it to the current value of 2 minutes.

This issue happens fairly regularly, the effect being a failed test run:
<img width="1088" alt="image" src="https://github.com/artilleryio/artillery/assets/1926537/528c0cdb-a56c-47cd-9ae0-29c742e8d421">

and an orphaned lambda floating in the aws account:
<img width="1650" alt="image" src="https://github.com/artilleryio/artillery/assets/1926537/df78c097-2f2f-4ddc-b572-45ccc8a46f8d">

I'm afraid I didn't open an issue first (or write tests) since the change is extremely trivial, but lmk if you think it warrants writing tests.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
