### PR TITLE
ci(test): run aws tests against published versions

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -42,6 +42,8 @@ jobs:
       packages: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    outputs:
+      ARTILLERY_VERSION: ${{ steps.get-artillery-version.outputs.ARTILLERY_VERSION }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -65,8 +67,27 @@ jobs:
       - run: npm -w artillery-plugin-fake-data publish --tag canary
       - run: npm -w artillery-plugin-slack publish --tag canary
       - run: npm -w artillery publish --tag canary
+      - id: get-artillery-version
+        run: |
+          ARTILLERY_VERSION=$(node -e "console.log(require('./packages/artillery/package.json').version)")
+          echo "ARTILLERY_VERSION=$ARTILLERY_VERSION" >> $GITHUB_OUTPUT
       # Skytrace is a Typescript Package and needs to install -> build -> publish
       - run: npm install -w skytrace --ignore-scripts
       - run: npm run build -w skytrace
       - run: npm -w skytrace publish --tag canary
       - run: npm -w artillery-plugin-memory-inspector publish --tag canary
+
+  run-distributed-tests:
+    uses: ./.github/workflows/run-distributed-tests.yml
+    needs: build
+    with:
+      ARTILLERY_VERSION_OVERRIDE: ${{ needs.build.outputs.ARTILLERY_VERSION }}
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      ARTILLERY_CLOUD_ENDPOINT_TEST: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+      ARTILLERY_CLOUD_API_KEY_TEST: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+      DD_TESTS_API_KEY: ${{ secrets.DD_TESTS_API_KEY }}
+      DD_TESTS_APP_KEY: ${{ secrets.DD_TESTS_APP_KEY }}
+      AWS_TEST_EXECUTION_ROLE_ARN_TEST5: ${{ secrets.AWS_TEST_EXECUTION_ROLE_ARN_TEST5 }}

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -32,6 +32,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      ARTILLERY_VERSION: ${{ steps.get-artillery-version.outputs.ARTILLERY_VERSION }}
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # this list should be kept in sync with create-release-pr.yml
@@ -67,6 +69,10 @@ jobs:
       - run: npm -w artillery-plugin-fake-data publish
       - run: npm -w artillery-plugin-slack publish
       - run: npm -w artillery publish
+      - id: get-artillery-version
+        run: |
+          ARTILLERY_VERSION=$(node -e "console.log(require('./packages/artillery/package.json').version)")
+          echo "ARTILLERY_VERSION=$ARTILLERY_VERSION" >> $GITHUB_OUTPUT
       # # Skytrace is a Typescript Package and needs to install -> build -> publish
       # - run: npm install -w skytrace --ignore-scripts
       # - run: npm run build -w skytrace
@@ -83,3 +89,18 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  run-distributed-tests:
+    uses: ./.github/workflows/run-distributed-tests.yml
+    needs: publish-packages-to-npm
+    with:
+      ARTILLERY_VERSION_OVERRIDE: ${{ needs.publish-packages-to-npm.outputs.ARTILLERY_VERSION }}
+    permissions:
+      contents: read
+      id-token: write
+    secrets:
+      ARTILLERY_CLOUD_ENDPOINT_TEST: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+      ARTILLERY_CLOUD_API_KEY_TEST: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+      DD_TESTS_API_KEY: ${{ secrets.DD_TESTS_API_KEY }}
+      DD_TESTS_APP_KEY: ${{ secrets.DD_TESTS_APP_KEY }}
+      AWS_TEST_EXECUTION_ROLE_ARN_TEST5: ${{ secrets.AWS_TEST_EXECUTION_ROLE_ARN_TEST5 }}

--- a/.github/workflows/run-aws-tests-on-pr.yml
+++ b/.github/workflows/run-aws-tests-on-pr.yml
@@ -1,4 +1,4 @@
-name: Run AWS tests
+name: Run AWS tests (on PR)
 
 on:
   pull_request_target:

--- a/.github/workflows/run-distributed-tests.yml
+++ b/.github/workflows/run-distributed-tests.yml
@@ -1,4 +1,4 @@
-name: Run AWS tests
+name: Run distributed tests
 
 on:
   workflow_call:
@@ -58,7 +58,6 @@ jobs:
       contents: read
       id-token: write
     env:
-      ECR_IMAGE_VERSION: ${{ inputs.COMMIT_SHA || github.sha }}
       ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
       ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
       DD_TESTS_API_KEY: ${{ secrets.DD_TESTS_API_KEY }}
@@ -84,6 +83,17 @@ jobs:
           node-version: 18.x
       - run: npm install
       - run: npm run build
+      - name: Install Specific Artillery Version if needed
+        if: ${{ inputs.ARTILLERY_VERSION_OVERRIDE || false }}
+        run: mkdir __artillery__ && cd __artillery__ && npm init -y && npm install artillery@${{ inputs.ARTILLERY_VERSION_OVERRIDE }}
+      - name: Set A9_PATH
+        if: ${{ inputs.ARTILLERY_VERSION_OVERRIDE || false }}
+        run: echo "A9_PATH=${{ github.workspace }}/__artillery__/node_modules/.bin/artillery" >> $GITHUB_ENV
+      - name: Set ECR Image Version if needed
+        if: ${{ inputs.COMMIT_SHA }}
+        run: |
+          echo "ECR_IMAGE_VERSION=${{ inputs.COMMIT_SHA }}" >> $GITHUB_ENV
+          echo "LAMBDA_IMAGE_VERSION=${{ inputs.COMMIT_SHA }}" >> $GITHUB_ENV
       # runs the single test file from `package` workspace in the `file`, as defined in the matrix output
       - run: npm run test:aws:ci --workspace ${{fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].package }} -- --files ${{ fromJson(needs.generate-test-matrix.outputs.matrix).namesToFiles[matrix.testName].file }}
         env:

