### PR TITLE
ci(test): retry npm install in distributed tests

### DIFF
--- a/.github/workflows/run-distributed-tests.yml
+++ b/.github/workflows/run-distributed-tests.yml
@@ -85,11 +85,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 18.x
-      - run: npm install
+      - run: .github/workflows/scripts/npm-command-retry.sh install
       - run: npm run build
       - name: Install Specific Artillery Version if needed
         if: ${{ inputs.ARTILLERY_VERSION_OVERRIDE || false }}
-        run: mkdir __artillery__ && cd __artillery__ && npm init -y && npm install artillery@${{ inputs.ARTILLERY_VERSION_OVERRIDE }}
+        run: mkdir __artillery__ && cd __artillery__ && npm init -y && .github/workflows/scripts/npm-command-retry.sh install artillery@${{ inputs.ARTILLERY_VERSION_OVERRIDE }}
       - name: Set A9_PATH
         if: ${{ inputs.ARTILLERY_VERSION_OVERRIDE || false }}
         run: echo "A9_PATH=${{ github.workspace }}/__artillery__/node_modules/.bin/artillery" >> $GITHUB_ENV

--- a/.github/workflows/scripts/npm-command-retry.sh
+++ b/.github/workflows/scripts/npm-command-retry.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This is necessary because npm commands can fail intermittently due to network issues
+# The script retries an npm command up to 5 times with a 2-second delay between each attempt
+run_npm_command() {
+  local max_retries=5
+  local retry_count=0
+  local sleep_time=2
+  local command="$@"
+
+  while [ $retry_count -lt $max_retries ]; do
+    $command && break
+
+    retry_count=$((retry_count + 1))
+    echo "Command attempt $retry_count failed. Retrying in $sleep_time seconds..."
+    sleep $sleep_time
+  done
+
+  if [ $retry_count -eq $max_retries ]; then
+    echo "Command failed after $max_retries attempts."
+    exit 1
+  else
+    echo "Command succeeded."
+  fi
+}
+
+if [ $# -eq 0 ]; then
+  echo "No npm command provided."
+  exit 1
+else
+  command="npm $@"
+fi
+
+run_npm_command "$command"


### PR DESCRIPTION
## Description

Tests are occasionally failing in an `npm install` step ([example](https://github.com/artilleryio/artillery/actions/runs/9759298237/job/26936970178)) that happens in main, seemingly due to intermittent network issues.

This PR creates a bash script to retry npm commands. If needed we can use this in more places in the future, but I've only seen this issue in these 2 install steps in recent history.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
