### PR TITLE
dep: upgrade posthog-node to fix moderate vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7530,19 +7530,20 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -17537,12 +17538,13 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-2.6.0.tgz",
-      "integrity": "sha512-/BiFw/jwdP0uJSRAIoYqLoBTjZ612xv74b1L/a3T/p1nJVL8e0OrHuxbJW56c6WVW/IKm9gBF/zhbqfaz0XgJQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.2.1.tgz",
+      "integrity": "sha512-l+fsjYEkTik3m/G0pE7gMr4qBJP84LhK779oQm6MBzhBGpd4By4qieTW+4FUAlNCyzQTynn3Nhsa50c0IELSxQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.27.0"
+        "axios": "^1.7.4",
+        "rusha": "^0.8.14"
       },
       "engines": {
         "node": ">=15.0.0"
@@ -22064,7 +22066,7 @@
         "moment": "^2.29.4",
         "nanoid": "^3.3.4",
         "ora": "^4.0.4",
-        "posthog-node": "^2.2.3",
+        "posthog-node": "^4.2.1",
         "rc": "^1.2.8",
         "sqs-consumer": "5.8.0",
         "temp": "^0.9.4",
@@ -22111,7 +22113,7 @@
       "dependencies": {
         "async": "^3.2.4",
         "debug": "^4.3.4",
-        "posthog-node": "^2.2.3"
+        "posthog-node": "^4.2.1"
       },
       "devDependencies": {
         "tap": "^19.0.2"
@@ -22120,17 +22122,6 @@
     "packages/artillery-engine-posthog/node_modules/async": {
       "version": "3.2.4",
       "license": "MIT"
-    },
-    "packages/artillery-engine-posthog/node_modules/posthog-node": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.27.0",
-        "rusha": "^0.8.14"
-      },
-      "engines": {
-        "node": ">=15.0.0"
-      }
     },
     "packages/artillery-plugin-apdex": {
       "version": "1.12.0",
@@ -22664,7 +22655,7 @@
         "jmespath": "^0.16.0",
         "js-yaml": "^3.13.1",
         "mime-types": "2.1.35",
-        "posthog-node": "^3.1.2",
+        "posthog-node": "^4.2.1",
         "sprintf-js": "^1.1.2",
         "temp": "^0.9.4"
       },
@@ -22907,17 +22898,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
-    },
-    "packages/skytrace/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "packages/skytrace/node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -23166,20 +23146,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/skytrace/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "packages/skytrace/node_modules/fs-extra": {
@@ -23433,19 +23399,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/skytrace/node_modules/posthog-node": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-3.6.3.tgz",
-      "integrity": "sha512-JB+ei0LkwE+rKHyW5z79Nd1jUaGxU6TvkfjFqY9vQaHxU5aU8dRl0UUaEmZdZbHwjp3WmXCBQQRNyimwbNQfCw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.2",
-        "rusha": "^0.8.14"
-      },
-      "engines": {
-        "node": ">=15.0.0"
       }
     },
     "packages/skytrace/node_modules/semver": {

--- a/packages/artillery-engine-posthog/index.js
+++ b/packages/artillery-engine-posthog/index.js
@@ -159,7 +159,7 @@ class PosthogEngine {
         }
 
         if (context.postHogClient) {
-          callbackify(context.postHogClient.shutdownAsync)((postHogErr) => {
+          callbackify(context.postHogClient.shutdown)((postHogErr) => {
             // Ignore PostHog error as there's nothing we can do anyway
             debug(postHogErr);
             return callback(err, context);

--- a/packages/artillery-engine-posthog/package.json
+++ b/packages/artillery-engine-posthog/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "async": "^3.2.4",
     "debug": "^4.3.4",
-    "posthog-node": "^2.2.3"
+    "posthog-node": "^4.2.1"
   }
 }

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -136,7 +136,7 @@
     "moment": "^2.29.4",
     "nanoid": "^3.3.4",
     "ora": "^4.0.4",
-    "posthog-node": "^2.2.3",
+    "posthog-node": "^4.2.1",
     "rc": "^1.2.8",
     "sqs-consumer": "5.8.0",
     "temp": "^0.9.4",

--- a/packages/skytrace/package.json
+++ b/packages/skytrace/package.json
@@ -35,7 +35,7 @@
     "jmespath": "^0.16.0",
     "js-yaml": "^3.13.1",
     "mime-types": "2.1.35",
-    "posthog-node": "^3.1.2",
+    "posthog-node": "^4.2.1",
     "sprintf-js": "^1.1.2",
     "temp": "^0.9.4"
   },


### PR DESCRIPTION
## Description

See https://github.com/advisories/GHSA-wf5p-g6vw-rhxx. This affects the `0.8.1 - 0.27.2` versions of `axios`, which affects the `<=1.3.0 || 2.1.0 - 3.1.2` versions of `posthog-node`, so I upgraded the latter to 4.1.2.

Fixes https://github.com/artilleryio/artillery/issues/2519.

Please find the breaking changes of `posthog-node` here:
https://github.com/PostHog/posthog-js-lite/blob/main/posthog-node/CHANGELOG.md

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
