### PR TITLE
fix(ecs): set ADOT's cpu/memory config only if the container exists

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1201,7 +1201,7 @@ async function ensureTaskExists(context) {
 
     context.taskDefinition = taskDefinition;
 
-    if (!context.isFargate) {
+    if (!context.isFargate && taskDefinition.containerDefinitions.length > 1) {
       // Limits for sidecar have to be set explicitly on ECS EC2
       taskDefinition.containerDefinitions[1].memory = 1024;
       taskDefinition.containerDefinitions[1].cpu = 1024;


### PR DESCRIPTION
## Description

Trying to run a test on an ECS EC2 container with `artillery run-fargate --launch-type ecs:ec2` currently fails because Artillery tries to set cpu/memory config explicitly for ADOT containers on ECS EC2, which does not always exist.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
