### PR TITLE
fix: only install Chromium in the Docker image

### DIFF
--- a/packages/artillery/Dockerfile
+++ b/packages/artillery/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/node/artillery
 
 COPY package*.json ./
 RUN npm --ignore-scripts --production install
-RUN yes | npx playwright install --with-deps
+RUN npx playwright install --with-deps chromium
 
 COPY . ./
 ENV PATH="/home/node/artillery/bin:${PATH}"


### PR DESCRIPTION
## Description

Follow up to #3445. Installing Chromium only as only Chromium is officially supported by Artillery + Playwright integration right now.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
