### PR TITLE
feat(core): specify a Content-Type for individual values when building a formdata request

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -405,15 +405,18 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               let V = template(v, context);
               let options;
               if (V && _.isPlainObject(V)) {
+                if (V.contentType) {
+                  options = { contentType: V.contentType };
+                }
                 if (V.fromFile) {
                   const absPath = path.resolve(
                     path.dirname(context.vars.$scenarioFile),
                     V.fromFile
                   );
                   fileUpload = absPath;
+                  options = { contentType: 'image/png' };
                   V = fs.createReadStream(absPath);
-                } else if (V.contentType) {
-                  options = { contentType: V.contentType };
+                } else if (V.value) {
                   V = V.value;
                 }
               }

--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -414,7 +414,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                     V.fromFile
                   );
                   fileUpload = absPath;
-                  options = { contentType: 'image/png' };
                   V = fs.createReadStream(absPath);
                 } else if (V.value) {
                   V = V.value;

--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -403,15 +403,21 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             requestParams.formData,
             function (acc, v, k) {
               let V = template(v, context);
-              if (V && _.isPlainObject(V) && V.fromFile) {
-                const absPath = path.resolve(
-                  path.dirname(context.vars.$scenarioFile),
-                  V.fromFile
-                );
-                fileUpload = absPath;
-                V = fs.createReadStream(absPath);
+              let options;
+              if (V && _.isPlainObject(V)) {
+                if (V.fromFile) {
+                  const absPath = path.resolve(
+                    path.dirname(context.vars.$scenarioFile),
+                    V.fromFile
+                  );
+                  fileUpload = absPath;
+                  V = fs.createReadStream(absPath);
+                } else if (V.contentType) {
+                  options = { contentType: V.contentType };
+                  V = V.value;
+                }
               }
-              acc.append(k, V);
+              acc.append(k, V, options);
               return acc;
             },
             f

--- a/packages/core/test/unit/engine_http.test.js
+++ b/packages/core/test/unit/engine_http.test.js
@@ -1051,7 +1051,13 @@ test('HTTP engine', function (tap) {
     nock('http://localhost:8888')
       .post(
         '/submit',
-        /Content-Disposition: form-data[\s\S]+activity[\s\S]+surfing/gi
+        (body) =>
+          body.match(
+            /Content-Disposition: form-data[\s\S]+activity[\s\S]+surfing/gi
+          ).length &&
+          body.match(
+            /Content-Disposition: form-data[\s\S]+climate[\s\S]+Content-Type: application\/json[\s\S]+{"temperature": 25, "unit": "Celcius"}/gi
+          ).length
       )
       .reply(200, 'ok');
 
@@ -1068,7 +1074,12 @@ test('HTTP engine', function (tap) {
                 formData: {
                   activity: '{{ activity }}',
                   type: '{{ type }}',
-                  location: '{{ location }}'
+                  location: '{{ location }}',
+                  climate: {
+                    value:
+                      '{"temperature": {{ climate.temperature }}, "unit": "{{ climate.unit }}"}',
+                    contentType: 'application/json'
+                  }
                 }
               }
             }
@@ -1095,7 +1106,11 @@ test('HTTP engine', function (tap) {
       vars: {
         location: 'Lahinch',
         type: 'beach',
-        activity: 'surfing'
+        activity: 'surfing',
+        climate: {
+          temperature: 25,
+          unit: 'Celcius'
+        }
       }
     };
 


### PR DESCRIPTION
## Description

Based on this discussion: https://github.com/artilleryio/artillery/discussions/3315

Support `contentType` when building a request with `formData`. Example:

```yaml
- post:
    name: Post activity
    url: /climate
    formData:
      activity: '{{ activity }}'
      type: '{{ type }}'
      photo:
        fromFile: './photo.png'
      climate:
        value: '{"temperature": "{{ climate.temperature }}", "unit": "{{ climate.unit }}"}'
        contentType: application/json
    expect:
      - statusCode: 201
```

## TODO
- [ ] update docs.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
