### PR TITLE
fix: check if exit code is not null before sending message

### DIFF
--- a/packages/artillery-plugin-slack/index.js
+++ b/packages/artillery-plugin-slack/index.js
@@ -69,7 +69,12 @@ class SlackPlugin {
 
         // When ensure is enabled, whether the beforeExit or the checks event will be triggered first will depend on the order of plugins in the test script
         // Since we need data from both events, first event triggered will store the data and the second event will send the report
-        if (this.exitCode !== undefined && this.report && !this.reportSent) {
+        if (
+          this.exitCode !== undefined &&
+          this.exitCode !== null &&
+          this.report &&
+          !this.reportSent
+        ) {
           debug('Sending report from checks event');
           await this.sendReport(this.report, this.ensureChecks);
           this.reportSent = true;
@@ -96,8 +101,8 @@ class SlackPlugin {
 
   getErrors(report) {
     const errorList = [];
-    for (const [key, value] of Object.entries(report.counters).filter(
-      ([key, value]) => key.startsWith('errors.')
+    for (const [key, value] of Object.entries(report.counters).filter(([key]) =>
+      key.startsWith('errors.')
     )) {
       errorList.push(`❌ ${key.replace('errors.', '')} (${value})`);
     }
@@ -126,10 +131,9 @@ class SlackPlugin {
       ]
     };
 
-    let errorsText;
-    if (errorList.length === 0) {
-      errorsText = '*Errors*\nNone';
-    } else {
+    let errorsText = '*Errors*\nNone';
+
+    if (errorList.length > 0) {
       // Only show first 10 errors to avoid Slack message length limit
       const maxErrors = 10;
       const trimmedList = errorList.slice(0, maxErrors);


### PR DESCRIPTION
## Description

Some Slack messages are showing the test as failed even though it passed. This is only on the header text, so trying to rule out the exit code being `null`. Checks and errors are showing correctly.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
