### PR TITLE
refactor(test): set report and trace file paths to test context

### DIFF
--- a/packages/artillery/test/publish-metrics/tracing/http-trace.test.js
+++ b/packages/artillery/test/publish-metrics/tracing/http-trace.test.js
@@ -7,16 +7,14 @@ const { setDynamicHTTPTraceExpectations } = require('../fixtures/helpers.js');
 
 const { runHttpTraceAssertions } = require('./http-trace-assertions.js');
 
-let reportFilePath;
-let tracesFilePath;
 beforeEach(async (t) => {
-  reportFilePath = generateTmpReportPath(t.name, 'json');
-  tracesFilePath = generateTmpReportPath('spans_' + t.name, 'json');
+  t.context.reportFilePath = generateTmpReportPath(t.name, 'json');
+  t.context.tracesFilePath = generateTmpReportPath('spans_' + t.name, 'json');
 });
 
 afterEach(async (t) => {
-  deleteFile(reportFilePath);
-  deleteFile(tracesFilePath);
+  deleteFile(t.context.reportFilePath);
+  deleteFile(t.context.tracesFilePath);
 });
 
 /* To write a test for the publish-metrics http tracing you need to:
@@ -40,7 +38,7 @@ test('OTel reporter correctly records trace data for http engine test runs', asy
             type: 'open-telemetry',
             traces: {
               exporter: '__test',
-              __outputPath: tracesFilePath,
+              __outputPath: t.context.tracesFilePath,
               useRequestNames: true,
               replaceSpanNameRegex: [{ pattern: 'armadillo', as: 'bombolini' }],
               attributes: {
@@ -77,10 +75,9 @@ test('OTel reporter correctly records trace data for http engine test runs', asy
   /// Run the test
   let output;
   try {
-    output =
-      await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${reportFilePath} --overrides ${JSON.stringify(
-        override
-      )}`;
+    output = await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${
+      t.context.reportFilePath
+    } --overrides ${JSON.stringify(override)}`;
   } catch (err) {
     console.error('There has been an error in test run execution: ', err);
     t.fail(err);
@@ -89,9 +86,9 @@ test('OTel reporter correctly records trace data for http engine test runs', asy
   // Get all main test run data
   const testRunData = {
     output,
-    reportSummary: JSON.parse(fs.readFileSync(reportFilePath, 'utf8'))
+    reportSummary: JSON.parse(fs.readFileSync(t.context.reportFilePath, 'utf8'))
       .aggregate,
-    spans: JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'))
+    spans: JSON.parse(fs.readFileSync(t.context.tracesFilePath, 'utf8'))
   };
 
   // Run assertions
@@ -112,7 +109,7 @@ test('OTel reporter works appropriately with "parallel" scenario setting ', asyn
             type: 'open-telemetry',
             traces: {
               exporter: '__test',
-              __outputPath: tracesFilePath,
+              __outputPath: t.context.tracesFilePath,
               useRequestNames: true,
               replaceSpanNameRegex: [{ pattern: 'armadillo', as: 'bombolini' }],
               attributes: {
@@ -163,10 +160,9 @@ test('OTel reporter works appropriately with "parallel" scenario setting ', asyn
   /// Run the test
   let output;
   try {
-    output =
-      await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${reportFilePath} --overrides ${JSON.stringify(
-        override
-      )}`;
+    output = await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${
+      t.context.reportFilePath
+    } --overrides ${JSON.stringify(override)}`;
   } catch (err) {
     t.fail(err);
   }
@@ -174,9 +170,9 @@ test('OTel reporter works appropriately with "parallel" scenario setting ', asyn
   // Get all main test run data
   const testRunData = {
     output,
-    reportSummary: JSON.parse(fs.readFileSync(reportFilePath, 'utf8'))
+    reportSummary: JSON.parse(fs.readFileSync(t.context.reportFilePath, 'utf8'))
       .aggregate,
-    spans: JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'))
+    spans: JSON.parse(fs.readFileSync(t.context.tracesFilePath, 'utf8'))
   };
 
   // Run assertions
@@ -197,7 +193,7 @@ test('Otel reporter appropriately records traces for test runs with errors', asy
             type: 'open-telemetry',
             traces: {
               exporter: '__test',
-              __outputPath: tracesFilePath,
+              __outputPath: t.context.tracesFilePath,
               useRequestNames: true,
               replaceSpanNameRegex: [{ pattern: 'armadillo', as: 'bombolini' }],
               attributes: {
@@ -249,10 +245,9 @@ test('Otel reporter appropriately records traces for test runs with errors', asy
   /// Run the test
   let output;
   try {
-    output =
-      await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${reportFilePath} --overrides ${JSON.stringify(
-        override
-      )}`;
+    output = await $`artillery run ${__dirname}/../fixtures/http-trace.yml -o ${
+      t.context.reportFilePath
+    } --overrides ${JSON.stringify(override)}`;
   } catch (err) {
     t.fail(err);
   }
@@ -260,9 +255,9 @@ test('Otel reporter appropriately records traces for test runs with errors', asy
   // Get all main test run data
   const testRunData = {
     output,
-    reportSummary: JSON.parse(fs.readFileSync(reportFilePath, 'utf8'))
+    reportSummary: JSON.parse(fs.readFileSync(t.context.reportFilePath, 'utf8'))
       .aggregate,
-    spans: JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'))
+    spans: JSON.parse(fs.readFileSync(t.context.tracesFilePath, 'utf8'))
   };
 
   // Run assertions

--- a/packages/artillery/test/publish-metrics/tracing/playwright-trace.test.js
+++ b/packages/artillery/test/publish-metrics/tracing/playwright-trace.test.js
@@ -122,7 +122,7 @@ test('OTel reporter correctly records trace data for playwright engine test runs
   }
 });
 
-test('OTel reporter correctly records trace data for playwright engine test runs', async (t) => {
+test('OTel reporter correctly records trace data for playwright engine test runs with errors', async (t) => {
   // Define test configuration
   const override = {
     config: {

--- a/packages/artillery/test/publish-metrics/tracing/playwright-trace.test.js
+++ b/packages/artillery/test/publish-metrics/tracing/playwright-trace.test.js
@@ -11,16 +11,14 @@ const {
   runPlaywrightTraceAssertions
 } = require('./playwright-trace-assertions.js');
 
-let reportFilePath;
-let tracesFilePath;
 beforeEach(async (t) => {
-  reportFilePath = generateTmpReportPath(t.name, 'json');
-  tracesFilePath = generateTmpReportPath('spans_' + t.name, 'json');
+  t.context.reportFilePath = generateTmpReportPath(t.name, 'json');
+  t.context.tracesFilePath = generateTmpReportPath('spans_' + t.name, 'json');
 });
 
 afterEach(async (t) => {
-  deleteFile(reportFilePath);
-  deleteFile(tracesFilePath);
+  deleteFile(t.context.reportFilePath);
+  deleteFile(t.context.tracesFilePath);
 });
 
 /* To write a test for the publish-metrics tracing you need to:
@@ -44,7 +42,7 @@ test('OTel reporter correctly records trace data for playwright engine test runs
             type: 'open-telemetry',
             traces: {
               exporter: '__test',
-              __outputPath: tracesFilePath,
+              __outputPath: t.context.tracesFilePath,
               replaceSpanNameRegex: [
                 {
                   pattern:
@@ -100,9 +98,9 @@ test('OTel reporter correctly records trace data for playwright engine test runs
   let output;
   try {
     output =
-      await $`artillery run ${__dirname}/../fixtures/playwright-trace.yml -o ${reportFilePath} --overrides ${JSON.stringify(
-        override
-      )}`;
+      await $`artillery run ${__dirname}/../fixtures/playwright-trace.yml -o ${
+        t.context.reportFilePath
+      } --overrides ${JSON.stringify(override)}`;
   } catch (err) {
     t.fail(err);
   }
@@ -110,9 +108,9 @@ test('OTel reporter correctly records trace data for playwright engine test runs
   // Assemble all test run data into one object for assertions (output of the test run, artillery report summary and exported spans)
   const testRunData = {
     output,
-    reportSummary: JSON.parse(fs.readFileSync(reportFilePath, 'utf8'))
+    reportSummary: JSON.parse(fs.readFileSync(t.context.reportFilePath, 'utf8'))
       .aggregate,
-    spans: JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'))
+    spans: JSON.parse(fs.readFileSync(t.context.tracesFilePath, 'utf8'))
   };
 
   // Run assertions
@@ -134,7 +132,7 @@ test('OTel reporter correctly records trace data for playwright engine test runs
             type: 'open-telemetry',
             traces: {
               exporter: '__test',
-              __outputPath: tracesFilePath,
+              __outputPath: t.context.tracesFilePath,
               replaceSpanNameRegex: [
                 { pattern: 'https://www.artillery.io/docs', as: 'docs_main' },
                 { pattern: 'Go to core concepts', as: 'bombolini' }
@@ -187,9 +185,9 @@ test('OTel reporter correctly records trace data for playwright engine test runs
   let output;
   try {
     output =
-      await $`artillery run ${__dirname}/../fixtures/playwright-trace.yml -o ${reportFilePath} --overrides ${JSON.stringify(
-        override
-      )}`;
+      await $`artillery run ${__dirname}/../fixtures/playwright-trace.yml -o ${
+        t.context.reportFilePath
+      } --overrides ${JSON.stringify(override)}`;
   } catch (err) {
     t.fail(err);
   }
@@ -197,9 +195,9 @@ test('OTel reporter correctly records trace data for playwright engine test runs
   // Assembling all test run data into one object for assertions (output of the test run, artillery report summary and exported spans)
   const testRunData = {
     output,
-    reportSummary: JSON.parse(fs.readFileSync(reportFilePath, 'utf8'))
+    reportSummary: JSON.parse(fs.readFileSync(t.context.reportFilePath, 'utf8'))
       .aggregate,
-    spans: JSON.parse(fs.readFileSync(tracesFilePath, 'utf8'))
+    spans: JSON.parse(fs.readFileSync(t.context.tracesFilePath, 'utf8'))
   };
 
   // Run assertions


### PR DESCRIPTION
## Description

There were a few occasions that the publish-metrics trace tests failed. I was not able to reproduce the issue but from the existing logs it seemed as the second test would use the report of the first one. 
These tests are within a single file and use `beforeEach` and `afterEach` to set `report` and `trace` file paths. The paths were not set on the test `context` though, I added them directly on the test context here to make sure each is explicitly using their own paths.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
