### PR TITLE
Playwright improvements

### DIFF
--- a/examples/browser-load-testing-playwright/browser-load-test.ts
+++ b/examples/browser-load-testing-playwright/browser-load-test.ts
@@ -13,6 +13,14 @@ export const config = {
   }
 };
 
+export const before = {
+  engine: 'playwright',
+  testFunction: async function beforeFunctionHook(_page, userContext, _events) {
+    // Any scenario variables we add via userContext.vars in this before hook will be available in every VU
+    userContext.vars.testStartTime = new Date();
+  }
+};
+
 export const scenarios = [
   {
     engine: 'playwright',

--- a/packages/artillery/lib/platform/local/index.js
+++ b/packages/artillery/lib/platform/local/index.js
@@ -30,7 +30,10 @@ class PlatformLocal {
     await this.init();
 
     if (this.platformOpts.mode === 'distribute') {
-      const count = Math.max(1, os.cpus().length - 1);
+      // Disable worker threads for Playwright-based load tests
+      const count = this.script.config.engines?.playwright
+        ? 1
+        : Math.max(1, os.cpus().length - 1);
       this.workerScripts = divideWork(this.script, count);
       this.count = this.workerScripts.length;
     } else {


### PR DESCRIPTION
## Description

- Update a Playwright TypeScript example to show how to use a `before` hook
- Disable worker threads for Playwright tests:
  - Fixes/avoids current issue of load tests written in TypeScript not respecting `phases` config. Because each worker re-imports the script, the original phase configuration is preserved, which leads to the load being multiplied rather than distrubuted.
  - There's no performance benefit to multiple threads in this case anyway because the actual work will happen in an external Chrome process

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
