### PR TITLE
feat(cloud): check that POST requests can be made when Cloud is enabled

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -60,6 +60,12 @@ class RunCommand extends Command {
           );
 
           process.exit(7);
+        } else if (err.name === 'PingFailed') {
+          console.error(
+            'Error: unable to reach Artillery Cloud API. This could be due to firewall restrictions on your network'
+          );
+          console.log('Please see https://docs.art/cloud/err-ping');
+          process.exit(7);
         } else {
           console.error(
             'Error: something went wrong connecting to Artillery Cloud'
@@ -136,7 +142,7 @@ RunCommand.flags = {
   'task-ephemeral-storage': Flags.string({
     description:
       'Ephemeral storage in GiB for the worker task. Maps to ephemeralStorage parameter in ECS container definition. Fargate-only.',
-    type: 'integer',
+    type: 'integer'
   }),
 
   'subnet-ids': Flags.string({

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -169,6 +169,12 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
           );
 
           await gracefulShutdown({ exitCode: 7 });
+        } else if (err.name === 'PingFailed') {
+          console.error(
+            'Error: unable to reach Artillery Cloud API. This could be due to firewall restrictions on your network'
+          );
+          console.log('https://docs.art/cloud/err-ping');
+          await gracefulShutdown({ exitCode: 7 });
         } else {
           console.error(
             'Error: something went wrong connecting to Artillery Cloud'

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -34,6 +34,7 @@ class ArtilleryCloudPlugin {
     this.eventsEndpoint = `${this.baseUrl}/api/events`;
     this.whoamiEndpoint = `${this.baseUrl}/api/user/whoami`;
     this.getAssetUploadUrls = `${this.baseUrl}/api/asset-upload-urls`;
+    this.pingEndpoint = `${this.baseUrl}/api/ping`;
 
     this.defaultHeaders = {
       'x-auth-token': this.apiKey
@@ -222,6 +223,31 @@ class ArtilleryCloudPlugin {
     if (res.statusCode === 401) {
       const err = new Error();
       err.name = 'APIKeyUnauthorized';
+      this.off = true;
+      throw err;
+    }
+
+    let postSucceeded = false;
+    try {
+      res = await request.post(this.pingEndpoint, {
+        headers: this.defaultHeaders,
+        throwHttpErrors: false,
+        retry: {
+          limit: 0
+        }
+      });
+
+      if (res.statusCode === 200) {
+        postSucceeded = true;
+      }
+    } catch (err) {
+      this.off = true;
+      throw err;
+    }
+
+    if (!postSucceeded) {
+      const err = new Error();
+      err.name = 'PingFailed';
       this.off = true;
       throw err;
     }


### PR DESCRIPTION
## Description

This helps detect a common issue on corporate networks where a firewall is blocking POST requests to unknown domains.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
