### PR TITLE
fix: make $rewriteMetricName work with TypeScript scripts

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -8,6 +8,11 @@ class PlaywrightEngine {
 
     this.config = script.config?.engines?.playwright || {};
     this.processor = script.config.processor || {};
+
+    if (script.$rewriteMetricName) {
+      this.processor.$rewriteMetricName = script.$rewriteMetricName;
+    }
+
     this.launchOptions = this.config.launchOptions || {};
     this.contextOptions = this.config.contextOptions || {};
 


### PR DESCRIPTION
## Description

Make `$rewriteMetricName` work with test scripts in TypeScript.

Needs to be exported from the script.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? No 
