### PR TITLE
refactor: make the Launcher abstraction less opinionated

### DIFF
--- a/packages/artillery/lib/launch-platform.js
+++ b/packages/artillery/lib/launch-platform.js
@@ -60,9 +60,12 @@ class Launcher {
 
   async initWorkerEvents(workerEvents) {
     workerEvents.on('workerError', (workerId, message) => {
-      this.exitedWorkersCount++;
-
       const { id, error, level, aggregatable, logs } = message;
+
+      if (level !== 'warn') {
+        this.exitedWorkersCount++;
+      }
+
       if (aggregatable) {
         this.workerMessageBuffer.push(message);
       } else {

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -376,13 +376,25 @@ class PlatformLambda {
     });
   }
 
+  getDesiredWorkerCount() {
+    return this.platformOpts.count;
+  }
+
+  async startJob() {
+    await this.init();
+
+    for (let i = 0; i < this.platformOpts.count; i++) {
+      const { workerId } = await this.createWorker();
+      this.workers[workerId] = { id: workerId };
+      await this.runWorker(workerId);
+    }
+  }
+
   async createWorker() {
     const workerId = randomUUID();
 
     return { workerId };
   }
-
-  async prepareWorker(workerId) {}
 
   async runWorker(workerId) {
     const lambda = new AWS.Lambda({

--- a/packages/artillery/lib/platform/local/index.js
+++ b/packages/artillery/lib/platform/local/index.js
@@ -5,7 +5,9 @@ const { handleScriptHook, prepareScript, loadProcessor } =
 const debug = require('debug')('platform:local');
 const EventEmitter = require('events');
 const _ = require('lodash');
-
+const divideWork = require('../../dist');
+const STATES = require('../worker-states');
+const os = require('node:os');
 class PlatformLocal {
   constructor(script, payload, opts, platformOpts) {
     // We need these to run before/after hooks:
@@ -13,10 +15,59 @@ class PlatformLocal {
     this.payload = payload;
     this.opts = opts;
     this.events = new EventEmitter(); // send worker events such as workerError, etc
-
+    this.platformOpts = platformOpts;
     this.workers = {};
-
+    this.workerScripts = {};
+    this.count = Infinity;
     return this;
+  }
+
+  getDesiredWorkerCount() {
+    return this.count;
+  }
+
+  async startJob() {
+    await this.init();
+
+    if (this.platformOpts.mode === 'distribute') {
+      const count = Math.max(1, os.cpus().length - 1);
+      this.workerScripts = divideWork(this.script, count);
+      this.count = this.workerScripts.length;
+    } else {
+      // --count may only be used when mode is "multiply"
+      this.count = this.platformOpts.count;
+      this.workerScripts = new Array(this.count).fill().map((_) => this.script);
+    }
+
+    for (const script of this.workerScripts) {
+      const w1 = await this.createWorker();
+
+      this.workers[w1.workerId] = {
+        id: w1.workerId,
+        script,
+        state: STATES.initializing,
+        proc: w1
+      };
+      debug(`worker init ok: ${w1.workerId}`);
+    }
+
+    for (const [workerId, w] of Object.entries(this.workers)) {
+      await this.prepareWorker(workerId, {
+        script: w.script,
+        payload: this.payload,
+        options: this.opts
+      });
+      this.workers[workerId].state = STATES.preparing;
+    }
+    debug('workers prepared');
+
+    // the initial context is stringified and copied to the workers
+    const contextVarsString = JSON.stringify(this.contextVars);
+
+    for (const [workerId, w] of Object.entries(this.workers)) {
+      await this.runWorker(workerId, contextVarsString);
+      this.workers[workerId].state = STATES.initializing;
+    }
   }
 
   async init() {
@@ -24,8 +75,6 @@ class PlatformLocal {
     // its context is then passed to the workers
     const contextVars = await this.runHook('before');
     this.contextVars = contextVars; // TODO: Rename to something more descriptive
-
-    return contextVars;
   }
 
   async createWorker() {
@@ -67,11 +116,6 @@ class PlatformLocal {
       process.nextTick(() => process.exit(11));
     });
 
-    this.workers[worker.workerId] = {
-      proc: worker,
-      state: worker.state // TODO: replace with getState() use
-    };
-
     return worker;
   }
 
@@ -84,11 +128,10 @@ class PlatformLocal {
     debug('runWorker', workerId);
     return this.workers[workerId].proc.run(contextVarsString);
   }
+
   async stopWorker(workerId) {
     return this.workers[workerId].proc.stop();
   }
-
-  async getWorkerState(workerId) {}
 
   async shutdown() {
     // 'after' hook is executed in the main thread, after all workers

--- a/packages/artillery/lib/platform/local/index.js
+++ b/packages/artillery/lib/platform/local/index.js
@@ -137,6 +137,10 @@ class PlatformLocal {
     // 'after' hook is executed in the main thread, after all workers
     // are done
     await this.runHook('after', this.contextVars);
+
+    for (const [workerId, w] of Object.entries(this.workers)) {
+      await this.stopWorker(workerId);
+    }
   }
 
   // ********

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/memory-hog/memory-hog.yml
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/memory-hog/memory-hog.yml
@@ -7,7 +7,7 @@ config:
   target: http://asciiart.artillery.io:8080
   phases:
     - arrivalRate: 1
-      duration: 10
+      duration: 12
   processor: './processor.js'
 
 scenarios:


### PR DESCRIPTION
## Description

After these changes the `Launcher` class will delegate more of how a test is run down to the actual implementation of the runtime platform (e.g. local, AWS Lambda, AWS ECS or something else).

It will no longer manage workers directly via `createWorker()`, `prepareWorker()` etc.

The only concerns handled in Launcher now are to:

- Initialize a specific platform implementation (e.g. AWS Lambda)
- Subscribe to events emitted by the platform
  - Worker-level events such as `'stats'` or `'phaseCompleted'` and aggregate metric reports from multiple workers

These changes make it easier to implement support for new platforms and to move the existing AWS ECS implementation over to use the `Launcher` abstraction.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
