### PR TITLE
fix: add utility functions to get  module type

### DIFF
--- a/packages/artillery/lib/util/prepare-test-execution-plan.js
+++ b/packages/artillery/lib/util/prepare-test-execution-plan.js
@@ -2,6 +2,7 @@ const csv = require('csv-parse');
 const fs = require('node:fs');
 const path = require('node:path');
 const p = require('util').promisify;
+const { isPackageESM } = require('@artilleryio/int-core').util;
 
 const {
   readScript,
@@ -118,6 +119,8 @@ function replaceProcessorIfTypescript(script, scriptPath) {
     return script;
   }
 
+  const packageType = isPackageESM(scriptPath) ? 'esm' : 'cjs';
+
   const actualProcessorPath = path.resolve(
     path.dirname(scriptPath),
     relativeProcessorPath
@@ -140,7 +143,7 @@ function replaceProcessorIfTypescript(script, scriptPath) {
       outfile: newProcessorPath,
       bundle: true,
       platform: 'node',
-      format: 'cjs',
+      format: packageType,
       sourcemap: 'inline',
       external: ['@playwright/test', ...userExternalPackages]
     });

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -94,5 +94,6 @@ module.exports = {
   engine_http: require('./lib/engine_http'),
   ssms: require('./lib/ssms'),
   isIdlePhase: require('./lib/is-idle-phase'),
-  updateGlobalObject
+  updateGlobalObject,
+  util: require('./lib/util')
 };

--- a/packages/core/lib/runner.js
+++ b/packages/core/lib/runner.js
@@ -13,6 +13,7 @@ const uuidv4 = require('uuid').v4;
 const { SSMS } = require('./ssms');
 const createPhaser = require('./phases');
 const createReader = require('./readers');
+const { isPackageESM } = require('./util');
 const engineUtil = require('@artilleryio/int-commons').engine_util;
 const wl = require('./weighted-pick');
 const { pathToFileURL } = require('url');
@@ -83,7 +84,7 @@ async function loadProcessor(script, options) {
       script.config.processor
     );
 
-    if (processorPath.endsWith('.mjs')) {
+    if (isPackageESM(processorPath)) {
       const fileUrl = pathToFileURL(processorPath);
       const exports = await import(fileUrl.href);
       script.config.processor = Object.assign(

--- a/packages/core/lib/util.js
+++ b/packages/core/lib/util.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const path = require('path');
+const fs = require('fs');
+
+function determineModuleTypeByPackageJson(filePath) {
+  // If it's .js, we need to check the package.json
+  try {
+    // Start from script directory and move up until we find package.json
+    let dir = path.dirname(filePath);
+    while (dir !== path.parse(dir).root) {
+      try {
+        const pkgPath = path.join(dir, 'package.json');
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        return pkg.type === 'module' ? 'esm' : 'commonjs';
+      } catch (err) {
+        dir = path.dirname(dir);
+      }
+    }
+
+    // No package.json found, default to commonjs
+    return 'commonjs';
+  } catch (err) {
+    return 'commonjs';
+  }
+}
+
+function determineModuleType(filePath) {
+  if (filePath.endsWith('.mjs')) return 'esm';
+  if (filePath.endsWith('.cjs')) return 'commonjs';
+
+  return determineModuleTypeByPackageJson(filePath);
+}
+
+/**
+ * Determine if a package is ESM or not.
+ * @param {string | undefined} filePath Path to the package.json file. If not provided, it will default to the current working directory.
+ * @returns A boolean indicating if the package is ESM or not.
+ */
+function isPackageESM(filePath) {
+  if (!filePath) filePath = process.cwd();
+
+  return determineModuleType(filePath) === 'esm';
+}
+
+/**
+ * Determine if a package is CommonJS or not.
+ * @param {string | undefined} filePath Path to the package.json file. If not provided, it will default to the current working directory.
+ * @returns A boolean indicating if the package is CommonJS or not.
+ */
+function isPackageCommonJS(filePath) {
+  if (!filePath) filePath = process.cwd();
+
+  return determineModuleType(filePath) === 'commonjs';
+}
+
+module.exports = {
+  determineModuleType,
+  isPackageESM,
+  isPackageCommonJS
+};


### PR DESCRIPTION
## Description

This PR will add more complete handling with regards to the CommonJS and ESM standards. This PR should solve #3203 and #2661.

We now look at the extension first, if it's .cjs or .mjs, great, that's easy to resolve. Otherwise, we look for the first package.json we come across, check it's module type, and then determine the project's standards.

The esbuild has been updated to accomodate this change as well.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
