### PR TITLE
feat: send GHA job URL to cloud for tests running on GHA

### DIFF
--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -62,7 +62,7 @@ class ArtilleryCloudPlugin {
         this.getLoadTestEndpoint = `${this.baseUrl}/api/load-tests/${this.testRunId}/status`;
 
         let ciURL = null;
-        if (isCI && ciName === GITHUB_ACTIONS) {
+        if (isCI && GITHUB_ACTIONS) {
           const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } =
             process.env;
           if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -12,7 +12,7 @@ const util = require('node:util');
 const chokidar = require('chokidar');
 const fs = require('fs');
 const path = require('path');
-const { isCI, name: ciName } = require('ci-info');
+const { isCI, name: ciName, GITHUB_ACTIONS } = require('ci-info');
 
 class ArtilleryCloudPlugin {
   constructor(_script, _events, { flags }) {
@@ -61,9 +61,19 @@ class ArtilleryCloudPlugin {
 
         this.getLoadTestEndpoint = `${this.baseUrl}/api/load-tests/${this.testRunId}/status`;
 
+        let ciURL = null;
+        if (isCI && ciName === GITHUB_ACTIONS) {
+          const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } =
+            process.env;
+          if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {
+            ciURL = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+          }
+        }
+
         const metadata = Object.assign({}, testInfo.metadata, {
           isCI,
-          ciName
+          ciName,
+          ciURL
         });
 
         await this._event('testrun:init', {


### PR DESCRIPTION
## Description

If an Artillery test is running on GitHub Actions, send the job URL to Artillery Cloud.

This will let the Artillery Cloud reports to link back to the GHA job run that triggered the test.


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
