### PR TITLE
feat: allow setting resource-level attributes for OpenTelemetry

### DIFF
--- a/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
+++ b/packages/artillery-plugin-publish-metrics/lib/open-telemetry/index.js
@@ -43,6 +43,12 @@ class OTelReporter {
         this.serviceName = translatedConfig.serviceName;
       }
 
+      if (translatedConfig.resourceAttributes) {
+        this.resourceAttributes = translatedConfig.resourceAttributes;
+      } else {
+        this.resourceAttributes = {};
+      }
+
       // Setting traces to first traces configured
       if (translatedConfig.traces && !this.tracesConfig) {
         this.tracesConfig = translatedConfig.traces;
@@ -77,10 +83,16 @@ class OTelReporter {
 
     // Setting resources here as they are used by both metrics and traces and need to be set in a central place where OTel setup is initialised and before any data is generated
     this.resource = Resource.default().merge(
-      new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]:
-          this.serviceName || 'Artillery-test'
-      })
+      new Resource(
+        Object.assign(
+          {},
+          {
+            [SemanticResourceAttributes.SERVICE_NAME]:
+              this.serviceName || 'Artillery-test'
+          },
+          this.resourceAttributes
+        )
+      )
     );
 
     // HANDLING METRICS


### PR DESCRIPTION
## Description

`resourceAttributes` may now be used to set resource [1] level attributes when reporting via Open Telemetry.

```yaml
config:
  plugins:
    publish-metrics:
        - type: 'open-telemetry'

          # Set resource attributes:
          resourceAttributes:
            service.name: Artillery.io
            custom-attribute: some-value
```

Original discussion: https://github.com/artilleryio/artillery/discussions/3333

1. https://opentelemetry.io/docs/languages/js/resources/

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
