### PR TITLE
feat(ecs): add ability to set DNS servers and ephemeral storage size

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -129,6 +129,16 @@ RunCommand.flags = {
     description:
       'JSON to customize launch configuration of ECS/Fargate tasks (see https://www.artillery.io/docs/reference/cli/run-fargate#using---launch-config)'
   }),
+  'container-dns-servers': Flags.string({
+    description:
+      'Comma-separated list of DNS servers for Artillery container. Maps to dnsServers parameter in ECS container definition'
+  }),
+  'task-ephemeral-storage': Flags.string({
+    description:
+      'Ephemeral storage in GiB for the worker task. Maps to ephemeralStorage parameter in ECS container definition. Fargate-only.',
+    type: 'integer',
+  }),
+
   'subnet-ids': Flags.string({
     description:
       'Comma-separated list of AWS VPC subnet IDs to launch Fargate tasks in'

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1203,6 +1203,10 @@ async function ensureTaskExists(context) {
       }
     };
 
+    if (context.cliOptions.containerDnsServers) {
+      artilleryContainerDefinition.dnsServers = context.cliOptions.containerDnsServers.split(',');
+    }
+  
     let taskDefinition = {
       family: context.taskName,
       containerDefinitions: [artilleryContainerDefinition],
@@ -1493,6 +1497,12 @@ async function generateTaskOverrides(context) {
 
   if (context.customRoleArn) {
     overrides.taskRoleArn = context.customRoleArn;
+  }
+
+  if (context.cliOptions.taskEphemeralStorage) {
+    overrides.ephemeralStorage = {
+      sizeInGiB: context.cliOptions.taskEphemeralStorage
+    };
   }
 
   overrides.containerOverrides[0].environment.push({


### PR DESCRIPTION
## Description

Add ability to customize two settings for Artillery workers on ECS:

- `--container-dns-servers` can now be used to set the `dnsServers` setting for the Artillery container
- `--ephemeral-storage` can now be used to set the amount of ephemeral storage for the worker task

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
