### PR TITLE
dep(playwright): update playwright version to v1.45.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,29 +4934,29 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.44.1.tgz",
-      "integrity": "sha512-ixlllsDKMzeCfU0GvlneqUtPu2jqak5r8BD0kRyJO5gNkOMa9UxippK1Ubgi7yqWn4RXvxFRoLSOeh/w6PHFrQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.0.tgz",
+      "integrity": "sha512-yZxAsaxvn60VEPaPghYuL7xC78f994QdkJ3PtPZKozKctsIkT60GiDjjemwJKvWVgo/Z4v/hjim4okLKMIRkEw==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.45.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
-      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
+      "integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
       "dependencies": {
-        "playwright": "1.44.1"
+        "playwright": "1.45.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -17804,31 +17804,31 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
-      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
+      "integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
       "dependencies": {
-        "playwright-core": "1.44.1"
+        "playwright-core": "1.45.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
-      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
+      "integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -23073,10 +23073,10 @@
       "version": "1.13.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@playwright/browser-chromium": "1.44.1",
-        "@playwright/test": "1.44.1",
+        "@playwright/browser-chromium": "1.45.0",
+        "@playwright/test": "1.45.0",
         "debug": "^4.3.2",
-        "playwright": "1.44.1"
+        "playwright": "1.45.0"
       },
       "devDependencies": {
         "tap": "^19.0.2",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.44.1
+FROM mcr.microsoft.com/playwright:v1.45.0
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -20,10 +20,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@playwright/browser-chromium": "1.44.1",
-    "@playwright/test": "1.44.1",
+    "@playwright/browser-chromium": "1.45.0",
+    "@playwright/test": "1.45.0",
     "debug": "^4.3.2",
-    "playwright": "1.44.1"
+    "playwright": "1.45.0"
   },
   "devDependencies": {
     "tap": "^19.0.2",

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: Version we use here needs to be kept consistent with that in
 # artillery-engine-playwright.
 # ********************************
-FROM mcr.microsoft.com/playwright:v1.44.1
+FROM mcr.microsoft.com/playwright:v1.45.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description

Upgrade to [Playwright v1.45.0](https://github.com/microsoft/playwright/releases). There are no mentioned breaking changes in this release, but there are a few API improvements in `playwright` and `@playwright/test`.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
