### PR TITLE
feat(lambda): remove --container flag

### DIFF
--- a/packages/artillery/lib/cmds/run-lambda.js
+++ b/packages/artillery/lib/cmds/run-lambda.js
@@ -60,13 +60,6 @@ RunLambdaCommand.flags = {
     // locally defaults to number of CPUs with mode = distribute
     default: '1'
   }),
-  container: Flags.boolean({
-    description: 'Use a container image for Lambda',
-    deprecated: {
-      message:
-        'The --container flag has been deprecated. Container images are now the default mode for Lambda functions.'
-    }
-  }),
   architecture: Flags.string({
     description: 'Architecture of the Lambda function',
     default: 'arm64',

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -377,7 +377,7 @@ function getExtraFiles(context, next) {
 function getDotEnv(context, next) {
   const flags = context.opts.flags;
   //TODO: For now only enabled on Lambda. Enable this for Fargate after refactoring to allow for it
-  if (!flags.dotenv || !flags.container || flags.platform !== 'aws:lambda') {
+  if (!flags.dotenv || flags.platform !== 'aws:lambda') {
     return next(null, context);
   }
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -21,7 +21,7 @@ tap.test('Run simple-bom', async (t) => {
   const scenarioPath = `${__dirname}/../fargate/fixtures/simple-bom/simple-bom.yml`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record --container`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
@@ -39,7 +39,7 @@ tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record --container`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -21,7 +21,7 @@ tap.test('Run dotenv test in Lambda Container', async (t) => {
   const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --container --dotenv ${dotenvPath}`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --dotenv ${dotenvPath}`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -21,7 +21,7 @@ tap.test('Run dotenv test in Lambda Container', async (t) => {
   const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 5 --record --dotenv ${dotenvPath}`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --dotenv ${dotenvPath} --output ${reportFilePath} --count 5 --record`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
@@ -19,7 +19,7 @@ tap.before(async () => {
 
 tap.test('Lambda Container run uses ensure', async (t) => {
   try {
-    await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --container --tags ${tags} --output ${reportFilePath} --count 15`;
+    await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 15`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -20,7 +20,7 @@ tap.test(
   'CLI should exit with non-zero exit code when there are failed expectations in container workers',
   async (t) => {
     try {
-      await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --container --count 2`;
+      await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --count 2`;
       t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
     } catch (output) {
       t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
@@ -21,7 +21,7 @@ tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
 
   const output =
-    await $`${A9_PATH} run-lambda --count 10 --region us-east-1 --architecture x86_64 --container --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
+    await $`${A9_PATH} run-lambda --count 10 --region us-east-1 --architecture x86_64 --config ${configPath} --record --tags ${tags} ${scenarioPath}`;
 
   t.equal(output.exitCode, 0, 'CLI should exit with code 0');
 
@@ -51,7 +51,7 @@ tap.test(
     const scenarioPath = `${__dirname}/fixtures/ts-external-pkg/with-external-foreign-pkg.yml`;
 
     const output =
-      await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --container --record --output ${reportFilePath} --tags ${tags},typescript:true`;
+      await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --record --output ${reportFilePath} --tags ${tags},typescript:true`;
 
     t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 


### PR DESCRIPTION
## Description

Remove unnecessary `--container` flag. This was a temporary measure while we improved Lambda, but is now unnecessary, and will only affect people specifically on version `2.0.12` where `--container` was not the default.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
