### PR TITLE
fix(lambda): set plugin path to plugin folder and test data folder

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -209,7 +209,8 @@ async function execArtillery(options) {
   const ARTILLERY_PATH =
     ARTILLERY_BINARY_PATH || `${ARTILLERY_NODE_MODULES}/artillery/bin/run`;
 
-  env.ARTILLERY_PLUGIN_PATH = TEST_DATA_NODE_MODULES;
+  // Set the plugin path to the legacy SQS plugin as well as to user's test data for third party plugins
+  env.ARTILLERY_PLUGIN_PATH = `${TEST_DATA_NODE_MODULES}:${ARTILLERY_NODE_MODULES}/artillery/lib/platform/aws-ecs/legacy/plugins`;
   env.HOME = '/tmp';
   env.NODE_PATH = ['/artillery/node_modules', TEST_DATA_NODE_MODULES].join(
     path.delimiter


### PR DESCRIPTION
## Description

https://github.com/artilleryio/artillery/pull/3291 introduced a regression to Lambda tests by [removing the installation](https://github.com/artilleryio/artillery/pull/3291/files#diff-a33800f8944e9e0680e8427bdbe98ef51764c448e6681c5a68737ca2c304fc19L43) of the `artillery-plugin-sqs-reporter`. This was anyway a piece of tech debt, as it's better to set the path to the plugin code that is bundled with the Artillery source code.

## Pre-merge checklist

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No, this was never released
