### PR TITLE
feat: a few ECS-related tweaks

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -146,7 +146,7 @@ RunCommand.flags = {
   }),
   memory: Flags.string({
     description:
-      'Set task memory on Fargate (defaults 8 GB). Value may be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)'
+      'Set task memory on Fargate (defaults to 8 GB). Value may be set as number of GB between 1-120 (e.g. 8), or as MiB (e.g. 8192)'
   }),
   packages: Flags.string({
     description:

--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -16,7 +16,7 @@ const dotenv = require('dotenv');
 const path = require('path');
 const fs = require('fs');
 class RunCommand extends Command {
-  static aliases = ['run:fargate'];
+  static aliases = ['run:fargate', 'run:ecs', 'run-ecs'];
   // Enable multiple args:
   static strict = false;
 

--- a/packages/artillery/lib/platform/aws/aws-cloudwatch.js
+++ b/packages/artillery/lib/platform/aws/aws-cloudwatch.js
@@ -72,7 +72,7 @@ function setCloudwatchRetention(
         if (opts.incr >= opts.maxRetries) {
           console.log(`\n${error.message}`);
           console.log(
-            '\nWARNING: Cannot find log group. Max retries exceeded setting CloudWatch retention policy:\n'
+            `\nWARNING: Cannot find log group ${logGroupName}\nMax retries exceeded setting CloudWatch retention policy:`
           );
           console.log(`${resumeTestMessage}\n`);
           clearInterval(interval);


### PR DESCRIPTION
## Description

A couple of ECS related things:

* Follow up to #3192. The fix in that PR did not work as intended because the array would always contain 2 elements
* Introduce `run-ecs` alias for `run-fargate`. This will be useful in future to make things less ambiguous when we add support for Amazon EKS, which also supports Fargate as a capacity provider.
* A couple of tweaks/fixes to copy

## Pre-merge checklist

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
