### PR TITLE
dep: upgrade to Playwright 1.48.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4494,25 +4494,23 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.45.3.tgz",
-      "integrity": "sha512-UVPW8HveE8SghaahoMy8CfG0QdJ2mO0BZLOcPT8nlQh7Z97Gkv4e3Ad69D1oCqM3m3zYkDPAiGB+hOASNS0d/g==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.48.0.tgz",
+      "integrity": "sha512-933FDk719os4Z6iUoXaoO/mxTGSnaXCXHqLgttfGFmNElB+7LVO4jhJ/gnRnQFjhrB3YKFXP86pnMepjaEykcw==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.45.3"
+        "playwright-core": "1.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-      "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
-      "license": "Apache-2.0",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
+      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
       "dependencies": {
-        "playwright": "1.45.3"
+        "playwright": "1.48.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -19951,12 +19949,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-      "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
-      "license": "Apache-2.0",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
+      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
       "dependencies": {
-        "playwright-core": "1.45.3"
+        "playwright-core": "1.48.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -19969,10 +19966,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-      "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
-      "license": "Apache-2.0",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
+      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -19985,7 +19981,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -24688,10 +24683,10 @@
       "version": "1.17.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@playwright/browser-chromium": "1.45.3",
-        "@playwright/test": "1.45.3",
+        "@playwright/browser-chromium": "^1.48.0",
+        "@playwright/test": "^1.48.0",
         "debug": "^4.3.2",
-        "playwright": "1.45.3"
+        "playwright": "^1.48.0"
       },
       "devDependencies": {
         "tap": "^19.0.2",

--- a/packages/artillery-engine-playwright/Dockerfile
+++ b/packages/artillery-engine-playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.45.3
+FROM mcr.microsoft.com/playwright:v1.48.0
 LABEL maintainer="team@artillery.io"
 
 RUN npm install -g artillery \

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -20,10 +20,10 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@playwright/browser-chromium": "1.45.3",
-    "@playwright/test": "1.45.3",
+    "@playwright/browser-chromium": "^1.48.0",
+    "@playwright/test": "^1.48.0",
     "debug": "^4.3.2",
-    "playwright": "1.45.3"
+    "playwright": "^1.48.0"
   },
   "devDependencies": {
     "tap": "^19.0.2",

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: Version we use here needs to be kept consistent with that in
 # artillery-engine-playwright.
 # ********************************
-FROM mcr.microsoft.com/playwright:v1.45.3
+FROM mcr.microsoft.com/playwright:v1.48.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description

Upgrade to most recent release of Playwright (v1.48.0)

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
