### PR TITLE
fix(examples): add @playwright/test in a package.json

### DIFF
--- a/examples/browser-playwright-reuse-authentication/README.md
+++ b/examples/browser-playwright-reuse-authentication/README.md
@@ -48,3 +48,9 @@ npx artillery run:fargate scenario.yml --count 2
 ```
 
 *Note: `before` hooks run once per Fargate worker, so the authentication step will run as many times as the `--count` you set.*
+
+## Playwright Version Compatibility
+
+It's important to note that Artillery uses specific versions of Playwright, which are listed in our [documentation](https://www.artillery.io/docs/reference/engines/playwright#playwright-compatibility).
+
+The `@playwright/test` version installed in your package.json should ideally match the version Artillery is currently using.

--- a/examples/browser-playwright-reuse-authentication/package.json
+++ b/examples/browser-playwright-reuse-authentication/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "browser-playwright-reuse-authentication",
+  "version": "1.0.0",
+  "description": "Playwright allows you to use `sessionStorage` to reuse authentication in your tests. This can be especially useful in Load Testing, where you might be interested in testing other parts of the application at scale, without having to exercise the login backend (which is sometimes third-party) with every VU.",
+  "main": "flow.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@playwright/test": "1.45.3"
+  }
+}

--- a/examples/browser-playwright-reuse-typescript/README.md
+++ b/examples/browser-playwright-reuse-typescript/README.md
@@ -8,6 +8,8 @@ The `performance` folder contains the Artillery/Playwright test. Using the same 
 
 ## Running the tests
 
+First, run `npm install`.
+
 To run the pure Playwright example:
 `cd e2e && npx playwright run`
 
@@ -23,3 +25,5 @@ In this example we didn't use a [Page Object Model](https://playwright.dev/docs/
 It's important to note that Artillery uses specific versions of Playwright, which are listed in our [documentation](https://www.artillery.io/docs/reference/engines/playwright#playwright-compatibility).
 
 Your regular Playwright tests must use features that are compatible with the versions used by Artillery.
+
+The `@playwright/test` version installed in your package.json should ideally match the version Artillery is currently using.

--- a/examples/browser-playwright-reuse-typescript/package.json
+++ b/examples/browser-playwright-reuse-typescript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "browser-playwright-reuse-typescript",
+  "version": "1.0.0",
+  "description": "This example shows you how you can reuse a pure Playwright codebase written in Typescript as Artillery tests.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@playwright/test": "1.45.3"
+  }
+}


### PR DESCRIPTION
## Description

There are currently some reports of running our examples resulting in a `Error: Cannot find module '@playwright/test'`. This happens when the Artillery package is installed in a different location than the test data.

For now, a quick fix is to get users to install the correct `@playwright/test` package themselves. We will look into a long term fix as well to make the package available to users. 

## Pre-merge checklist

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
