### PR TITLE
fix(core): import mjs path correctly to account for windows paths

### DIFF
--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -18,6 +18,7 @@ const isIdlePhase = require('./is-idle-phase');
 const createReader = require('./readers');
 const engineUtil = require('@artilleryio/int-commons').engine_util;
 const wl = require('./weighted-pick');
+const { pathToFileURL } = require('url');
 
 const Engines = {
   http: require('./engine_http'),
@@ -86,7 +87,9 @@ async function loadProcessor(script, options) {
     );
 
     if (processorPath.endsWith('.mjs')) {
-      const exports = await import(processorPath);
+      const fileUrl = pathToFileURL(processorPath);
+      const exports = await import(fileUrl.href);
+
       script.config.processor = Object.assign(
         {},
         script.config.processor,


### PR DESCRIPTION
## Description

Same fix as https://github.com/artilleryio/artillery/pull/2662. PR was inactive , and we've since implemented windows tests in CI to confirm the fix, so easier to just create the PR ourselves to confirm the fix.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
