### PR TITLE
fix: accept 0 values for defaultNavigationTimeout and defaultTimeout

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -14,12 +14,13 @@ class PlaywrightEngine {
     this.tracing = global.artillery.OTEL_TRACING_ENABLED || false;
 
     this.defaultNavigationTimeout =
-      (parseInt(this.config.defaultNavigationTimeout, 10) || 30) * 1000;
+      (isNaN(Number(this.config.defaultNavigationTimeout)) ? 30 : Number(this.config.defaultNavigationTimeout))
+      * 1000
+    ;
     this.defaultTimeout =
-      (parseInt(
-        this.config.defaultPageTimeout || this.config.defaultTimeout,
-        10
-      ) || 30) * 1000;
+      (isNaN(Number(
+        this.config.defaultPageTimeout || this.config.defaultTimeout
+      )) ? 30 : Number(this.config.defaultPageTimeout || this.config.defaultTimeout)) * 1000;
 
     this.testIdAttribute = this.config.testIdAttribute;
 

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -18,9 +18,9 @@ class PlaywrightEngine {
       * 1000
     ;
     this.defaultTimeout =
-      (isNaN(Number(
-        this.config.defaultPageTimeout || this.config.defaultTimeout
-      )) ? 30 : Number(this.config.defaultPageTimeout || this.config.defaultTimeout)) * 1000;
+      (isNaN(Number(this.config.defaultTimeout)) ? 30 : Number(this.config.defaultTimeout))
+      * 1000
+    ;
 
     this.testIdAttribute = this.config.testIdAttribute;
 


### PR DESCRIPTION
fixes #2785

## Description

`0` is a falsy value, so `0 || 30` will get `30` which is not what we want (`0` is a valid timeout setting, meaning no timeout).

I've used `Number` instead of `parseInt`, which is less verbose and in our case just better.
Maybe styling is not good, I'll look at the PR checks (edit: seems like they are skipped for the moment, let me know).
Speaking of lengh of lines, I found out two new questions :
- why are the setting in seconds instead of millis like the playwright config ? Isn't it just reducing the possibilities, for no gain (and les readable code here) ?
- where is `defaultPageTimeout` coming from ? It does not exist in playwright, and is not mentioned in artillery's doc neither. (so as you see I did not added a falsy protection on it)

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
