### PR TITLE
fix: disable SSL verification on arm64 as a workaround

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -4,6 +4,8 @@
 # ********************************
 FROM mcr.microsoft.com/playwright:v1.48.0
 
+ARG TARGETARCH
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install aws-lambda-ric build dependencies
@@ -16,6 +18,15 @@ RUN apt-get update && apt-get install -y \
     autoconf \
     libtool \
     python3-pip && pip3 install awscli --break-system-packages
+
+RUN <<EOT
+echo 'ipv4' >> ~/.curlrc
+if [ "$TARGETARCH" = "arm64" ]; then
+# Temporal fix for SSL_ERROR_SYSCALL error on arm64
+# see: https://github.com/curl/curl/issues/14154
+echo 'insecure' >> ~/.curlrc
+fi
+EOT
 
 RUN wget https://aka.ms/InstallAzureCLIDeb && bash InstallAzureCLIDeb
 


### PR DESCRIPTION
This change temporarily disables SSL verification in `curl` at build time on ARM64 only. This is a workaround to have ARM64 builds working again, see https://github.com/artilleryio/artillery/pull/3375