### PR TITLE
fix(cli): remove worker error message when expect errors in workers

### DIFF
--- a/packages/artillery-plugin-expect/index.js
+++ b/packages/artillery-plugin-expect/index.js
@@ -183,7 +183,7 @@ function expectationsPluginCheckExpectations(
   }
 
   if (global.artillery) {
-    global.artillery.suggestedExitCode = 1;
+    global.artillery.suggestedExitCode = 21;
   }
 
   if (userContext.expectationsPlugin.reportFailuresAsErrors) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1917,11 +1917,14 @@ async function listen(context, ee) {
           )
         );
       }
-      artillery.log(
-        chalk.yellow(
-          `Worker exited with an error, worker ID = ${attrs.workerId.StringValue}`
-        )
-      );
+      if (body.exitCode != 21) {
+        artillery.log(
+          chalk.yellow(
+            `Worker exited with an error, worker ID = ${attrs.workerId.StringValue}`
+          )
+        );
+      }
+
       // TODO: Copy log over and print path to log file so that user may inspect it - in a temporary location
       global.artillery.suggestedExitCode = body.exitCode || 1;
     });

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -26,6 +26,7 @@ declare -r ERR_INTERRUPTED=7
 declare -r ERR_UNKNOWN_PLATFORM=8
 declare -r ERR_DEP=9
 declare -r ERR_DEP_INSTALL=10 # npm install / yarn install failed
+declare -r ERR_CLI_ERROR_EXPECT=21
 
 ERR_EXTRA_INFO=""
 
@@ -314,6 +315,8 @@ run_a9 () {
 
     if [[ $CLI_STATUS -eq 0 ]] ; then
         EXIT_CODE=0
+    elif [[ $CLI_STATUS -eq $ERR_CLI_ERROR_EXPECT ]] ; then
+        EXIT_CODE=$ERR_CLI_ERROR_EXPECT
     else
         EXIT_CODE=$ERR_CLI_ERROR
     fi

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -302,15 +302,17 @@ class PlatformLambda {
           } else if (body.event === 'workerError') {
             global.artillery.suggestedExitCode = body.exitCode || 1;
 
-            this.events.emit(body.event, workerId, {
-              id: workerId,
-              error: new Error(
-                `A Lambda function has exited with an error. Reason: ${body.reason}`
-              ),
-              level: 'error',
-              aggregatable: false,
-              logs: body.logs
-            });
+            if (body.exitCode != 21) {
+              this.events.emit(body.event, workerId, {
+                id: workerId,
+                error: new Error(
+                  `A Lambda function has exited with an error. Reason: ${body.reason}`
+                ),
+                level: 'error',
+                aggregatable: false,
+                logs: body.logs
+              });
+            }
           } else if (body.event == 'workerReady') {
             this.events.emit(body.event, workerId);
             this.waitingReadyCount++;

--- a/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/expect-plugin.test.js
@@ -22,7 +22,12 @@ test('CLI should exit with non-zero exit code when there are failed expectations
     await $`${A9} run-fargate ${__dirname}/fixtures/cli-exit-conditions/with-expect.yml --record --tags ${baseTags} --output ${reportFilePath} --count 2`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
-    t.equal(output.exitCode, 6, 'CLI Exit Code should be 6');
+    t.equal(output.exitCode, 21, 'CLI Exit Code should be 21');
+
+    t.ok(
+      !output.stderr.includes('Worker exited with an error'),
+      'Should not have worker exit error message in stdout'
+    );
 
     const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
     t.equal(

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -19,7 +19,11 @@ tap.test(
       await $`artillery run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
       t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
     } catch (output) {
-      t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');
+      t.equal(output.exitCode, 21, 'CLI Exit Code should be 21');
+      t.ok(
+        !output.stderr.includes('Worker exited with an error'),
+        'Should not have worker exit error message in stdout'
+      );
 
       const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
       t.equal(


### PR DESCRIPTION
## Description

This PR removes the error messages that show up when running expect in distributed tests (`Worker exited with an error, worker ID = <id>`) by giving a specific exit code to expect that can be caught in distributed tests.

This may get further improvements in the future, but right now it's the easiest way to avoid the confusing error message.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry? Yes
