### PR TITLE
feat(publish-metrics): implement multiple otel improvements

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/metrics.js
@@ -51,8 +51,7 @@ class OTelMetricsReporter {
       includeOnly: config.includeOnly || [],
       exclude: config.exclude || [],
       attributes: {
-        ...(config.attributes || {}),
-        test_id: global.artillery.testRunId
+        ...(config.attributes || {})
       }
     };
 

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -137,6 +137,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
             pageSpan.setAttributes({
               'vu.uuid': vuContext.vars.$uuid,
               test_id: vuContext.vars.$testId,
+              url: pageUrl,
               ...(this.config.attributes || {})
             });
             lastPageUrl = pageUrl;

--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/tracing/playwright.js
@@ -77,7 +77,7 @@ class OTelPlaywrightTraceReporter extends OTelTraceBase {
           }
 
           // Associate only the metrics that belong to the page
-          if (metadata.url !== pageSpan.name.replace('Page: ', '')) {
+          if (metadata.url !== pageSpan.attributes.url) {
             return;
           }
           const webVitals = ['LCP', 'FCP', 'CLS', 'TTFB', 'INP', 'FID'];

--- a/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
@@ -34,7 +34,7 @@ test('traces succesfully arrive to datadog', async (t) => {
   }
 
   /// Expected values
-  const expectedTotalSpans = 52; // 4 VUs * (1 scenario root span + 2 requests + 10 timing zone spans (5 per request))
+  const expectedTotalSpans = 12; // 4 VUs * (1 scenario root span + 2 requests)
   const expectedVus = 4;
   const expectedRequests = 8;
   const expectedStatusCode200 = 8;


### PR DESCRIPTION
## Description
Multiple changes in OTel:
1. `url` attribute is added to page spans in Playwright tracing 

2. fix for  bug in Playwright tracing support - using `url` attribute instead of `name` is used along with `vu.uuid` to match web vitals with appropriate `pageSpan` (`replaceSpanNameRegex` introduced a bug where web vitals would not appear for spans with replaced names) 
3.  remove `test_id` being added by default to OTel metrics

4. Request timing phases  are recorded as attributes instead of spans in HTTP tracing for the purpose of reducing the cost. (e.g. `dns_lookup` span is now  `dns_lookup.duration` attribute with a value in `ms` set on the request span it belongs to.) 
    - **!This will change the structure of traces for HTTP engine support** 

### Testing

Tested manually, and will be added to OTel tracing tests in https://github.com/artilleryio/artillery/pull/2718

- Due to 4. changing the structure of tests the `dd-adot.test` that runs http test is adjusted to reflect the change in trace structure.

## Pre-merge checklist

- [x] Does this require an update to the docs?
- [x] Does this require a changelog entry?
