### PR TITLE
fix: optional task role name in Fargate run command

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -75,14 +75,16 @@ class RunCommand extends Command {
       }
     }
 
+    flags.taskRoleName = flags['task-role-name'] || ECS_WORKER_ROLE_NAME;
+
     const ECS = new PlatformECS(
       null,
       null,
       {},
-      { testRunId: 'foo', region: flags.region }
+      { testRunId: 'foo', region: flags.region, taskRoleName: flags.taskRoleName }
     );
     await ECS.init();
-    flags.taskRoleName = flags['task-role-name'] || ECS_WORKER_ROLE_NAME;
+    
     process.env.USE_NOOP_BACKEND_STORE = 'true';
 
     telemetry.capture('run:fargate', {

--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -48,12 +48,14 @@ class PlatformECS {
 
   async init() {
     await setDefaultAWSCredentials(AWS);
-
     this.accountId = await getAccountId();
 
     await ensureSSMParametersExist(this.platformOpts.region);
     await ensureS3BucketExists('global', this.s3LifecycleConfigurationRules);
-    await createIAMResources(this.accountId);
+    
+    if (!this.platformOpts.taskRoleName) {
+      await createIAMResources(this.accountId);
+    }
   }
 
   async createWorker() {}

--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -11,10 +11,7 @@ const AWS = require('aws-sdk');
 
 const { ensureParameterExists } = require('./legacy/aws-util');
 
-const {
-  S3_BUCKET_NAME_PREFIX,
-  ECS_WORKER_ROLE_NAME
-} = require('../aws/constants');
+const { S3_BUCKET_NAME_PREFIX } = require('../aws/constants');
 
 const getAccountId = require('../aws/aws-get-account-id');
 
@@ -52,7 +49,7 @@ class PlatformECS {
 
     await ensureSSMParametersExist(this.platformOpts.region);
     await ensureS3BucketExists('global', this.s3LifecycleConfigurationRules);
-    await createIAMResources(this.accountId);
+    await createIAMResources(this.accountId, this.platformOpts.taskRoleName);
   }
 
   async createWorker() {}
@@ -111,19 +108,19 @@ async function ensureSSMParametersExist(region) {
   );
 }
 
-async function createIAMResources(accountId) {
-  const workerRoleArn = await createWorkerRole(accountId);
+async function createIAMResources(accountId, taskRoleName) {
+  const workerRoleArn = await createWorkerRole(accountId, taskRoleName);
 
   return {
     workerRoleArn
   };
 }
 
-async function createWorkerRole(accountId) {
+async function createWorkerRole(accountId, taskRoleName) {
   const iam = new AWS.IAM();
 
   try {
-    const res = await iam.getRole({ RoleName: this.platformOpts.taskRoleName }).promise();
+    const res = await iam.getRole({ RoleName: taskRoleName }).promise();
     return res.Role.Arn;
   } catch (err) {
     debug(err);
@@ -144,7 +141,7 @@ async function createWorkerRole(accountId) {
         ]
       }),
       Path: '/',
-      RoleName: ECS_WORKER_ROLE_NAME
+      RoleName: taskRoleName
     })
     .promise();
 
@@ -230,7 +227,7 @@ async function createWorkerRole(accountId) {
   await iam
     .attachRolePolicy({
       PolicyArn: createPolicyResp.Policy.Arn,
-      RoleName: ECS_WORKER_ROLE_NAME
+      RoleName: taskRoleName
     })
     .promise();
 

--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -52,10 +52,7 @@ class PlatformECS {
 
     await ensureSSMParametersExist(this.platformOpts.region);
     await ensureS3BucketExists('global', this.s3LifecycleConfigurationRules);
-    
-    if (!this.platformOpts.taskRoleName) {
-      await createIAMResources(this.accountId);
-    }
+    await createIAMResources(this.accountId);
   }
 
   async createWorker() {}
@@ -126,7 +123,7 @@ async function createWorkerRole(accountId) {
   const iam = new AWS.IAM();
 
   try {
-    const res = await iam.getRole({ RoleName: ECS_WORKER_ROLE_NAME }).promise();
+    const res = await iam.getRole({ RoleName: this.platformOpts.taskRoleName }).promise();
     return res.Role.Arn;
   } catch (err) {
     debug(err);


### PR DESCRIPTION
resolved #3470 

Allow specifying a custom task role name when running Artillery on Fargate, with a fallback to the default worker role. This provides more flexibility in IAM role configuration during Fargate test runs.

## Description
currently there isn't a way to pass a custom role name for tasks to assume. In `PlatformECS.init` it always looks for the default role name. this fixes it by passing the `task-role-name` flag to PlatformECS

<!-- PR description goes here.

Why the change is needed, and any details to help code reviewers.

-->

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
