### PR TITLE
fix: use wget instead of curl to install az CLI

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     libtool \
     python3-pip && pip3 install awscli --break-system-packages
 
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN wget https://aka.ms/InstallAzureCLIDeb && bash InstallAzureCLIDeb
 
 ARG WORKER_VERSION
 ENV WORKER_VERSION=$WORKER_VERSION


### PR DESCRIPTION
## Description

Docker builds for arm64 have been broken since https://github.com/artilleryio/artillery/pull/3363

The issue is caused by:

- An issue with curl/OpenSSL specific to Ubuntu 24 on arm64:
  - https://github.com/curl/curl/issues/14154
  - https://bugs.launchpad.net/ubuntu/+source/curl/+bug/2073448
- Our image uses Ubuntu 24 now as that's what the Playwright v1.48.0 image is based on



## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
