### PR TITLE
ci(docker): build single architecture instead of multi arch image manifest

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -53,9 +53,6 @@ jobs:
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       
       - name: Replace package version
         if: ${{ inputs.USE_COMMIT_SHA_IN_VERSION || false }}
@@ -95,19 +92,19 @@ jobs:
         with:
           registry-type: public
       
-      - name: Build and push Docker image (Public ECR)
+      - name: Build the Docker image (Public ECR)
         if: matrix.registry == 'public'
-        uses: docker/build-push-action@v4
-        env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
-        with:
-          context: .
-          file: ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
-          push: true
-          tags: public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            WORKER_VERSION=${{ env.WORKER_VERSION }}
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        run: |
+          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+      
+      - name: Push Docker image (Public ECR)
+        if: matrix.registry == 'public'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        run: |
+          docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }}
 
       - name: Configure AWS Credentials (Private ECR)
         if: matrix.registry == 'private'
@@ -124,18 +121,18 @@ jobs:
         id: login-ecr-private
         uses: aws-actions/amazon-ecr-login@v1
     
-      - name: Build and push Docker image (Private ECR)
+      - name: Build the Docker image (Private ECR)
         if: matrix.registry == 'private'
-        uses: docker/build-push-action@v4
-        env:
-          DOCKER_IMAGE_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
-        with:
-          context: .
-          file: ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
-          push: true
-          tags: 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_IMAGE_TAG }}
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            WORKER_VERSION=${{ env.WORKER_VERSION }}
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        run: |
+          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+
+      - name: Push Docker image (Private ECR)
+        if: matrix.registry == 'private'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+        run: |
+          docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }}
         
       

--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -1,7 +1,12 @@
 name: Build & publish ECS/Fargate worker image to ECR
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
+    inputs:
+      SHOULD_BUILD_ARM64:
+        description: 'Whether to build the ARM64 image.'
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       COMMIT_SHA:

--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -11,6 +11,10 @@ on:
       USE_COMMIT_SHA_IN_VERSION:
         description: 'Whether to use the commit sha in building the pkg version of the image.'
         type: boolean
+      SHOULD_BUILD_ARM64:
+        description: 'Whether to build the ARM64 image.'
+        type: boolean
+        default: false
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN:
         description: 'ARN of the IAM role to assume to push the image to ECR.'
@@ -21,29 +25,14 @@ permissions:
   contents: read
 
 jobs:
-  build_docker_image:
+  build_docker_image_amd64:
     runs-on: ubuntu-latest
     env:
       # Set by the caller workflow, defaults to github.sha when not passed (e.g. workflow_dispatch against a branch)
       WORKER_VERSION: ${{ inputs.COMMIT_SHA || github.sha }}
     strategy:
       matrix:
-        platform: [ linux/amd64 , linux/arm64 ]
         registry: [ public, private ]
-        include:
-          # sets platform_name to match AWS convention
-          - platform: linux/amd64
-            registry: public
-            platform_name: x86_64
-          - platform: linux/amd64
-            registry: private
-            platform_name: x86_64
-          - platform: linux/arm64
-            registry: public
-            platform_name: arm64
-          - platform: linux/arm64
-            registry: private
-            platform_name: arm64
 
     steps:
       - uses: actions/checkout@v3
@@ -95,14 +84,14 @@ jobs:
       - name: Build the Docker image (Public ECR)
         if: matrix.registry == 'public'
         env: 
-          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
         run: |
-          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          docker build . --platform linux/amd64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
       
       - name: Push Docker image (Public ECR)
         if: matrix.registry == 'public'
         env: 
-          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
         run: |
           docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }}
 
@@ -124,14 +113,114 @@ jobs:
       - name: Build the Docker image (Private ECR)
         if: matrix.registry == 'private'
         env: 
-          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
         run: |
-          docker build . --platform ${{ matrix.platform }} --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+          docker build . --platform linux/amd64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
 
       - name: Push Docker image (Private ECR)
         if: matrix.registry == 'private'
         env: 
