### PR TITLE
feat: allow worker image overrides on Azure

### DIFF
--- a/packages/artillery/lib/platform/az/aci.js
+++ b/packages/artillery/lib/platform/az/aci.js
@@ -443,7 +443,9 @@ class PlatformAzureACI {
     const imageVersion =
       process.env.ARTILLERY_WORKER_IMAGE_VERSION || IMAGE_VERSION;
     const defaultArchitecture = 'x86_64';
-    const containerImageURL = `public.ecr.aws/d8a4z9o5/artillery-worker:${imageVersion}-${defaultArchitecture}`;
+    const containerImageURL =
+      process.env.WORKER_IMAGE_URL ||
+      `public.ecr.aws/d8a4z9o5/artillery-worker:${imageVersion}-${defaultArchitecture}`;
 
     const client = new ContainerInstanceManagementClient(
       credential,


### PR DESCRIPTION
## Description

Allow for the worker image to be overridden on Azure via `WORKER_IMAGE_URL` environment variable (same as on AWS Lambda and Fargate). Useful for development & debugging.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
