### PR TITLE
fix(http): check if default strictCapture is set to false

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -856,9 +856,14 @@ function lastRequest(res, requestParams) {
 HttpEngine.prototype.setInitialContext = function (initialContext) {
   initialContext._successCount = 0;
 
-  initialContext._defaultStrictCapture =
-    this.config.http.defaults.strictCapture ||
-    this.config.defaults.strictCapture;
+  initialContext._defaultStrictCapture = true;
+  if (
+    this.config.http?.defaults?.strictCapture === false ||
+    this.config.defaults?.strictCapture === false
+  ) {
+    initialContext._defaultStrictCapture = false;
+  }
+
   initialContext._jar = new tough.CookieJar(
     null,
     this.config.http.cookieJarOptions


### PR DESCRIPTION
## Description

Fixes `config.http.defaults.strictCapture` not being taken into account when set to "false". Change to an explicit check to avoid it being set to `undefined` with current check.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? - No
- [ ] Does this require a changelog entry? - Yes
