### PR TITLE
feat(lambda): remove experimental status from lambda

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -108,7 +108,7 @@ class PlatformLambda {
   }
 
   async init() {
-    artillery.log('λ Creating AWS Lambda function...');
+    artillery.log('λ Preparing AWS Lambda function...');
 
     await setDefaultAWSCredentials(AWS);
     this.accountId = await getAccountId();

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -108,10 +108,6 @@ class PlatformLambda {
   }
 
   async init() {
-    artillery.log(
-      'NOTE: AWS Lambda support is experimental. Not all Artillery features work yet.\nFor details please see https://docs.art/aws-lambda'
-    );
-    artillery.log();
     artillery.log('λ Creating AWS Lambda function...');
 
     await setDefaultAWSCredentials(AWS);


### PR DESCRIPTION
## Description

Lambda is in a good state parity-wise with Fargate support, and doesn't need to be considered experimental anymore.

https://github.com/artilleryio/artillery/commit/e3bd9bf9998b35af7cd2ab6016d768c12c06651b also changes `Creating` to `Preparing`, to better align with the fact that it doesn't always create a new Lambda Function anymore.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Maybe to say it's no longer experimental.