### PR TITLE
fix: handle SIGTERM correctly on Fargate

### DIFF
--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -337,10 +337,10 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
     var finalReport = {};
     var shuttingDown = false;
     process.on('SIGINT', async () => {
-      gracefulShutdown({ earlyStop: true });
+      gracefulShutdown({ earlyStop: true, exitCode: 130 });
     });
     process.on('SIGTERM', async () => {
-      gracefulShutdown({ earlyStop: true });
+      gracefulShutdown({ earlyStop: true, exitCode: 143 });
     });
 
     async function gracefulShutdown(opts = { exitCode: 0 }) {

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -418,9 +418,19 @@ cleanup () {
         if [[ $CLI_RUNNING = "yes" ]] ; then
             printf "Interrupted with %s, stopping\n" "$sig"
             EXIT_CODE=$ERR_INTERRUPTED
-            kill -TERM $CLI_PID # TODO: Check handling in A9 CLI
-            wait $CLI_PID
-            CLI_STATUS=$(cat exitCode) # TODO: Could be 0, but is not a successful run
+            kill -TERM $CLI_PID
+            set +e
+            timeout 20 tail --pid $CLI_PID -f /dev/null
+            if [[ $? -eq 124 ]] ; then
+                # timeout exits with 124 if the process it's waiting on is still running
+                # i.e. if tail is still running it means the Artillery CLI did not exit:
+                kill -KILL $CLI_PID
+                CLI_STATUS=143 # SIGTERM (128 + 15)
+            else
+                # Preserve the exit code of the CLI
+                CLI_STATUS=$(cat exitCode)
+            fi
+            set -e
             CLI_RUNNING="no"
         fi
 


### PR DESCRIPTION
## Description

Fix handling of `SIGTERM`:

- Exit with appropriate exit code (143) from the `run` command
- On Fargate (e.g. when stopped early by Fargate Spot, or via explicit task stop, e.g. through `aws ecs stop-task`) - replace the use of `wait` with `timeout`. `wait` cannot be used for processes that run in a subshell - https://github.com/artilleryio/artillery/blob/27fae398ce0d6bab5f4226e361a9de6d4d8bec2a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker#L277

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
