### PR TITLE
fix: remove files in Azure Blob Storage only once per test run

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -578,13 +578,15 @@ cleanup () {
         CLEANING_UP="yes"
 
         if [[ "$is_azure" = "yes" ]] ; then
-            if [[ -z "${AZURE_RETAIN_BLOBS:-""}" ]] ; then
-                # This exits with 0 regardless of whether the pattern matches any
-                # blobs or not so it's OK to run this multiple times
-                az storage blob delete-batch \
-                    --account-name "$AZURE_STORAGE_ACCOUNT" \
-                    -s "$azure_storage_container_name" \
-                    --pattern "tests/$test_run_id/*"
+            if [[ "$is_leader" = "true" ]] ; then
+                if [[ -z "${AZURE_RETAIN_BLOBS:-""}" ]] ; then
+                    # This exits with 0 regardless of whether the pattern matches any
+                    # blobs or not so it's OK to run this multiple times
+                    az storage blob delete-batch \
+                        --account-name "$AZURE_STORAGE_ACCOUNT" \
+                        -s "$azure_storage_container_name" \
+                        --pattern "tests/$test_run_id/*"
+                fi
             fi
         fi
 


### PR DESCRIPTION
## Description

The current cleanup() code will attempt to remove files from Blob Storage in every worker in a test. This can lead to the following issue:

- User launches a test with a lot of workers (e.g. 100)
- Workers 1 to 50 launch and boostrap successfully
- Worker 51 encounters an error and exits early
- Workers 52 onwards won't be able to download test-related assets from Blob Storage anymore, and will fail

The main problem with this is that this makes debugging the actual cause of a failure much harder, as container logs will be polluted with errors related to inability to download test assets.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