--- a/packages/artillery-engine-playwright/test/fargate.aws.js
+++ b/packages/artillery-engine-playwright/test/fargate.aws.js
@@ -1,4 +1,4 @@
-const { test, afterEach, beforeEach } = require('tap');
+const { test, afterEach, beforeEach, before } = require('tap');
 const { $ } = require('zx');
 const { getTestTags } = require('../../artillery/test/cli/_helpers.js');
 const fs = require('fs');
@@ -15,9 +15,14 @@ afterEach(async () => {
   fs.unlinkSync(playwrightOutput);
 });
 
+const A9_PATH = process.env.A9_PATH || '../artillery/bin/run';
+before(async () => {
+  await $`${A9_PATH} -V`;
+});
+
 test('playwright typescript test works and reports data', async (t) => {
   const output =
-    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --tags ${tags} --record`;
+    await $`${A9_PATH} run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --tags ${tags} --record`;
 
   t.equal(
     output.exitCode,
@@ -122,7 +127,7 @@ test('playwright typescript test fails and has correct vu count when expectation
   });
 
   try {
-    await $`../artillery/bin/run run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --overrides ${scenarioOverride} --tags ${tags} --record`;
+    await $`${A9_PATH} run:fargate ./test/fixtures/pw-acceptance-ts.yml --output ${playwrightOutput} --overrides ${scenarioOverride} --tags ${tags} --record`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(

--- a/packages/artillery/test/cloud-e2e/fargate/bom.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/bom.test.js
@@ -7,10 +7,10 @@ const {
   execute
 } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -54,7 +54,7 @@ test('Run mixed-hierarchy', async (t) => {
   const configPath = `${__dirname}/fixtures/mixed-hierarchy/config/config.yml`;
 
   const output =
-    await $`${A9} run-fargate ${scenarioPath} --config ${configPath} -e main --record --tags ${baseTags} --output ${reportFilePath}`;
+    await $`${A9_PATH} run-fargate ${scenarioPath} --config ${configPath} -e main --record --tags ${baseTags} --output ${reportFilePath}`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/fargate/cw-adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/cw-adot.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { test, afterEach, beforeEach } = require('tap');
+const { test, afterEach, beforeEach, before } = require('tap');
 const { $ } = require('zx');
 const fs = require('fs');
 const {
@@ -8,9 +8,9 @@ const {
   deleteFile,
   getTestTags
 } = require('../../cli/_helpers.js');
-
 const { getTestId, getXRayTraces } = require('./fixtures/adot/helpers.js');
 
+const A9_PATH = process.env.A9_PATH || 'artillery';
 // NOTE: This test reports to Artillery Dashboard to dogfood and improve visibility
 const baseTags = getTestTags(['type:acceptance']);
 
@@ -21,6 +21,10 @@ beforeEach(async (t) => {
 
 afterEach(async (t) => {
   deleteFile(reportFilePath);
+});
+
+before(async () => {
+  await $`${A9_PATH} -V`;
 });
 
 test('traces succesfully arrive to cloudwatch', async (t) => {
@@ -36,7 +40,7 @@ test('traces succesfully arrive to cloudwatch', async (t) => {
 
   // Act:
   const output =
-    await $`artillery run-fargate ${__dirname}/fixtures/adot/adot-cloudwatch.yml --record --tags ${baseTags} --output ${reportFilePath}`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/adot/adot-cloudwatch.yml --record --tags ${baseTags} --output ${reportFilePath}`;
 
   const testId = getTestId(output.stdout);
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));

