### PR TITLE
ci: add action for publishing cf templates to s3

### DIFF
--- a/.github/workflows/s3-publish-cf-templates.yml
+++ b/.github/workflows/s3-publish-cf-templates.yml
@@ -1,0 +1,15 @@
+name: Publish CloudFormation templates to AWS S3
+
+on:
+  workflow_dispatch:
+
+jobs:
+  put-cloudformation-templates:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: "Hello world"
+        run: echo "Hello world"


### PR DESCRIPTION
## Description

This will be part of a larger task to create and publish codified CF templates for IAM permissions needed for Artillery.

In order to test the workflow e2e, it must exist already on `main`, so just creating a dummy workflow first.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Later, when the full work is done
- [ ] Does this require a changelog entry? Later, when the full work is done
