### PR TITLE
feat: define Artillery + Playwright tests fully in TypeScript

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,11 +28,10 @@ jobs:
         run: npm ci
 
       - name: Run example
-        uses: actions/setup-node@v3
+        uses: artilleryio/action-cli@v1
         with:
-          node-version: '20.x'
-      - run: |
-          artillery run browser-load-test.ts --record --tags ${{ env.CLI_TAGS }},group:browser-load-test --note ${{ env.CLI_NOTE }}
+          command: run browser-load-test.ts --record --tags ${{ env.CLI_TAGS }},group:browser-load-test --note ${{ env.CLI_NOTE }}
+          working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
           ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,32 @@ env:
   CLI_NOTE: Running&nbsp;from&nbsp;the&nbsp;Official&nbsp;Artillery&nbsp;Github&nbsp;Action!&nbsp;😀
 
 jobs:
+  browser-load-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CWD: ./examples/browser-load-testing-playwright
+    defaults:
+      run:
+        working-directory: ${{ env.CWD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install
+        run: npm ci
+
+      - name: Run example
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      - run: |
+          artillery run browser-load-test.ts --record --tags ${{ env.CLI_TAGS }},group:browser-load-test --note ${{ env.CLI_NOTE }}
+        env:
+          ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
+          ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}
+          ARTILLERY_CLOUD_API_KEY: ${{ secrets.ARTILLERY_CLOUD_API_KEY_TEST }}
+
   http-metrics-by-endpoint:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,14 +24,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install
-        run: npm ci
-
       - name: Run example
-        uses: artilleryio/action-cli@v1
+        uses: actions/setup-node@v3
         with:
-          command: run browser-load-test.ts --record --tags ${{ env.CLI_TAGS }},group:browser-load-test --note ${{ env.CLI_NOTE }}
-          working-directory: ${{ env.CWD }}
+          node-version: '20.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run test
+        run: |
+          $ARTILLERY_BINARY_PATH run browser-load-test.ts --record --tags ${{ env.CLI_TAGS }},group:browser-load-test --note "${{ env.CLI_NOTE }}"
+        working-directory: ${{ env.CWD }}
         env:
           ARTILLERY_BINARY_PATH: ${{ env.ARTILLERY_BINARY_PATH }}
           ARTILLERY_CLOUD_ENDPOINT: ${{ secrets.ARTILLERY_CLOUD_ENDPOINT_TEST }}

--- a/examples/browser-load-testing-playwright/README.md
+++ b/examples/browser-load-testing-playwright/README.md
@@ -1,14 +1,24 @@
-# Load testing and smoke testing with real browsers
+# Load testing and smoke testing with headless browsers
 
+Artillery can run Playwright scripts as performance tests. This example shows you how to run a simple load test, a smoke test, and how to track custom metrics for part of the flow.
 
-Ever wished you could run load tests with *real browsers*? Well, now you can! You can combine Artillery with Playwright to run full browser tests, and this example shows you how. We can run both load tests, and smoke tests with headless browsers.
+- [Why load test with headless browsers?](https://www.artillery.io/docs/playwright#why-load-test-with-headless-browsers)
 
+> [!TIP]
+> Artillery's uses YAML as its default configuration format, but Playwright tests can be written as TypeScript. The examples below are shown as both TypeScript-only, and YAML + TypeScript.
 
 ## Example 1: A simple load test
 
 Run a simple load test using a plain Playwright script (recorded with `playwright codegen` - no Artillery-specific changes required):
 
+
 ```sh
+# Run the TypeScript example:
+npx artillery run browser-load-test.ts
+```
+
+```sh
+# The same example configured with a separate YAML config file:
 npx artillery run browser-load-test.yml
 ```
 
@@ -25,6 +35,12 @@ For every row in the CSV file, we'll load the URL from the first column, and che
 The test will load each page specified in the CSV file, and check that it contains the text
 
 ```sh
+# Run the TypeScript example:
+npx artillery run browser-smoke-test.ts
+```
+
+```sh
+# The same example configured with a separate YAML config file:
 npx artillery run browser-smoke-test.yml
 ```
 
@@ -92,6 +108,10 @@ browser.page_domcontentloaded.dominteractive.https://artillery.io/pro/:
   p99: ...................................................... 1380.5
 ```
 
-## Scale out
+## Scaling browser tests
 
-Want to run 1,000 browsers at the same time? 10,000? more? Run your load tests on AWS Fargate with built-in support in Artillery. See our guide for [Load testing on AWS Fargate](https://www.artillery.io/docs/load-testing-at-scale/aws-fargate) for more information.
+Running headless browsers in parallel will quickly exhaust CPU and memory of a single machine.
+
+Artillery has built-in support for cloud-native distributed load testing on AWS Fargate or Azure Container Instances.
+
+See our guide for [Distributed load testing](https://www.artillery.io/docs/load-testing-at-scale) for more information.

--- a/examples/browser-load-testing-playwright/browser-load-test.ts
+++ b/examples/browser-load-testing-playwright/browser-load-test.ts
@@ -1,0 +1,22 @@
+import { checkOutArtilleryCoreConceptsFlow } from './flows.js';
+
+export const config = {
+  target: 'https://www.artillery.io',
+  phases: [
+    {
+      arrivalRate: 1,
+      duration: 10
+    }
+  ],
+  engines: {
+    playwright: {}
+  }
+};
+
+export const scenarios = [
+  {
+    engine: 'playwright',
+    name: 'check_out_core_concepts_scenario',
+    testFunction: checkOutArtilleryCoreConceptsFlow
+  }
+];

--- a/examples/browser-load-testing-playwright/browser-smoke-test.ts
+++ b/examples/browser-load-testing-playwright/browser-smoke-test.ts
@@ -1,0 +1,27 @@
+import { checkPage } from './flows';
+export const config = {
+  target: 'https://www.artillery.io',
+  phases: [
+    {
+      arrivalCount: 1,
+      duration: 1
+    }
+  ],
+  payload: {
+    path: './pages.csv',
+    fields: ['url', 'title'],
+    loadAll: true,
+    name: 'pageChecks'
+  },
+  engines: {
+    playwright: {}
+  }
+};
+
+export const scenarios = [
+  {
+    name: 'smoke_test_page',
+    engine: 'playwright',
+    testFunction: checkPage
+  }
+];

--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -351,7 +351,8 @@ class PlaywrightEngine {
 
         const fn =
           self.processor[spec.testFunction] ||
-          self.processor[spec.flowFunction];
+          self.processor[spec.flowFunction] ||
+          spec.testFunction;
 
         if (!fn) {
           console.error('Playwright test function not found:', fn);

--- a/packages/artillery/lib/artillery-global.js
+++ b/packages/artillery/lib/artillery-global.js
@@ -17,10 +17,6 @@ async function createGlobalObject(opts) {
   global.artillery._workerThreadSend =
     global.artillery._workerThreadSend || null;
 
-  // TODO: Refactor these special fields away
-  global.artillery.__util = global.artillery.__util || {};
-  global.artillery.__util.parseScript = parseScript;
-  global.artillery.__util.readScript = readScript;
   global.artillery.__createReporter = require('./console-reporter');
 
   global.artillery._exitCode = 0;

--- a/packages/artillery/lib/cmds/quick.js
+++ b/packages/artillery/lib/cmds/quick.js
@@ -70,8 +70,8 @@ class QuickCommand extends Command {
       script.scenarios[0].engine = 'ws';
     }
 
-    const tmpf = tmp.fileSync();
-    fs.writeFileSync(tmpf.name, JSON.stringify(script, null, 2), { flag: 'w' });
+    const tmpf = `${tmp.fileSync().name}.yml`;
+    fs.writeFileSync(tmpf, JSON.stringify(script, null, 2), { flag: 'w' });
 
     const runArgs = [];
     if (flags.output) {
@@ -82,7 +82,7 @@ class QuickCommand extends Command {
       runArgs.push('--quiet');
     }
 
-    runArgs.push(`${tmpf.name}`);
+    runArgs.push(tmpf);
 
     RunCommand.run(runArgs);
   }

--- a/packages/artillery/lib/platform/local/artillery-worker-local.js
+++ b/packages/artillery/lib/platform/local/artillery-worker-local.js
@@ -104,9 +104,23 @@ class ArtilleryWorker {
     this.state = STATES.preparing;
 
     const { script, payload, options } = opts;
+    let scriptForWorker = script;
+
+    if (script.__transpiledTypeScriptPath && script.__originalScriptPath) {
+      scriptForWorker = {
+        __transpiledTypeScriptPath: script.__transpiledTypeScriptPath,
+        __originalScriptPath: script.__originalScriptPath
+      };
+    }
+
     this.worker.postMessage({
       command: 'prepare',
-      opts: { script, payload, options, testRunId: global.artillery.testRunId }
+      opts: {
+        script: scriptForWorker,
+        payload,
+        options,
+        testRunId: global.artillery.testRunId
+      }
     });
 
     await awaitOnEE(this.workerEvents, 'readyWaiting', 50);

--- a/packages/artillery/lib/platform/local/index.js
+++ b/packages/artillery/lib/platform/local/index.js
@@ -52,6 +52,7 @@ class PlatformLocal {
     }
 
     for (const [workerId, w] of Object.entries(this.workers)) {
+      this.opts.cliArgs = this.platformOpts.cliArgs;
       await this.prepareWorker(workerId, {
         script: w.script,
         payload: this.payload,

--- a/packages/artillery/lib/platform/local/worker.js
+++ b/packages/artillery/lib/platform/local/worker.js
@@ -105,7 +105,17 @@ async function prepare(opts) {
     send({ event: 'log', args });
   });
 
-  const { script: _script, payload, options } = opts;
+  let _script;
+  if (
+    opts.script.__transpiledTypeScriptPath &&
+    opts.script.__originalScriptPath
+  ) {
+    _script = require(opts.script.__transpiledTypeScriptPath);
+  } else {
+    _script = opts.script;
+  }
+
+  const { payload, options } = opts;
   const script = await loadProcessor(_script, options);
 
   global.artillery.testRunId = opts.testRunId;

--- a/packages/artillery/lib/platform/local/worker.js
+++ b/packages/artillery/lib/platform/local/worker.js
@@ -31,6 +31,8 @@ const EventEmitter = require('eventemitter3');
 const p = require('util').promisify;
 const { loadProcessor } = core.runner.runnerFuncs;
 
+const prepareTestExecutionPlan = require('../../util/prepare-test-execution-plan');
+
 process.env.LOCAL_WORKER_ID = threadId;
 
 parentPort.on('message', onMessage);
@@ -110,7 +112,12 @@ async function prepare(opts) {
     opts.script.__transpiledTypeScriptPath &&
     opts.script.__originalScriptPath
   ) {
-    _script = require(opts.script.__transpiledTypeScriptPath);
+    // Load and process pre-compiled TypeScript file
+    _script = await prepareTestExecutionPlan(
+      [opts.script.__originalScriptPath],
+      opts.options.cliArgs,
+      []
+    );
   } else {
     _script = opts.script;
   }

--- a/packages/artillery/test/cloud-e2e/fargate/misc.test.js
+++ b/packages/artillery/test/cloud-e2e/fargate/misc.test.js
@@ -8,6 +8,8 @@ const {
   checkAggregateCounterSums
 } = require('../../helpers/expectations');
 
+const path = require('path');
+
 const A9_PATH = process.env.A9_PATH || 'artillery';
 
 before(async () => {
@@ -21,6 +23,20 @@ beforeEach(async (t) => {
   $.verbose = true;
 
   reportFilePath = generateTmpReportPath(t.name, 'json');
+});
+
+test('Playwright test in TypeScript (example)', async (t) => {
+  const scenarioPath = path.resolve(
+    __dirname,
+    '../../../../../examples/browser-load-testing-playwright/browser-load-test.ts'
+  );
+  const output =
+    await $`${A9_PATH} run-fargate ${scenarioPath} --record --tags ${baseTags}`;
+  t.ok(output.stdout.includes('Summary report'));
+  t.ok(output.stdout.includes('p99'));
+  t.ok(output.stdout.includes('vusers.completed'));
+  t.ok(output.stdout.includes('browser.page.FCP.https://www.artillery.io/'));
+  t.equal(output.exitCode, 0, 'CLI Exit Code should be 0');
 });
 
 test('Kitchen Sink Test - multiple features together', async (t) => {


### PR DESCRIPTION
## Description

This PR adds support for defining Artillery + Playwright load tests entirely in TypeScript:

- `config` and `scenario` sections map exactly onto their YAML equivalents
- `config.processor` is no longer needed - test functions can be defined inline (or imported from another existing module)

**Known limitations & issues:**

- [x] CLI flags that dynamically override anything in the test definition (e.g. `--solo` or `--overrides`) are not taken into account yet
- [ ] Type definitions need to be added
- [x] Cloud bundler is not aware of TypeScript yet - won't run on Fargate / ACI yet

- [x] Also missing e2e tests.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
