### PR TITLE
feat: allow worker timeout override on Azure ACI

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/constants.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/constants.js
@@ -1,6 +1,19 @@
 const pkgJson = require('../../../../package.json');
 const DEFAULT_IMAGE_TAG = pkgJson.version;
 
+// Default wait timeout for cloud workers to start
+let WAIT_TIMEOUT_SEC = 600;
+
+// Legacy override
+if (process.env.ECS_WAIT_TIMEOUT) {
+  WAIT_TIMEOUT_SEC = parseInt(process.env.ECS_WAIT_TIMEOUT, 10);
+}
+
+// Override
+if (process.env.WORKER_WAIT_TIMEOUT_SEC) {
+  WAIT_TIMEOUT_SEC = parseInt(process.env.WORKER_WAIT_TIMEOUT_SEC, 10);
+}
+
 module.exports = {
   ARTILLERY_CLUSTER_NAME: 'artilleryio-cluster',
   TASK_NAME: 'artilleryio-loadgen-worker',
@@ -9,9 +22,6 @@ module.exports = {
   LOGGROUP_NAME: 'artilleryio-log-group',
   LOGGROUP_RETENTION_DAYS: process.env.ARTILLERY_LOGGROUP_RETENTION_DAYS || 180,
   IMAGE_VERSION: process.env.ECR_IMAGE_VERSION || DEFAULT_IMAGE_TAG,
-  WAIT_TIMEOUT:
-    typeof process.env.ECS_WAIT_TIMEOUT === 'undefined'
-      ? 600
-      : parseInt(process.env.ECS_WAIT_TIMEOUT, 10),
+  WAIT_TIMEOUT: WAIT_TIMEOUT_SEC,
   TEST_RUNS_MAX_TAGS: parseInt(process.env.TEST_RUNS_MAX_TAGS, 10) || 8
 };

--- a/packages/artillery/lib/platform/az/aci.js
+++ b/packages/artillery/lib/platform/az/aci.js
@@ -16,7 +16,7 @@ const util = require('../aws-ecs/legacy/util');
 const generateId = require('../../util/generate-id');
 const EventEmitter = require('eventemitter3');
 const debug = require('debug')('platform:azure-aci');
-const { IMAGE_VERSION } = require('../aws-ecs/legacy/constants');
+const { IMAGE_VERSION, WAIT_TIMEOUT } = require('../aws-ecs/legacy/constants');
 const { regionNames } = require('./regions');
 const path = require('path');
 const { Timeout, sleep } = require('../aws-ecs/legacy/time');
@@ -345,7 +345,7 @@ class PlatformAzureACI {
       this.azureSubscriptionId
     );
 
-    const provisioningWaitTimeout = new Timeout(5 * 60 * 1000).start();
+    const provisioningWaitTimeout = new Timeout(WAIT_TIMEOUT * 1000).start();
 
     let containerGroupsInTestRun = [];
     while (true) {


### PR DESCRIPTION
## Description

* Allow the default worker provisioning timeout to be customized on Azure ACI (similarly to what's already available for AWS ECS)
* The override on both ACI and ECS is now via the `WORKER_WAIT_TIMEOUT_SEC` environment variable. The legacy AWS ECS-specific `ECS_WAIT_TIMEOUT` env var is still supported.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
