### PR TITLE
fix: make hidden files available to Azure worker

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -224,9 +224,11 @@ sync_test_data_azure () {
     # So we need to move them all up two levels to the current directory
     az storage blob download-batch -d . --account-name "$AZURE_STORAGE_ACCOUNT" -s "$azure_storage_container_name" --pattern "tests/$test_run_id/*"
     local tmpdir="$(mktemp -d)"
-    mv tests/$test_run_id/* $tmpdir
+    set +e
+    mv tests/$test_run_id/{.,}* $tmpdir
     rm -rf tests/$test_run_id
-    mv $tmpdir/* .
+    mv $tmpdir/{.,}* .
+    set -e
 }
 
 sync_test_data_s3 () {


### PR DESCRIPTION
## Description

This change makes sure that files such as custom .npmrc config are made available to the worker on Azure.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
