### PR TITLE
feat(azure): require that client id and secret are set via env vars

### DIFF
--- a/packages/artillery/lib/cmds/run-aci.js
+++ b/packages/artillery/lib/cmds/run-aci.js
@@ -27,9 +27,7 @@ class RunACICommand extends Command {
       `subscription-id=${flags['subscription-id']}`,
       `storage-account=${flags['storage-account']}`,
       `blob-container=${flags['blob-container']}`,
-      `resource-group=${flags['resource-group']}`,
-      `client-id=${flags['client-id']}`,
-      `client-secret=${flags['client-secret']}`
+      `resource-group=${flags['resource-group']}`
     ];
 
     RunCommand.runCommandImplementation(flags, argv, args);
@@ -82,14 +80,6 @@ RunACICommand.flags = {
   'resource-group': Flags.string({
     description:
       'Azure Resource Group name. May also be set via AZURE_RESOURCE_GROUP environment variable.'
-  }),
-  'client-id': Flags.string({
-    description:
-      'Azure app client ID. May also be set via AZURE_CLIENT_ID environment variable.'
-  }),
-  'client-secret': Flags.string({
-    description:
-      'Azure app client secret. May also be set via AZURE_CLIENT_SECRET environment variable.'
   })
 };
 

--- a/packages/artillery/lib/platform/az/aci.js
+++ b/packages/artillery/lib/platform/az/aci.js
@@ -44,11 +44,8 @@ class PlatformAzureACI {
     this.azureSubscriptionId =
       process.env.AZURE_SUBSCRIPTION_ID ||
       platformOpts.platformConfig['subscription-id'];
-    this.azureClientId =
-      process.env.AZURE_CLIENT_ID || platformOpts.platformConfig['client-id'];
-    this.azureClientSecret =
-      process.env.AZURE_CLIENT_SECRET ||
-      platformOpts.platformConfig['client-secret'];
+    this.azureClientId = process.env.AZURE_CLIENT_ID;
+    this.azureClientSecret = process.env.AZURE_CLIENT_SECRET;
 
     this.storageAccount =
       process.env.AZURE_STORAGE_ACCOUNT ||


### PR DESCRIPTION
## Description

We won't allow setting those values via CLI flags anymore so that authentication relies only on [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme?view=azure-node-latest#defaultazurecredential).

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
