### PR TITLE
feat: set number of SQS consumers dynamically

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/sqs-reporter.js
@@ -36,6 +36,10 @@ class SqsReporter extends EventEmitter {
     // Debug info:
     this.messagesProcessed = {};
     this.metricsMessagesFromWorkers = {};
+
+    this.poolSize = typeof process.env.SQS_CONSUMER_POOL_SIZE !== 'undefined'
+      ? parseInt(process.env.SQS_CONSUMER_POOL_SIZE, 10)
+      : Math.max(Math.ceil(this.count / 10), 75);
   }
 
   _allWorkersDone() {
@@ -326,7 +330,7 @@ class SqsReporter extends EventEmitter {
     };
 
     this.sqsConsumers = [];
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < this.poolSize; i++) {
       const sqsConsumer = createConsumer(i);
 
       sqsConsumer.on('error', (err) => {


### PR DESCRIPTION
## Description

* Number of consumers no longer hardcoded at 30. Instead, one consumer will be created per 10 workers in the test
* Number of consumers may be overridden via SQS_CONSUMER_POOL_SIZE environment variable

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
