### PR TITLE
Pre-install browsers in docker container

### DIFF
--- a/packages/artillery/Dockerfile
+++ b/packages/artillery/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:18-alpine
+FROM node:22-bookworm-slim
 LABEL maintainer="team@artillery.io"
 
 WORKDIR /home/node/artillery
 
 COPY package*.json ./
 RUN npm --ignore-scripts --production install
-RUN yes | npx playwright install
+RUN yes | npx playwright install --with-deps
 
 COPY . ./
 ENV PATH="/home/node/artillery/bin:${PATH}"

--- a/packages/artillery/Dockerfile
+++ b/packages/artillery/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /home/node/artillery
 
 COPY package*.json ./
 RUN npm --ignore-scripts --production install
+RUN yes | npx playwright install
 
 COPY . ./
 ENV PATH="/home/node/artillery/bin:${PATH}"


### PR DESCRIPTION
The current docker container can't run playwright scripts since the required playwright browsers are missing, this PR fixes that by pre-installing them

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
