### PR TITLE
docs: update links for ensure and expect docs

### DIFF
--- a/packages/artillery-plugin-ensure/README.md
+++ b/packages/artillery-plugin-ensure/README.md
@@ -1,43 +1,12 @@
 # Metric / SLO checks with Artillery
 
-With this plugin Artillery can validate if a metric meets a predefined threshold or condition. You can create simple checks, e.g. that `p95` response time is <250ms, or more complex conditions which are based on several metrics.
+With this plugin Artillery can validate if a metric meets a predefined threshold or condition.
 
 If an `ensure` check fails Artillery will exit with a non-zero exit code. This is useful in CI/CD pipelines for automatic quality checks and as a way to check that SLOs are met.
 
-Docs: https://www.artillery.io/docs/reference/extensions/ensure
+## Documentation
 
-## Example
-
-In the following example, we set three `ensure` checks:
-
-1. The first one checks that HTTP response time `p95` is <= 1000ms, with a `threshold` check
-2. The second one uses a more complex conditional expression, and checks that HTTP response time `p99` is less than 2000ms **and** that at least 10 virtual users were launched
-3. The third check makes sure that all virtual user scenarios completed successfully
-
-```yaml
-config:
-  target: "https://www.artillery.io"
-  plugins:
-    ensure: {}
-  phases:
-    - duration: 10
-      arrivalRate: 1
-  ensure:
-    thresholds:
-      - engine.http.response_time.p95: 1000
-    conditions:
-      - expression: engine.http.response_time.p99 < 2000 and core.vusers.created.total > 10
-        strict: false
-      - expression: core.vusers.failed == 0
-scenarios:
-  - flow:
-      - get:
-          url: "/"
-      - get:
-          url: "/docs"
-      - get:
-          url: "/integrations"
-```
+📖 [Plugin documentation](https://www.artillery.io/docs/reference/extensions/ensure)
 
 ## License
 

--- a/packages/artillery-plugin-expect/README.md
+++ b/packages/artillery-plugin-expect/README.md
@@ -12,7 +12,7 @@
 
 ## Documentation
 
-📖 [Plugin documentation](https://artillery.io/docs/guides/plugins/plugin-expectations-assertions.html)
+📖 [Plugin documentation](https://www.artillery.io/docs/reference/extensions/expect)
 
 ## Feedback, Bugs, Issues
 


### PR DESCRIPTION
## Description

Update links to Artillery Docs.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
