### PR TITLE
fix(core): prevent setting random fields when using loadAll

### DIFF
--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -405,18 +405,27 @@ function datafileVariables(script) {
   let result = {};
   if (script.config.payload) {
     _.each(script.config.payload, function (el) {
-      // If data = [] (i.e. the CSV file is empty, or only has headers and
-      // skipHeaders = true), then row could = undefined
-      let row = el.reader(el.data) || [];
-      _.each(el.fields, function (fieldName, j) {
-        result[fieldName] = row[j];
-      });
+      //when loading all the csv, we don't set individual fields
+      if (!el.loadAll) {
+        // If data = [] (i.e. the CSV file is empty, or only has headers and
+        // skipHeaders = true), then row could = undefined
+        let row = el.reader(el.data) || [];
+        _.each(el.fields, function (fieldName, j) {
+          result[fieldName] = row[j];
+        });
+      }
+
       if (typeof el.name !== 'undefined') {
         // Make the entire CSV available
         result[el.name] = el.reader(el.data);
+      } else {
+        console.log(
+          'WARNING: loadAll is set to true but no name is provided for the CSV data'
+        );
       }
     });
   }
+
   return result;
 }
 


### PR DESCRIPTION
## Description

- Should solve https://github.com/artilleryio/artillery/issues/3268
- Adds a warning when `loadAll` is set without `name`

## Testing
Automated tests need to be added for all the possible options (there aren't any existing ones that check these options). I'll handle that separately to get the fix out now.

However, I have tested manually all cases:
- `loadAll:true, name:something`: this is the bug, resolves it by not setting the random key:value pairs on the root, and only setting the whole csv
- `loadAll:undefined, name:something`: remains the same (sets the data under the name key, but also sets the random key:value pairs).
- `loadAll:true, name:undefined`: previously would set a random key:value pair on the root. This doesn't make sense, as there is a clear intent to load all data. Now logs a warning (in the future, perhaps this should be done with earlier validation, but no validation exists currently for any payload fields).

I've also tested the above when no `fields` are set, and it works (with `loadAll` + `name` it loads all the data, with just `name` it loads a random row).

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes, this section should be clarified
- [ ] Does this require a changelog entry? Yes
