### PR TITLE
ci: disable ARM64 builds & tests for canary releases

### DIFF
--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       COMMIT_SHA: ${{ github.sha }}
       USE_COMMIT_SHA_IN_VERSION: true
-      SHOULD_BUILD_ARM64: true
+      SHOULD_BUILD_ARM64: false
     secrets:
       ECR_WORKER_IMAGE_PUSH_ROLE_ARN: ${{ secrets.ECR_WORKER_IMAGE_PUSH_ROLE_ARN }}
 
@@ -82,7 +82,7 @@ jobs:
     needs: build
     with:
       ARTILLERY_VERSION_OVERRIDE: ${{ needs.build.outputs.ARTILLERY_VERSION }}
-      HAS_ARM64_BUILD: true
+      HAS_ARM64_BUILD: false
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Description

Disabling ARM64 builds & tests for canary releases - those can take upwards of 35m at a time.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
