### PR TITLE
feat(ci): adding GHA for testing AWS IAM setup

### DIFF
--- a/.github/workflows/test-iam-setup-using-cf-templates.yml
+++ b/.github/workflows/test-iam-setup-using-cf-templates.yml
@@ -1,0 +1,15 @@
+name: Test CLI AWS IAM permissions setup
+
+on:
+  workflow_dispatch:
+
+jobs:
+  set-up-iam-and-run-lambda-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: "Hello world"
+        run: echo "Hello world"


### PR DESCRIPTION
## Description

This will be part of a larger task to test setting up AWS IAM permissions necessary to run tests on Lambda/Fargate and then running Lambda/Fargate test respectively. 

The IAM permissions will be set up on a clean AWS account by deploying the CloudFormation templates that contain the policy definition as we provide it to the users in our docs.

In order to test the workflow e2e, it must exist already on `main`, so just creating a dummy workflow first.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Later, when the full work is done
- [ ] Does this require a changelog entry? Later, when the full work is done
