### PR TITLE
fix(bom): make sure self-contained TS scripts are bundled as expected

### DIFF
--- a/examples/browser-load-testing-playwright/browser-load-test.ts
+++ b/examples/browser-load-testing-playwright/browser-load-test.ts
@@ -1,5 +1,3 @@
-import { checkOutArtilleryCoreConceptsFlow } from './flows.js';
-
 export const config = {
   target: 'https://www.artillery.io',
   phases: [
@@ -9,7 +7,9 @@ export const config = {
     }
   ],
   engines: {
-    playwright: {}
+    playwright: {
+      trace: true
+    }
   }
 };
 
@@ -25,6 +25,34 @@ export const scenarios = [
   {
     engine: 'playwright',
     name: 'check_out_core_concepts_scenario',
-    testFunction: checkOutArtilleryCoreConceptsFlow
+    testFunction: async function checkOutArtilleryCoreConceptsFlow(
+      page,
+      userContext,
+      events,
+      test
+    ) {
+      await test.step('Go to Artillery', async () => {
+        const requestPromise = page.waitForRequest('https://artillery.io/');
+        await page.goto('https://artillery.io/');
+        const req = await requestPromise;
+      });
+      await test.step('Go to docs', async () => {
+        const docs = await page.getByRole('link', { name: 'Docs' });
+        await docs.click();
+        await page.waitForURL('https://www.artillery.io/docs');
+      });
+
+      await test.step('Go to core concepts', async () => {
+        await page
+          .getByRole('link', {
+            name: 'Review core concepts'
+          })
+          .click();
+
+        await page.waitForURL(
+          'https://www.artillery.io/docs/get-started/core-concepts'
+        );
+      });
+    }
   }
 ];

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -297,6 +297,10 @@ function getCustomJsDependencies(context, next) {
     // Could be JSON files too.
     context.localFilePaths = context.localFilePaths.concat(tree);
     context.npmModules = context.npmModules.concat(reduced);
+    // Remove duplicate entries for the same file when invoked on a single .ts script
+    // See line 44 - the config.processor property is always set on .ts files, which leads to
+    // multiple entries in the localFilePaths array for the same file
+    context.localFilePaths = _.uniq(context.localFilePaths);
     debug('got custom JS dependencies');
     return next(null, context);
   } else {

--- a/packages/artillery/test/unit/fargate-bom.test.js
+++ b/packages/artillery/test/unit/fargate-bom.test.js
@@ -1,9 +1,40 @@
 'use strict';
 
-const { test, afterEach } = require('tap');
-const { applyScriptChanges } = require('../../lib/platform/aws-ecs/legacy/bom');
+const promisify = require('util').promisify;
+const path = require('path');
+const { test } = require('tap');
+const {
+  createBOM,
+  applyScriptChanges
+} = require('../../lib/platform/aws-ecs/legacy/bom');
 
 // TODO: Add tests for other functions in bom.js
+
+test('Self-contained .ts script with no dependencies', async (t) => {
+  const inputFilename = 'browser-load-test.ts';
+  const inputScript = path.join(
+    __dirname,
+    '../../../../examples/browser-load-testing-playwright',
+    inputFilename
+  );
+  const createBOMAsync = promisify(createBOM);
+  const bom = await createBOMAsync(inputScript, [], {
+    scenarioPath: inputScript,
+    flags: {}
+  });
+  console.log(bom);
+  t.equal(
+    bom.files.length,
+    1,
+    'Input file is expected to have no dependencies'
+  );
+  t.equal(bom.files[0].orig.endsWith(inputFilename), true);
+  t.equal(
+    bom.files[0].noPrefix,
+    inputFilename,
+    'Unprefixed filename should be the same as the input filename'
+  );
+});
 
 test('applyScriptChanges should resolve config templates with cli variables', async (t) => {
   // Arrange


### PR DESCRIPTION
## Description

Fixes an issue where a self-contained TypeScript test definitions wouldn't get bundled as expected, resulting in nothing being uploaded to S3 / Blob Storage bucket.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
