### PR TITLE
test(cli): use zx with env vars on simple bom fargate test

### DIFF
--- a/packages/artillery/test/cloud-e2e/fargate/bom.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/bom.test.js
@@ -3,8 +3,7 @@ const { $ } = require('zx');
 const fs = require('fs');
 const {
   generateTmpReportPath,
-  getTestTags,
-  execute
+  getTestTags
 } = require('../../cli/_helpers.js');
 
 const A9_PATH = process.env.A9_PATH || 'artillery';
@@ -24,21 +23,11 @@ beforeEach(async (t) => {
 
 test('Run simple-bom', async (t) => {
   const scenarioPath = `${__dirname}/fixtures/simple-bom/simple-bom.yml`;
-  const [exitCode, output] = await execute([
-    'run-fargate',
-    '--environment',
-    'test',
-    '--region',
-    'eu-west-1',
-    '--count',
-    '51',
-    '--tags',
-    baseTags,
-    '--record',
-    scenarioPath
-  ]);
 
-  t.equal(exitCode, 0, 'CLI Exit Code should be 0');
+  const output =
+    await $`${A9_PATH} run-fargate ${scenarioPath} --environment test --region eu-west-1 --count 51 --tags ${baseTags} --record`;
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
   t.match(output.stdout, /summary report/i, 'print summary report');
   t.match(output.stdout, /p99/i, 'a p99 value is reported');


### PR DESCRIPTION
## Description

Noticed the right version isn't being picked up by this specific test. Need to use `zx` so the path to the executable will be correctly overridden by the workflow.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
