### PR TITLE
fix: don't print a warning when loadAll is not set

### DIFF
--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -407,23 +407,23 @@ function datafileVariables(script) {
   let result = {};
   if (script.config.payload) {
     _.each(script.config.payload, function (el) {
-      //when loading all the csv, we don't set individual fields
       if (!el.loadAll) {
+        // Load individual fields from the CSV into VU context variables
         // If data = [] (i.e. the CSV file is empty, or only has headers and
         // skipHeaders = true), then row could = undefined
         let row = el.reader(el.data) || [];
         _.each(el.fields, function (fieldName, j) {
           result[fieldName] = row[j];
         });
-      }
-
-      if (typeof el.name !== 'undefined') {
-        // Make the entire CSV available
-        result[el.name] = el.reader(el.data);
       } else {
-        console.log(
-          'WARNING: loadAll is set to true but no name is provided for the CSV data'
-        );
+        if (typeof el.name !== 'undefined') {
+          // Make the entire CSV available
+          result[el.name] = el.reader(el.data);
+        } else {
+          console.log(
+            'WARNING: loadAll is set to true but no name is provided for the CSV data'
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
## Description

Fix issue where Artillery prints a warning when running a test with a payload that does not set `loadAll`.

https://github.com/artilleryio/artillery/pull/3277#issuecomment-2272522330

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No.
- [ ] Does this require a changelog entry? Yes.
