### PR TITLE
fix(ws): report errors returned by hooks

### DIFF
--- a/packages/core/lib/engine_ws.js
+++ b/packages/core/lib/engine_ws.js
@@ -343,6 +343,7 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
     async.waterfall(steps, function scenarioWaterfallCb(err, context) {
       if (err) {
+        ee.emit('error', err.code || err.message);
         debug(err);
       }
 


### PR DESCRIPTION
## Description

This change includes errors thrown by `function` steps in WebSocket scenarios in the console report (similar to how it works in the HTTP engine).