-          DOCKER_TAG: ${{ env.WORKER_VERSION }}-${{ matrix.platform_name }}
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
+        run: |
+          docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }}
+        
+  build_docker_image_arm64:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.SHOULD_BUILD_ARM64 }}
+    env:
+      # Set by the caller workflow, defaults to github.sha when not passed (e.g. workflow_dispatch against a branch)
+      WORKER_VERSION: ${{ inputs.COMMIT_SHA || github.sha }}
+    strategy:
+      matrix:
+        registry: [ public, private ]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.WORKER_VERSION }}
+          fetch-depth: 0
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Replace package version
+        if: ${{ inputs.USE_COMMIT_SHA_IN_VERSION || false }}
+        run: node .github/workflows/scripts/replace-package-versions.js
+        env:
+          COMMIT_SHA: ${{ env.WORKER_VERSION }}
+          REPLACE_MAIN_VERSION_ONLY: true # we don't need to replace dependencies, as docker image builds using workspaces
+
+      - name: Get Artillery version
+        # we only want to tag with an actual version from pkg.json outside of PRs and manual dispatches
+        # NOTE: can't check for refs/head/main because of pull_request_target used in some workflows
+        if: github.event.pull_request == null && github.event_name != 'workflow_dispatch'
+        run: |
+            echo "WORKER_VERSION=$(node -e 'console.log(require("./packages/artillery/package.json").version)')" >> $GITHUB_ENV
+
+      - name: Show git ref
+        run: |
+          echo GITHUB REF ${{ github.ref }}
+          echo GITHUB PR HEAD SHA ${{ github.event.pull_request.head.sha }}
+          echo GITHUB SHA ${{ github.sha }}
+          echo WORKER_VERSION ENV ${{ env.WORKER_VERSION }}
+      
+      - name: Configure AWS Credentials (Public ECR)
+        if: matrix.registry == 'public'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          audience: sts.amazonaws.com
+          role-to-assume: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
+          role-session-name: OIDCSession
+          mask-aws-account-id: true
+
+      - name: Login to Amazon (Public ECR)
+        if: matrix.registry == 'public'
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
+      
+      - name: Build the Docker image (Public ECR)
+        if: matrix.registry == 'public'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
+        run: |
+          docker build . --platform linux/arm64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+      
+      - name: Push Docker image (Public ECR)
+        if: matrix.registry == 'public'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
+        run: |
+          docker push public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }}
+
+      - name: Configure AWS Credentials (Private ECR)
+        if: matrix.registry == 'private'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-1
+          audience: sts.amazonaws.com
+          role-to-assume: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
+          role-session-name: OIDCSession
+          mask-aws-account-id: true
+
+      - name: Login to Amazon (Private ECR)
+        if: matrix.registry == 'private'
+        id: login-ecr-private
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build the Docker image (Private ECR)
+        if: matrix.registry == 'private'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
+        run: |
+          docker build . --platform linux/arm64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+
+      - name: Push Docker image (Private ECR)
+        if: matrix.registry == 'private'
+        env: 
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
         run: |
           docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }}
         

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       COMMIT_SHA: ${{ github.sha }}
       USE_COMMIT_SHA_IN_VERSION: true
+      SHOULD_BUILD_ARM64: true
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -19,6 +19,7 @@ jobs:
       id-token: write
     with:
       COMMIT_SHA: ${{ github.sha }}
+      SHOULD_BUILD_ARM64: true
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 

--- a/.github/workflows/npm-publish-specific-package.yml
+++ b/.github/workflows/npm-publish-specific-package.yml
@@ -22,6 +22,7 @@ jobs:
       id-token: write
     with:
       COMMIT_SHA: ${{ github.sha }}
+      SHOULD_BUILD_ARM64: true
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 


### PR DESCRIPTION
## Description

Using the `docker/build-push-action` uses buildx and sets an `image manifest` type which is unsupported by Lambda. We now build the image with `docker build` as before, but setup `qemu` to ensure emulation is present for building `arm64`.

Note: builds `arm64` conditionally so we can skip in PR's for now (given how long it takes). We can then add smoke tests to main against canary.

### Testing

Tested this in another branch with a `workflow_dispatch` build, and locally triggered some Lambda tests against arm64 and x86_64. All seems to be working.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
