### PR TITLE
fix(fargate): set cloud endpoint from env in fargate containers

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -237,15 +237,26 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     context.dotenv = dotenv.parse(contents);
   }
 
-  // Explicitly make Artillery Cloud API key available to workers (if it's set)
-  // Relying on the fact that contents of context.dotenv gets passed onto workers
-  // for it
-  const cloudKey = options.key || process.env.ARTILLERY_CLOUD_API_KEY;
-  if (cloudKey) {
-    if (!context.dotenv) {
-      context.dotenv = {};
+  if (options.record) {
+    const cloudKey = options.key || process.env.ARTILLERY_CLOUD_API_KEY;
+    const cloudEndpoint = process.env.ARTILLERY_CLOUD_ENDPOINT;
+    // Explicitly make Artillery Cloud API key available to workers (if it's set)
+    // Relying on the fact that contents of context.dotenv gets passed onto workers
+    // for it
+    if (cloudKey) {
+      context.dotenv = {
+        ...context.dotenv,
+        ARTILLERY_CLOUD_API_KEY: cloudKey
+      };
     }
-    context.dotenv.ARTILLERY_CLOUD_API_KEY = cloudKey;
+
+    // Explicitly make Artillery Cloud endpoint available to workers (if it's set)
+    if (cloudEndpoint) {
+      context.dotenv = {
+        ...context.dotenv,
+        ARTILLERY_CLOUD_ENDPOINT: cloudEndpoint
+      };
+    }
   }
 
   if (options.bundle) {


### PR DESCRIPTION
## Description

This fixes two issues:
- Cloud workers will do the `/whoami` call in the container without taking into account the endpoint, so if the endpoint is not prod, the api key will not be correct, causing the error.
- If you set `ARTILLERY_CLOUD_API_KEY` in the environment, but don't set `--record`, the key will still get passed to the worker, which causes it to run unnecessarily.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
