### PR TITLE
feat(cli): set nontemplated url as req name by default in metrics

### DIFF
--- a/packages/artillery-plugin-metrics-by-endpoint/index.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/index.js
@@ -11,7 +11,7 @@ let useOnlyRequestNames;
 let stripQueryString;
 let ignoreUnnamedRequests;
 let metricsPrefix;
-let useDefaultName;
+let groupDynamicURLs;
 
 // NOTE: Will not work with `parallel` - need request UIDs for that
 function MetricsByEndpoint(script, events) {
@@ -43,8 +43,8 @@ function MetricsByEndpoint(script, events) {
   metricsPrefix =
     script.config.plugins['metrics-by-endpoint'].metricsNamespace ||
     'plugins.metrics-by-endpoint';
-  useDefaultName =
-    script.config.plugins['metrics-by-endpoint'].useDefaultName ?? true;
+  groupDynamicURLs =
+    script.config.plugins['metrics-by-endpoint'].groupDynamicURLs ?? true;
 
   script.config.processor.metricsByEndpoint_afterResponse =
     metricsByEndpoint_afterResponse;
@@ -93,7 +93,7 @@ function getReqName(target, originalRequestUrl, requestName) {
 }
 
 function metricsByEndpoint_beforeRequest(req, userContext, events, done) {
-  if (useDefaultName) {
+  if (groupDynamicURLs) {
     req.defaultName = getReqName(userContext.vars.target, req.url, req.name);
   }
 
@@ -101,9 +101,9 @@ function metricsByEndpoint_beforeRequest(req, userContext, events, done) {
 }
 
 function metricsByEndpoint_onError(err, req, userContext, events, done) {
-  //if useDefaultName is true, then req.defaultName is set in beforeRequest
+  //if groupDynamicURLs is true, then req.defaultName is set in beforeRequest
   //otherwise, we must calculate the reqName here as req.url is the non-templated version
-  const reqName = useDefaultName
+  const reqName = groupDynamicURLs
     ? req.defaultName
     : getReqName(userContext.vars.target, req.url, req.name);
 
@@ -121,9 +121,9 @@ function metricsByEndpoint_onError(err, req, userContext, events, done) {
 }
 
 function metricsByEndpoint_afterResponse(req, res, userContext, events, done) {
-  //if useDefaultName is true, then req.defaultName is set in beforeRequest
+  //if groupDynamicURLs is true, then req.defaultName is set in beforeRequest
   //otherwise, we must calculate the reqName here as req.url is the non-templated version
-  const reqName = useDefaultName
+  const reqName = groupDynamicURLs
     ? req.defaultName
     : getReqName(userContext.vars.target, req.url, req.name);
 

--- a/packages/artillery-plugin-metrics-by-endpoint/test/fixtures/scenario-templated-url.yml
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/fixtures/scenario-templated-url.yml
@@ -1,0 +1,18 @@
+config:
+  target: http://asciiart.artillery.io:8080
+  phases:
+    - duration: 2
+      arrivalRate: 2
+  plugins:
+    metrics-by-endpoint:
+      stripQueryString: true
+
+scenarios:
+  - flow:
+      - get:
+          url: "/dino/{{ $randomString() }}?potato=1&tomato=2"
+          name: "GET /dino"
+      - get:
+          url: "/armadillo/{{ $randomString() }}"
+      - get: 
+          url: "/pony"

--- a/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
@@ -78,3 +78,107 @@ test("Reports correctly when 'parallel' is used", async (t) => {
     );
   }
 });
+
+test('Reports correctly when `useDefaultName` is set to true (default)', async (t) => {
+  const reportPath =
+    os.tmpdir() + '/artillery-plugin-metrics-by-endpoint-use-path-as-name.json';
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario-templated-url.yml -o ${reportPath}`;
+
+  const report = require(reportPath);
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+  t.equal(
+    report.aggregate.counters[
+      'plugins.metrics-by-endpoint./armadillo/{{ $randomString() }}.codes.200'
+    ],
+    4,
+    'should have counter metrics including templated url and no query strings'
+  );
+  t.equal(
+    report.aggregate.counters[
+      'plugins.metrics-by-endpoint./dino/{{ $randomString() }} (GET /dino).codes.200'
+    ],
+    4,
+    'should have counter metrics including templated url with request name specified'
+  );
+  t.equal(
+    report.aggregate.counters['plugins.metrics-by-endpoint./pony.codes.200'],
+    4
+  ),
+    'should display counter metrics for /pony as normal';
+
+  t.ok(
+    Object.keys(report.aggregate.summaries).includes(
+      'plugins.metrics-by-endpoint.response_time./armadillo/{{ $randomString() }}'
+    ),
+    'should have summary metrics including templated url'
+  );
+  t.ok(
+    Object.keys(report.aggregate.summaries).includes(
+      'plugins.metrics-by-endpoint.response_time./dino/{{ $randomString() }} (GET /dino)'
+    ),
+    'should have summary metrics including templated url with request name specified'
+  );
+  t.ok(
+    Object.keys(report.aggregate.summaries).includes(
+      'plugins.metrics-by-endpoint.response_time./pony'
+    ),
+    'should display summary metrics for /pony as normal'
+  );
+});
+
+test('Reports correctly when `useDefaultName` is explicitly set to false', async (t) => {
+  const reportPath =
+    os.tmpdir() +
+    '/artillery-plugin-metrics-by-endpoint-use-path-without-name-test.json';
+  const overrides = {
+    config: {
+      plugins: {
+        'metrics-by-endpoint': {
+          useDefaultName: false,
+          stripQueryString: false
+        }
+      }
+    }
+  };
+  const output =
+    await $`../artillery/bin/run run ./test/fixtures/scenario-templated-url.yml -o ${reportPath} --overrides ${JSON.stringify(
+      overrides
+    )}`;
+
+  const report = require(reportPath);
+
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
+
+  const aggregateCounters = Object.keys(report.aggregate.counters);
+
+  const countersWithName = aggregateCounters.filter((counter) => {
+    return new RegExp(
+      /plugins\.metrics-by-endpoint\.\/dino\/[a-zA-Z0-9]+\.?\w+\?potato=1&tomato=2 \(GET \/dino\)\.codes\.200/
+    ).test(counter);
+  });
+
+  const countersWithoutName = aggregateCounters.filter((counter) => {
+    return new RegExp(
+      /plugins\.metrics-by-endpoint\.\/armadillo\/[a-zA-Z0-9]+\.?\w+\.codes\.200/
+    ).test(counter);
+  });
+
+  const regularPonyCounter = aggregateCounters.filter(
+    (counter) => counter == 'plugins.metrics-by-endpoint./pony.codes.200'
+  );
+
+  t.ok(
+    countersWithName.length > 0,
+    `should have counter metrics without the templated url, got ${countersWithName}`
+  );
+  t.ok(
+    countersWithoutName.length > 0,
+    `should have counter metrics without the templated url and request name specified, got ${countersWithoutName}`
+  );
+  t.ok(
+    regularPonyCounter.length == 1,
+    `should display counter metrics for /pony as normal, got ${regularPonyCounter}`
+  );
+});

--- a/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/index.spec.js
@@ -79,7 +79,7 @@ test("Reports correctly when 'parallel' is used", async (t) => {
   }
 });
 
-test('Reports correctly when `useDefaultName` is set to true (default)', async (t) => {
+test('Reports correctly when `groupDynamicURLs` is set to true (default)', async (t) => {
   const reportPath =
     os.tmpdir() + '/artillery-plugin-metrics-by-endpoint-use-path-as-name.json';
   const output =
@@ -128,7 +128,7 @@ test('Reports correctly when `useDefaultName` is set to true (default)', async (
   );
 });
 
-test('Reports correctly when `useDefaultName` is explicitly set to false', async (t) => {
+test('Reports correctly when `groupDynamicURLs` is explicitly set to false', async (t) => {
   const reportPath =
     os.tmpdir() +
     '/artillery-plugin-metrics-by-endpoint-use-path-without-name-test.json';
@@ -136,7 +136,7 @@ test('Reports correctly when `useDefaultName` is explicitly set to false', async
     config: {
       plugins: {
         'metrics-by-endpoint': {
-          useDefaultName: false,
+          groupDynamicURLs: false,
           stripQueryString: false
         }
       }

--- a/packages/artillery-plugin-metrics-by-endpoint/test/index.unit.js
+++ b/packages/artillery-plugin-metrics-by-endpoint/test/index.unit.js
@@ -33,7 +33,7 @@ const baseScript = {
   ]
 };
 
-test('afterResponse', async (t) => {
+test('beforeRequest and afterResponse', async (t) => {
   let defaultPluginPrefix = 'plugins.metrics-by-endpoint';
   let script;
   let hookArgs;
@@ -85,18 +85,28 @@ test('afterResponse', async (t) => {
     };
   });
 
-  t.test('sets up afterResponse hook correctly', async (t) => {
-    new Plugin(script, hookArgs.events);
+  t.test(
+    'sets up beforeRequest and afterResponse hook correctly',
+    async (t) => {
+      new Plugin(script, hookArgs.events);
 
-    // check afterResponse is in processor
-    t.hasProp(script.config.processor, 'metricsByEndpoint_afterResponse');
+      // check afterResponse is in processor
+      t.hasProp(script.config.processor, 'metricsByEndpoint_afterResponse');
+      t.hasProp(script.config.processor, 'metricsByEndpoint_beforeRequest');
 
-    // check afterResponse is each scenario
-    script.scenarios.forEach((scenario) => {
-      t.equal(scenario.afterResponse.length, 1);
-      t.equal(scenario.afterResponse[0], 'metricsByEndpoint_afterResponse');
-    });
-  });
+      // check afterResponse is each scenario
+      script.scenarios.forEach((scenario) => {
+        t.equal(scenario.afterResponse.length, 1);
+        t.equal(scenario.afterResponse[0], 'metricsByEndpoint_afterResponse');
+      });
+
+      // check beforeRequest is each scenario
+      script.scenarios.forEach((scenario) => {
+        t.equal(scenario.beforeRequest.length, 1);
+        t.equal(scenario.beforeRequest[0], 'metricsByEndpoint_beforeRequest');
+      });
+    }
+  );
 
   t.test('only runs plugin inside workers', async (t) => {
     delete process.env.LOCAL_WORKER_ID;
@@ -110,6 +120,13 @@ test('afterResponse', async (t) => {
     'emits counter and histogram metrics correctly with basic configuration',
     async (t) => {
       new Plugin(script, hookArgs.events);
+
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
 
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
@@ -145,6 +162,13 @@ test('afterResponse', async (t) => {
       hookArgs.req.url = `http://${requestUrlWithoutProtocol}`;
       new Plugin(script, hookArgs.events);
 
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
+
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
         hookArgs.res,
@@ -178,6 +202,13 @@ test('afterResponse', async (t) => {
     hookArgs.req.url = requestWithPort;
     new Plugin(script, hookArgs.events);
 
+    script.config.processor.metricsByEndpoint_beforeRequest(
+      hookArgs.req,
+      hookArgs.userContext,
+      hookArgs.events,
+      hookArgs.done
+    );
+
     script.config.processor.metricsByEndpoint_afterResponse(
       hookArgs.req,
       hookArgs.res,
@@ -206,6 +237,13 @@ test('afterResponse', async (t) => {
 
     const serverTiming = 105;
     hookArgs.res.headers['server-timing'] = `total;dur=${serverTiming}`;
+
+    script.config.processor.metricsByEndpoint_beforeRequest(
+      hookArgs.req,
+      hookArgs.userContext,
+      hookArgs.events,
+      hookArgs.done
+    );
 
     script.config.processor.metricsByEndpoint_afterResponse(
       hookArgs.req,
@@ -236,6 +274,13 @@ test('afterResponse', async (t) => {
 
       const serverTiming = 105;
       hookArgs.res.headers['server-timing'] = `total;potatoes=${serverTiming}`;
+
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
 
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
@@ -269,6 +314,13 @@ test('afterResponse', async (t) => {
     const reqName = 'bunnyRequest123';
     hookArgs.req.name = reqName;
 
+    script.config.processor.metricsByEndpoint_beforeRequest(
+      hookArgs.req,
+      hookArgs.userContext,
+      hookArgs.events,
+      hookArgs.done
+    );
+
     script.config.processor.metricsByEndpoint_afterResponse(
       hookArgs.req,
       hookArgs.res,
@@ -300,6 +352,13 @@ test('afterResponse', async (t) => {
 
       const reqName = 'bunnyRequest123';
       hookArgs.req.name = reqName;
+
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
 
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
@@ -335,6 +394,13 @@ test('afterResponse', async (t) => {
       };
       new Plugin(script, hookArgs.events);
 
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
+
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
         hookArgs.res,
@@ -365,6 +431,13 @@ test('afterResponse', async (t) => {
       };
       new Plugin(script, hookArgs.events);
 
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
+
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
         hookArgs.res,
@@ -386,6 +459,13 @@ test('afterResponse', async (t) => {
       };
       hookArgs.req.name = 'iAmNamed';
       new Plugin(script, hookArgs.events);
+
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
 
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,
@@ -420,6 +500,13 @@ test('afterResponse', async (t) => {
       };
       hookArgs.req.url = '/dino?query=stringy&another=one';
       new Plugin(script, hookArgs.events);
+
+      script.config.processor.metricsByEndpoint_beforeRequest(
+        hookArgs.req,
+        hookArgs.userContext,
+        hookArgs.events,
+        hookArgs.done
+      );
 
       script.config.processor.metricsByEndpoint_afterResponse(
         hookArgs.req,

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/cli-kitchen-sink/kitchen-sink.yml
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/cli-kitchen-sink/kitchen-sink.yml
@@ -3,7 +3,7 @@ config:
   plugins:
     ensure: {}
     metrics-by-endpoint:
-      useDefaultName: false
+      groupDynamicURLs: false
   phases:
     - duration: 20
       arrivalRate: 1

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/cli-kitchen-sink/kitchen-sink.yml
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/cli-kitchen-sink/kitchen-sink.yml
@@ -2,6 +2,8 @@ config:
   target: http://asciiart.artillery.io:8080
   plugins:
     ensure: {}
+    metrics-by-endpoint:
+      useDefaultName: false
   phases:
     - duration: 20
       arrivalRate: 1

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -22,7 +22,13 @@ const MetricsByEndpointPluginConfigSchema = Joi.object({
   metricsNamespace: Joi.string()
     .meta({ title: 'Metrics Namespace' })
     .description('Custom prefix to use for metrics published by this plugin.')
-    .default('plugins.metrics-by-endpoint')
+    .default('plugins.metrics-by-endpoint'),
+  useDefaultName: Joi.boolean()
+    .default(true)
+    .meta({ title: 'Use Default Name' })
+    .description(
+      'Use the url field of the request as the default name if no name is provided (including templated strings).'
+    )
 })
   .unknown(false)
   .meta({ title: 'Metrics by Endpoint Plugin' })

--- a/packages/types/schema/plugins/metrics-by-endpoint.js
+++ b/packages/types/schema/plugins/metrics-by-endpoint.js
@@ -23,12 +23,10 @@ const MetricsByEndpointPluginConfigSchema = Joi.object({
     .meta({ title: 'Metrics Namespace' })
     .description('Custom prefix to use for metrics published by this plugin.')
     .default('plugins.metrics-by-endpoint'),
-  useDefaultName: Joi.boolean()
+  groupDynamicURLs: Joi.boolean()
     .default(true)
-    .meta({ title: 'Use Default Name' })
-    .description(
-      'Use the url field of the request as the default name if no name is provided (including templated strings).'
-    )
+    .meta({ title: 'Group Dynamic URLs' })
+    .description('Group metrics by the non-templated request URL.')
 })
   .unknown(false)
   .meta({ title: 'Metrics by Endpoint Plugin' })


### PR DESCRIPTION
## Description

By default, we will start setting a `req.name` equal to the non-templated url. This solves the issue with reports getting too big when users don't set `req.name`, which is particularly relevant in Cloud Dashboard, where it becomes unreadable. It will now look like this:

<img width="1194" alt="Screenshot 2024-07-11 at 16 37 13" src="https://github.com/artilleryio/artillery/assets/39738771/f7da4b53-1a02-4c26-a3da-11efeef040ed">

Users can opt-out of this behaviour by setting `groupDynamicURLs: false` in their config.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
