### PR TITLE
feat(JSONPath-Plus): Use library correctly

### DIFF
--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -271,8 +271,7 @@ function templateObjectOrArray(o, context) {
     debug(
       `path = ${path} ; value = ${JSON.stringify(
         value
-      )} (${typeof value}) ; (subj type: ${
-        subj.length ? 'list' : 'hash'
+      )} (${typeof value}) ; (subj type: ${subj.length ? 'list' : 'hash'
       }) ; newValue = ${JSON.stringify(newValue)} ; newPath = ${newPath}`
     );
 
@@ -571,7 +570,6 @@ function dummyParser(body, callback) {
   return callback(null, body);
 }
 
-// doc is a JSON object
 function extractJSONPath(doc, expr) {
   // typeof null is 'object' hence the explicit check here
   if (typeof doc !== 'object' || doc === null) {
@@ -581,7 +579,7 @@ function extractJSONPath(doc, expr) {
   let results;
 
   try {
-    results = jsonpath(expr, doc);
+    results = jsonpath({ path: expr, json: doc, wrap: false });
   } catch (queryErr) {
     debug(queryErr);
   }
@@ -590,11 +588,7 @@ function extractJSONPath(doc, expr) {
     return '';
   }
 
-  if (results.length > 1) {
-    return results[randomInt(0, results.length - 1)];
-  } else {
-    return results[0];
-  }
+  return results;
 }
 
 // doc is a string or an object (body parsed by Request when headers indicate JSON)

--- a/packages/commons/engine_util.js
+++ b/packages/commons/engine_util.js
@@ -570,7 +570,8 @@ function dummyParser(body, callback) {
   return callback(null, body);
 }
 
-function extractJSONPath(doc, expr) {
+// doc is a JSON object
+function extractJSONPath(doc, expr, opts) {
   // typeof null is 'object' hence the explicit check here
   if (typeof doc !== 'object' || doc === null) {
     return '';
@@ -579,7 +580,7 @@ function extractJSONPath(doc, expr) {
   let results;
 
   try {
-    results = jsonpath({ path: expr, json: doc, wrap: false });
+    results = jsonpath({ path: expr, json: doc, wrap: opts.multiple ?? true });
   } catch (queryErr) {
     debug(queryErr);
   }
@@ -588,7 +589,15 @@ function extractJSONPath(doc, expr) {
     return '';
   }
 
-  return results;
+  if (opts.multiple === false) {
+    return results;
+  }
+
+  if (results.length > 1) {
+    return results[randomInt(0, results.length - 1)];
+  } else {
+    return results[0];
+  }
 }
 
 // doc is a string or an object (body parsed by Request when headers indicate JSON)


### PR DESCRIPTION
## Description

This updates the JSON parse logic so that it returns what is requested by the user using the [JSONpath-plus](https://www.npmjs.com/package/jsonpath-plus) standard queries

refactors the `extractJSONPath` function to improve its flexibility and simplify its implementation.


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
