### PR TITLE
set the NODE_PATH environment variable

### DIFF
--- a/packages/artillery/Dockerfile
+++ b/packages/artillery/Dockerfile
@@ -1,13 +1,16 @@
-FROM node:22-bookworm-slim
+FROM node:22-bookworm
 LABEL maintainer="team@artillery.io"
+
+RUN apt-get update && apt-get install bash
 
 WORKDIR /home/node/artillery
 
 COPY package*.json ./
-RUN npm --ignore-scripts --production install
+RUN npm --ignore-scripts --production install && npm install @playwright/test
 RUN npx playwright install --with-deps chromium
 
 COPY . ./
 ENV PATH="/home/node/artillery/bin:${PATH}"
+ENV NODE_PATH=/home/node/artillery/node_modules
 
 ENTRYPOINT ["/home/node/artillery/bin/run"]


### PR DESCRIPTION
## Add the NODE_PATH 

<!-- 
when running Playwright scripts from out side the artillery repository, nodeJS needs to know where the libraries are. Setting NODE_PATH is a common way of achieving this
-->

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
