### PR TITLE
feat: send CI status to cloud

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24637,7 +24637,7 @@
         "aws-sdk": "^2.1338.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.6.0",
-        "ci-info": "^3.8.0",
+        "ci-info": "^4.0.0",
         "cli-table3": "^0.6.0",
         "cross-spawn": "^7.0.3",
         "csv-parse": "^4.16.3",
@@ -24973,6 +24973,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "packages/artillery/node_modules/ci-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
+      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/artillery/node_modules/color-convert": {

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -12,6 +12,8 @@ const util = require('node:util');
 const chokidar = require('chokidar');
 const fs = require('fs');
 const path = require('path');
+const { isCI, name: ciName } = require('ci-info');
+
 class ArtilleryCloudPlugin {
   constructor(_script, _events, { flags }) {
     this.enabled = false;
@@ -59,8 +61,13 @@ class ArtilleryCloudPlugin {
 
         this.getLoadTestEndpoint = `${this.baseUrl}/api/load-tests/${this.testRunId}/status`;
 
+        const metadata = Object.assign({}, testInfo.metadata, {
+          isCI,
+          ciName
+        });
+
         await this._event('testrun:init', {
-          metadata: testInfo.metadata
+          metadata: metadata
         });
         this.setGetLoadTestInterval = this.setGetStatusInterval();
 

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -116,7 +116,7 @@
     "aws-sdk": "^2.1338.0",
     "chalk": "^2.4.2",
     "chokidar": "^3.6.0",
-    "ci-info": "^3.8.0",
+    "ci-info": "^4.0.0",
     "cli-table3": "^0.6.0",
     "cross-spawn": "^7.0.3",
     "csv-parse": "^4.16.3",


### PR DESCRIPTION
## Description

If the test is running in CI, set isCI true and send the name of the CI service to Artillery Cloud as part of test's metadata.

This will be shown in reports and available as a property to filter & search on too.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
