### PR TITLE
dep(playwright): update playwright version to v1.45.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4934,23 +4934,23 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.0.tgz",
-      "integrity": "sha512-yZxAsaxvn60VEPaPghYuL7xC78f994QdkJ3PtPZKozKctsIkT60GiDjjemwJKvWVgo/Z4v/hjim4okLKMIRkEw==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.2.tgz",
+      "integrity": "sha512-oYWP32mCpEtPCE26uY+e82oF/oHa8y6Hx9EPN7ljrHyo6hb+/NDXp6OoJEZ/bwnGHEMKxfeD4yre0iXxBOLTxA==",
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.45.0"
+        "playwright-core": "1.45.2"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
-      "integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.2.tgz",
+      "integrity": "sha512-JxG9eq92ET75EbVi3s+4sYbcG7q72ECeZNbdBlaMkGcNbiDQ4cAi8U2QP5oKkOx+1gpaiL1LDStmzCaEM1Z6fQ==",
       "dependencies": {
-        "playwright": "1.45.0"
+        "playwright": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -17804,11 +17804,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
-      "integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.2.tgz",
+      "integrity": "sha512-ReywF2t/0teRvNBpfIgh5e4wnrI/8Su8ssdo5XsQKpjxJj+jspm00jSoz9BTg91TT0c9HRjXO7LBNVrgYj9X0g==",
       "dependencies": {
-        "playwright-core": "1.45.0"
+        "playwright-core": "1.45.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -17821,9 +17821,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
-      "integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.2.tgz",
+      "integrity": "sha512-ha175tAWb0dTK0X4orvBIqi3jGEt701SMxMhyujxNrgd8K0Uy5wMSwwcQHtyB4om7INUkfndx02XnQ2p6dvLDw==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -23073,10 +23073,10 @@
       "version": "1.14.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@playwright/browser-chromium": "1.45.0",
-        "@playwright/test": "1.45.0",
+        "@playwright/browser-chromium": "1.45.2",
+        "@playwright/test": "1.45.2",
         "debug": "^4.3.2",
-        "playwright": "1.45.0"
+        "playwright": "1.45.2"
       },
       "devDependencies": {
         "tap": "^19.0.2",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.45.0
+FROM mcr.microsoft.com/playwright:v1.45.2
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -20,10 +20,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@playwright/browser-chromium": "1.45.0",
-    "@playwright/test": "1.45.0",
+    "@playwright/browser-chromium": "1.45.2",
+    "@playwright/test": "1.45.2",
     "debug": "^4.3.2",
-    "playwright": "1.45.0"
+    "playwright": "1.45.2"
   },
   "devDependencies": {
     "tap": "^19.0.2",

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: Version we use here needs to be kept consistent with that in
 # artillery-engine-playwright.
 # ********************************
-FROM mcr.microsoft.com/playwright:v1.45.0
+FROM mcr.microsoft.com/playwright:v1.45.2
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description

Upgrades Playwright from 1.45.0 to [1.45.2](https://github.com/microsoft/playwright/releases/tag/v1.45.2). These releases include bug fixes from regressions introduced in 1.45.0.

## Pre-merge checklist

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
