### PR TITLE
ci(test): run arm64 lambda tests in main

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -82,6 +82,7 @@ jobs:
     needs: build
     with:
       ARTILLERY_VERSION_OVERRIDE: ${{ needs.build.outputs.ARTILLERY_VERSION }}
+      HAS_ARM64_BUILD: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -95,6 +95,7 @@ jobs:
     needs: publish-packages-to-npm
     with:
       ARTILLERY_VERSION_OVERRIDE: ${{ needs.publish-packages-to-npm.outputs.ARTILLERY_VERSION }}
+      HAS_ARM64_BUILD: true
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/run-distributed-tests.yml
+++ b/.github/workflows/run-distributed-tests.yml
@@ -7,6 +7,9 @@ on:
         type: string
       ARTILLERY_VERSION_OVERRIDE:
         type: string
+      HAS_ARM64_BUILD:
+        type: boolean
+        default: false
     secrets:
       ARTILLERY_CLOUD_ENDPOINT_TEST: 
         required: true
@@ -64,6 +67,7 @@ jobs:
       DD_TESTS_APP_KEY: ${{ secrets.DD_TESTS_APP_KEY }}
       GITHUB_REPO: ${{ github.repository }}
       GITHUB_ACTOR: ${{ github.actor }}
+      HAS_ARM64_BUILD: ${{ inputs.HAS_ARM64_BUILD }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-bom.test.js
@@ -6,6 +6,7 @@ const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
 const tags = getTestTags(['type:acceptance']);
 
 const A9_PATH = process.env.A9_PATH || 'artillery';
+const ARCHITECTURE = process.env.HAS_ARM64_BUILD ? 'arm64' : 'x86_64';
 
 tap.before(async () => {
   await $`${A9_PATH} -V`;
@@ -21,7 +22,7 @@ tap.test('Run simple-bom', async (t) => {
   const scenarioPath = `${__dirname}/../fargate/fixtures/simple-bom/simple-bom.yml`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 -e test --tags ${tags} --output ${reportFilePath} --count 51 --record`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture ${ARCHITECTURE} -e test --tags ${tags} --output ${reportFilePath} --count 51 --record`;
 
   t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 
@@ -39,7 +40,7 @@ tap.test('Run mixed-hierarchy test in Lambda Container', async (t) => {
   const configPath = `${__dirname}/../fargate/fixtures/mixed-hierarchy/config/config-no-file-uploads.yml`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture ${ARCHITECTURE} --config ${configPath} -e main --tags ${tags} --output ${reportFilePath} --record`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-dotenv.test.js
@@ -5,6 +5,7 @@ const { getTestTags, generateTmpReportPath } = require('../../cli/_helpers.js');
 
 const tags = getTestTags(['type:acceptance']);
 const A9_PATH = process.env.A9_PATH || 'artillery';
+const ARCHITECTURE = process.env.HAS_ARM64_BUILD ? 'arm64' : 'x86_64';
 
 tap.before(async () => {
   await $`${A9_PATH} -V`;
@@ -21,7 +22,7 @@ tap.test('Run dotenv test in Lambda Container', async (t) => {
   const dotenvPath = `${__dirname}/fixtures/dotenv/.env-test`;
 
   const output =
-    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --tags ${tags} --dotenv ${dotenvPath} --output ${reportFilePath} --count 5 --record`;
+    await $`${A9_PATH} run-lambda ${scenarioPath} --architecture ${ARCHITECTURE} --tags ${tags} --dotenv ${dotenvPath} --output ${reportFilePath} --count 5 --record`;
 
   const report = JSON.parse(fs.readFileSync(reportFilePath, 'utf8'));
 

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-ensure.test.js
@@ -13,13 +13,15 @@ tap.beforeEach(async (t) => {
 });
 
 const A9_PATH = process.env.A9_PATH || 'artillery';
+const ARCHITECTURE = process.env.HAS_ARM64_BUILD ? 'arm64' : 'x86_64';
+
 tap.before(async () => {
   await $`${A9_PATH} -V`;
 });
 
 tap.test('Lambda Container run uses ensure', async (t) => {
   try {
-    await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture x86_64 --tags ${tags} --output ${reportFilePath} --count 15`;
+    await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/uses-ensure/with-ensure.yaml --architecture ${ARCHITECTURE} --tags ${tags} --output ${reportFilePath} --count 15`;
     t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
   } catch (output) {
     t.equal(output.exitCode, 1, 'CLI Exit Code should be 1');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-expect.test.js
@@ -12,6 +12,8 @@ tap.beforeEach(async (t) => {
 });
 
 const A9_PATH = process.env.A9_PATH || 'artillery';
+const ARCHITECTURE = process.env.HAS_ARM64_BUILD ? 'arm64' : 'x86_64';
+
 tap.before(async () => {
   await $`${A9_PATH} -V`;
 });
@@ -20,7 +22,7 @@ tap.test(
   'CLI should exit with non-zero exit code when there are failed expectations in container workers',
   async (t) => {
     try {
-      await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture x86_64 --record --tags ${tags} --output ${reportFilePath} --count 2`;
+      await $`${A9_PATH} run-lambda ${__dirname}/../fargate/fixtures/cli-exit-conditions/with-expect.yml --architecture ${ARCHITECTURE} --record --tags ${tags} --output ${reportFilePath} --count 2`;
       t.fail(`Test "${t.name}" - Should have had non-zero exit code.`);
     } catch (output) {
       t.equal(output.exitCode, 21, 'CLI Exit Code should be 21');

--- a/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
+++ b/packages/artillery/test/cloud-e2e/lambda/lambda-smoke.test.js
@@ -12,10 +12,13 @@ tap.beforeEach(async (t) => {
 });
 
 const A9_PATH = process.env.A9_PATH || 'artillery';
+const ARCHITECTURE = process.env.HAS_ARM64_BUILD ? 'arm64' : 'x86_64';
+
 tap.before(async () => {
   await $`${A9_PATH} -V`;
 });
 
+//Note: we run this test always in x86_64 so we still run one x86_64 test in main pipeline as a smoke test
 tap.test('Run a test on AWS Lambda using containers', async (t) => {
   const configPath = `${__dirname}/fixtures/quick-loop-with-csv/config.yml`;
   const scenarioPath = `${__dirname}/fixtures/quick-loop-with-csv/blitz.yml`;
@@ -51,7 +54,7 @@ tap.test(
     const scenarioPath = `${__dirname}/fixtures/ts-external-pkg/with-external-foreign-pkg.yml`;
 
     const output =
-      await $`${A9_PATH} run-lambda ${scenarioPath} --architecture x86_64 --record --output ${reportFilePath} --tags ${tags},typescript:true`;
+      await $`${A9_PATH} run-lambda ${scenarioPath} --architecture ${ARCHITECTURE} --record --output ${reportFilePath} --tags ${tags},typescript:true`;
 
     t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 


### PR DESCRIPTION
## Description

Change lambda tests that run against canary or mainline published versions to run against `arm64` (except for one, which remains as a smoke test for `x86_64`). Possible to do after https://github.com/artilleryio/artillery/pull/2807.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No
