### PR TITLE
fix(fargate): wait for ECS worker role to be available

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -18,6 +18,8 @@ const {
 
 const getAccountId = require('../aws/aws-get-account-id');
 
+const sleep = require('../../util/sleep');
+
 class PlatformECS {
   constructor(script, payload, opts, platformOpts) {
     this.opts = opts;
@@ -233,6 +235,8 @@ async function createWorkerRole(accountId) {
     })
     .promise();
 
+  debug('Waiting for IAM role to be ready');
+  await sleep(30 * 1000);
   return createRoleResp.Role.Arn;
 }
 


### PR DESCRIPTION
## Description
Adding a 30s wait after creating the IAM `artilleryio-ecs-worker-role` in order to make sure the IAM role is created and ready before using it. 

### Context
When a Fargate test runs for the first time on an AWS account, Artillery creates the `artilleryio-ecs-worker-role`, but doesn't wait before attempting to use the role. 
While creating the e2e tests in https://github.com/artilleryio/artillery/pull/2800 it was found that sometimes the IAM role is not ready in time an the following error occurs:

This is added because it was discovered that in some occasions the `artilleryio-ecs-worker-role` will not be ready in time and the following error will occur:
`ClientException: ECS was unable to assume the role 'arn:aws:iam::***:role/artilleryio-ecs-worker-role' that was provided for this task. Please verify that the role being passed has the proper trust relationship and permissions and that your IAM user has permissions to pass this role.`

To resolve this a wait of 30s will be added after creating the role, before the attempt to use it. 
As Artillery creates the role only if it does not exist on the account already, this wait will only happen the first time a user runs a Fargate test.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [x] Does this require a changelog entry?