--- a/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/dd-adot.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { test, afterEach, beforeEach } = require('tap');
+const { test, afterEach, beforeEach, before } = require('tap');
 const { $ } = require('zx');
 const fs = require('fs');
 const {
@@ -11,6 +11,7 @@ const {
 
 const { getDatadogSpans, getTestId } = require('./fixtures/adot/helpers.js');
 
+const A9_PATH = process.env.A9_PATH || 'artillery';
 //NOTE: This test reports to Artillery Dashboard to dogfood and improve visibility
 const baseTags = getTestTags(['type:acceptance']);
 
@@ -21,6 +22,10 @@ beforeEach(async (t) => {
 
 afterEach(async (t) => {
   deleteFile(reportFilePath);
+});
+
+before(async () => {
+  await $`${A9_PATH} -V`;
 });
 
 test('traces succesfully arrive to datadog', async (t) => {
@@ -43,7 +48,7 @@ test('traces succesfully arrive to datadog', async (t) => {
 
   // Act:
   const output =
-    await $`artillery run-fargate ${__dirname}/fixtures/adot/adot-dd-pass.yml --record --tags ${baseTags} --output ${reportFilePath}`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/adot/adot-dd-pass.yml --record --tags ${baseTags} --output ${reportFilePath}`;
 
   const testId = getTestId(output.stdout);
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));

--- a/packages/artillery/test/cloud-e2e/fargate/ensure-plugin.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/ensure-plugin.test.js
@@ -4,10 +4,10 @@ const chalk = require('chalk');
 const fs = require('fs');
 const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -19,7 +19,7 @@ beforeEach(async (t) => {
 
 test('Run uses ensure', async (t) => {
   try {
-    await $`${A9} run:fargate ${__dirname}/fixtures/uses-ensure/with-ensure.yaml --record --tags ${baseTags} --output ${reportFilePath} --count 15`;
+    await $`${A9_PATH} run:fargate ${__dirname}/fixtures/uses-ensure/with-ensure.yaml --record --tags ${baseTags} --output ${reportFilePath} --count 15`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
@@ -4,10 +4,10 @@ const chalk = require('chalk');
 const fs = require('fs');
 const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -19,7 +19,7 @@ beforeEach(async (t) => {
 
 test('CLI should exit with non-zero exit code when there are failed expectations in workers', async (t) => {
   try {
-    await $`${A9} run-fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
@@ -42,7 +42,7 @@ test('Ensure (with new interface) should still run when workers exit from expect
   //Note: this test uses new ensure plugin interface (config.plugins.ensure) to test that indirectly
 
   try {
-    await $`${A9} run:fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect-ensure.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
+    await $`${A9_PATH} run:fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect-ensure.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/fargate/memory.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/memory.test.js
@@ -2,10 +2,10 @@ const { test, before, beforeEach } = require('tap');
 const { $ } = require('zx');
 const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -13,7 +13,7 @@ const baseTags = getTestTags(['type:acceptance']);
 
 test('Fargate should exit with error code when workers run out of memory', async (t) => {
   try {
-    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:true --region us-east-1`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:true --region us-east-1`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
@@ -25,7 +25,7 @@ test('Fargate should exit with error code when workers run out of memory', async
 
 test('Fargate should not run out of memory when cpu and memory is increased via launch config', async (t) => {
   const output =
-    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --launch-config '{"cpu":"4096", "memory":"12288"}'`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --launch-config '{"cpu":"4096", "memory":"12288"}'`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
   t.match(output, /summary report/i, 'print summary report');
@@ -34,7 +34,7 @@ test('Fargate should not run out of memory when cpu and memory is increased via 
 
 test('Fargate should not run out of memory when cpu and memory is increased via flags', async (t) => {
   const output =
-    await $`${A9} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --cpu 4 --memory 12`;
+    await $`${A9_PATH} run-fargate ${__dirname}/fixtures/memory-hog/memory-hog.yml --record --tags ${baseTags},should_fail:false --region us-east-1 --cpu 4 --memory 12`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
   t.match(output, /summary report/i, 'print summary report');

--- a/packages/artillery/test/cloud-e2e/fargate/misc.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/misc.test.js
@@ -4,10 +4,10 @@ const chalk = require('chalk');
 const fs = require('fs');
 const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -30,7 +30,7 @@ test('Kitchen Sink Test - multiple features together', async (t) => {
   };
 
   const output =
-    await $`${A9} run-fargate ${scenarioPath} --output ${reportFilePath} --dotenv ${dotEnvPath} --record --tags ${baseTags} --count 2 --region us-east-2 --spot --launch-config ${JSON.stringify(
+    await $`${A9_PATH} run-fargate ${scenarioPath} --output ${reportFilePath} --dotenv ${dotEnvPath} --record --tags ${baseTags} --count 2 --region us-east-2 --spot --launch-config ${JSON.stringify(
       launchConfig
     )}`;
 
@@ -83,7 +83,7 @@ test('Run lots-of-output', async (t) => {
   $.verbose = false; // we don't want megabytes of output on the console
 
   const output =
-    await $`${A9} run:fargate ${__dirname}/fixtures/large-output/lots-of-output.yml --record --tags ${baseTags}`;
+    await $`${A9_PATH} run:fargate ${__dirname}/fixtures/large-output/lots-of-output.yml --record --tags ${baseTags}`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 

--- a/packages/artillery/test/cloud-e2e/fargate/processors.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/processors.test.js
@@ -4,10 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 
-const A9 = process.env.A9 || 'artillery';
+const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
-  await $`${A9} -V`;
+  await $`${A9_PATH} -V`;
 });
 
 //NOTE: all these tests report to Artillery Dashboard to dogfood and improve visibility
@@ -21,7 +21,7 @@ test('Run with typescript processor and external package', async (t) => {
   const scenarioPath = `${__dirname}/fixtures/ts-external-pkg/with-external-foreign-pkg.yml`;
 
   const output =
-    await $`${A9} run-fargate ${scenarioPath} --output ${reportFilePath} --record --tags ${baseTags},typescript:true`;
+    await $`${A9_PATH} run-fargate ${scenarioPath} --output ${reportFilePath} --record --tags ${baseTags},typescript:true`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
@@ -45,7 +45,7 @@ test('Run a test with an ESM processor', async (t) => {
   );
 
   const output =
-    await $`${A9} run-fargate ${scenarioPath} --output ${reportFilePath} --record --tags ${baseTags}`;
+    await $`${A9_PATH} run-fargate ${scenarioPath} --output ${reportFilePath} --record --tags ${baseTags}`;
 
   t.equal(output.exitCode, 0, 'CLI exit code should be 0');
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -5,9 +5,14 @@ const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
 
 const tags = getTestTags(['type:acceptance']);
 
+const A9_PATH = process.env.A9_PATH || 'artillery';
+
+tap.before(async () => {
+  await $`${A9_PATH} -V`;
+});
+
 let reportFilePath;
 tap.beforeEach(async (t) => {
-  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
   process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
@@ -16,7 +21,7 @@ tap.test('Run simple-bom', async (t) => {
   const scenarioPath = `${__dirname}/../fargate/fixtures/simple-bom/simple-bom.yml`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
@@ -34,7 +39,7 @@ tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -4,10 +4,14 @@ const { $ } = require('zx');
 const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
 
 const tags = getTestTags(['type:acceptance']);
+const A9_PATH = process.env.A9_PATH || 'artillery';
+
+tap.before(async () => {
+  await $`${A9_PATH} -V`;
+});
 
 let reportFilePath;
 tap.beforeEach(async (t) => {
-  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
   process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
@@ -17,7 +21,7 @@ tap.test('Run dotenv test in Lambda Container', async (t) => {
   const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
 
   const output =
-    await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
@@ -8,14 +8,18 @@ const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 const tags = getTestTags(['type:acceptance']);
 let reportFilePath;
 tap.beforeEach(async (t) => {
-  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
   process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
 });
 
+const A9_PATH = process.env.A9_PATH || 'artillery';
+tap.before(async () => {
+  await $`${A9_PATH} -V`;
+});
+
 tap.test('Lambda Container run uses ensure', async (t) => {
   try {
-    await $`artillery run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --container --tags ${tags} --output ${reportFilePath} --count 15`;
+    await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --container --tags ${tags} --output ${reportFilePath} --count 15`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -7,16 +7,20 @@ const { generateTmpReportPath, getTestTags } = require('../../cli/_helpers.js');
 const tags = getTestTags(['type:acceptance']);
 let reportFilePath;
 tap.beforeEach(async (t) => {
-  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
   process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+const A9_PATH = process.env.A9_PATH || 'artillery';
+tap.before(async () => {
+  await $`${A9_PATH} -V`;
 });
 
 tap.test(
   'CLI should exit with non-zero exit code when there are failed expectations in container workers',
   async (t) => {
     try {
-      await $`artillery run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
+      await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
       t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
     } catch (output) {
       t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
@@ -7,9 +7,13 @@ const tags = getTestTags(['type:acceptance']);
 
 let reportFilePath;
 tap.beforeEach(async (t) => {
-  process.env.LAMBDA_IMAGE_VERSION = process.env.ECR_IMAGE_VERSION;
   process.env.RETAIN_LAMBDA = 'false';
   reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+const A9_PATH = process.env.A9_PATH || 'artillery';
+tap.before(async () => {
+  await $`${A9_PATH} -V`;
 });
 
 tap.test('Run a test on AWS Lambda using containers', async (t) => {
@@ -17,7 +21,7 @@ tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
   const output =
-    await $`artillery run-lambda --count 10 --region us-east-1 --architecture x86_64 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
+    await $`${A9_PATH} run-lambda --count 10 --region us-east-1 --architecture x86_64 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
 
   t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 
@@ -47,7 +51,7 @@ tap.test(
     const scenarioPath = `${__dirname}/fixtures/ts-external-pkg/with-external-foreign-pkg.yml`;
 
     const output =
-      await $`artillery run-lambda ${scenarioPath} --architecture x86_64 --container --record --output ${reportFilePath} --tags ${tags},typescript:true`;
+      await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --container --record --output ${reportFilePath} --tags ${tags},typescript:true`;
 
     t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 


### PR DESCRIPTION
## Description

This gives us the ability to run tests after NPM publish (canary or mainline).

Follow up of https://github.com/artilleryio/artillery/pull/2805.

Triggers the reusable workflow for AWS tests from NPM publish workflows, overriding the new `A9_PATH` env variable with the path to a locally freshly installed NPM version (after publish). Tests will then use that version rather than local workspace version.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
