### PR TITLE
ci(test): only send windows notification on failure

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,17 +71,12 @@ jobs:
       - name: Run windows tests and capture exit code
         continue-on-error: true
         run: |
-          try {
-            npm run test:windows --workspace artillery
-            $global:ExitCode = 0
-          } catch {
-            $global:ExitCode = $LASTEXITCODE
-          }
-          echo "ExitCode=$global:ExitCode" >> $env:GITHUB_ENV
+          npm run test:windows --workspace artillery
+          echo "HAS_PASSED=$?" >> $env:GITHUB_ENV
         env:
           FORCE_COLOR: 1
       - name: Notify about failures
-        if: ${{ env.ExitCode }} != 0
+        if: env.HAS_PASSED == 'False'
         uses: 8398a7/action-slack@v3.15.1
         with:
           status: failure


### PR DESCRIPTION
## Description

Notifications weren't working well, this should now only notify on failure correctly.

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
