### PR TITLE
docs: update browser smoke test example

### DIFF
--- a/examples/browser-load-testing-playwright/README.md
+++ b/examples/browser-load-testing-playwright/README.md
@@ -16,7 +16,13 @@ That's it! Artillery will create headless Chrome browsers that will run Playwrig
 
 ## Example 2: A smoke test
 
-This example shows how we can implement a smoke test (or a synthetic check) using a headless browser. We make use of Artillery's [CSV payload](https://artillery.io/docs/guides/guides/test-script-reference.html#Payload-files) feature to specify the URLs we want to check, and [custom metric API](https://artillery.io/docs/guides/guides/extending.html#Tracking-custom-metrics) to track custom metrics.
+This example shows how we can implement a smoke test (or a synthetic check) using a headless browser.
+
+We make use of Artillery's [CSV payload](https://artillery.io/docs/guides/guides/test-script-reference.html#Payload-files) feature to specify the URLs we want to check, and [custom metric API](https://artillery.io/docs/guides/guides/extending.html#Tracking-custom-metrics) to track custom metrics.
+
+For every row in the CSV file, we'll load the URL from the first column, and check that the page contains the text specified in the second column.
+
+The test will load each page specified in the CSV file, and check that it contains the text
 
 ```sh
 npx artillery run browser-smoke-test.yml

--- a/examples/browser-load-testing-playwright/browser-smoke-test.yml
+++ b/examples/browser-load-testing-playwright/browser-smoke-test.yml
@@ -5,6 +5,8 @@ config:
       fields:
         - "url"
         - "title"
+      loadAll: true
+      name: pageChecks
   engines:
     playwright: {}
   processor: ./flows.js

--- a/examples/browser-load-testing-playwright/flows.js
+++ b/examples/browser-load-testing-playwright/flows.js
@@ -37,22 +37,24 @@ async function checkOutArtilleryCoreConceptsFlow(
 // A simple smoke test using a headless browser:
 //
 async function checkPage(page, userContext, events) {
-  const url = userContext.vars.url;
-  const title = userContext.vars.title;
-  const response = await page.goto(url);
-  if (response.status() !== 200) {
-    events.emit('counter', `user.status_check_failed.${url}`, 1);
-  } else {
-    events.emit('counter', `user.status_check_ok.${url}`, 1);
+  // The pageChecks variable is created via the config.payload
+  // section in the YML config file
+  for (const { url, title } of userContext.vars.pageChecks) {
+    const response = await page.goto(url);
+    if (response.status() !== 200) {
+      events.emit('counter', `user.status_check_failed.${url}`, 1);
+    } else {
+      events.emit('counter', `user.status_check_ok.${url}`, 1);
+    }
+
+    const isElementVisible = await page.getByText(title).isVisible();
+
+    if (!isElementVisible) {
+      events.emit('counter', `user.element_check_failed.${title}`, 1);
+    }
+
+    await page.reload();
   }
-
-  const isElementVisible = await page.getByText(title).isVisible();
-
-  if (!isElementVisible) {
-    events.emit('counter', `user.element_check_failed.${title}`, 1);
-  }
-
-  await page.reload();
 }
 
 async function multistepWithCustomMetrics(page, userContext, events, test) {

--- a/examples/browser-load-testing-playwright/pages.csv
+++ b/examples/browser-load-testing-playwright/pages.csv
@@ -1,3 +1,3 @@
 https://www.artillery.io/,The Artillery Manifesto
 https://www.artillery.io/docs,What's different about Artillery?
-https://www.artillery.io/cloud,Test more effectively & fix issues faster
+https://www.artillery.io/changelog,Feature updates and improvements to Artillery


### PR DESCRIPTION
## Description

The example will currently check only one page by default unless a `config.phases` section is added with the number of VUs matching the number of rows. This PR fixes that:

- Use `loadAll` to always load all rows in the CSV file and only run one VU (instead of relying on creating the right number of VUs)
- Update the checks in the CSV file

Reported in https://github.com/artilleryio/artillery/discussions/3367

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
