### PR TITLE
dep(core): use rc of tough-cookie to fix deprecated package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18284,10 +18284,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "license": "MIT"
-    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "dev": true,
@@ -18315,7 +18311,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20677,6 +20675,24 @@
         "tinycolor2": "^1.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.27.tgz",
+      "integrity": "sha512-FoCm8k5dd2Aw0waigesduQAbOXWVi31XMo0+DcCJc67wolyy0dORRf7CUkIxl49ZgI8N4zelPehy3QanbOLnKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.27.tgz",
+      "integrity": "sha512-uGoj4yLqgFdgF82UpR1wCweJUcd/qMdm97VA3Xo6q7PoEYmlgQxJiVZq1b1cwshmgaLj5q86sj0smoO4QngdKw==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "license": "MIT",
@@ -20719,25 +20735,17 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "version": "5.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0-rc.2.tgz",
+      "integrity": "sha512-dwe5OkVHGe1NinilLDJWapqyQyHBtxlai0qWhIjysY7nSnATpsqhnfIEkZTTJ5HUdECz8V14zf015GF7V+xACA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "punycode": "^2.3.1",
+        "tldts": "^6.1.14",
+        "url-parse": "^1.5.10"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -24341,7 +24349,7 @@
         "protobufjs": "^7.2.4",
         "socket.io-client": "^4.5.1",
         "socketio-wildcard": "^2.0.0",
-        "tough-cookie": "^4.0.0",
+        "tough-cookie": "^5.0.0-rc.2",
         "try-require": "^1.2.1",
         "uuid": "^8.0.0",
         "ws": "^7.5.7"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
     "protobufjs": "^7.2.4",
     "socket.io-client": "^4.5.1",
     "socketio-wildcard": "^2.0.0",
-    "tough-cookie": "^4.0.0",
+    "tough-cookie": "^5.0.0-rc.2",
     "try-require": "^1.2.1",
     "uuid": "^8.0.0",
     "ws": "^7.5.7"


### PR DESCRIPTION
## Description

`punycode` is showing a deprecation notice when running the CLI on Node 21+. From what I can tell, this is coming from `tough-cookie`, and they've solved the issue on the unreleased version 5. From what I've read, this is mostly a rewrite to Typescript, and should not contain functional changes. It's unknown when they'll officially release it.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
