### PR TITLE
fix(lambda): handle function creation conflicts correctly

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -635,13 +635,19 @@ class PlatformLambda {
     };
 
     const configHash = crypto
-      .createHash('sha256')
+      .createHash('md5')
       .update(JSON.stringify(changeableConfig))
       .digest('hex');
 
-    return `artilleryio-v${this.currentVersion.replace(/\./g, '-')}-${
+    let name = `artilleryio-v${this.currentVersion.replace(/\./g, '-')}-${
       this.architecture
     }-${configHash}`;
+
+    if (name.length > 64) {
+      name = name.slice(0, 64);
+    }
+
+    return name;
   }
 
   async createLambda(opts) {


### PR DESCRIPTION
## Description

This PR slightly changes how the function creation works. We now hash any changeable config and add that to the name, so that a change in config is handled properly. This prevents a function update on the same function causing some of the invokes to use one function configuration, and other invokes another.

Additionally, we also look for `ResourceConflictException` when creating the function, so that if a function already exists that looks like that, we don't create another. 

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?