### PR TITLE
feat: add --name option for setting test names in Artillery Cloud

### DIFF
--- a/packages/artillery/lib/cli/common-flags.js
+++ b/packages/artillery/lib/cli/common-flags.js
@@ -53,7 +53,12 @@ const CommonRunFlags = {
     hidden: true
   }),
 
-  //Artillery Cloud commands
+  //Artillery Cloud options:
+
+  name: Flags.string({
+    description:
+      'Name of the test run. This name will be shown in the Artillery Cloud dashboard. Equivalent to setting a "name" tag.'
+  }),
   tags: Flags.string({
     description:
       'Comma-separated list of tags in key:value format to tag the test run with in Artillery Cloud, for example: --tags team:sqa,service:foo'

--- a/packages/artillery/lib/cmds/run.js
+++ b/packages/artillery/lib/cmds/run.js
@@ -198,6 +198,14 @@ RunCommand.runCommandImplementation = async function (flags, argv, args) {
         value: path.basename(runnerOpts.scriptPath)
       });
     }
+    // Override the "name" tag with the value of --name if set
+    if (flags.name) {
+      for (const t of tagResult.tags) {
+        if (t.name === 'name') {
+          t.value = flags.name;
+        }
+      }
+    }
 
     if (flags.config) {
       runnerOpts.absoluteConfigPath = path.resolve(process.cwd(), flags.config);

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -299,6 +299,14 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     }
   }
 
+  if (options.name) {
+    for (const t of context.tags) {
+      if (t.name === 'name') {
+        t.value = options.name;
+      }
+    }
+  }
+
   context.extraSecrets = options.secret || [];
 
   context.testId = global.artillery.testRunId;
@@ -1204,9 +1212,10 @@ async function ensureTaskExists(context) {
     };
 
     if (context.cliOptions.containerDnsServers) {
-      artilleryContainerDefinition.dnsServers = context.cliOptions.containerDnsServers.split(',');
+      artilleryContainerDefinition.dnsServers =
+        context.cliOptions.containerDnsServers.split(',');
     }
-  
+
     let taskDefinition = {
       family: context.taskName,
       containerDefinitions: [artilleryContainerDefinition],


### PR DESCRIPTION
## Description

Add `--name` option to all run commands (`run`, `run-lambda`, `run-ecs` and `run-aci`).

The option can be used to set the name of the test that will be shown in Artillery Cloud.

Shorthand for setting the `name` tag. Overrides the `name` tag if that's also set via `--tags`.


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
