### PR TITLE
fix(azure): pass value of WAIT_TIMEOUT_SEC into worker containers

### DIFF
--- a/packages/artillery/lib/platform/az/aci.js
+++ b/packages/artillery/lib/platform/az/aci.js
@@ -555,6 +555,8 @@ class PlatformAzureACI {
             util.btoa(JSON.stringify(this.artilleryArgs)),
             '-i',
             this.testRunId,
+            '-t',
+            WAIT_TIMEOUT,
             '-d',
             'NOT_USED_ON_AZURE',
             '-r',


### PR DESCRIPTION
## Description

Follow up to https://github.com/artilleryio/artillery/pull/3527

The value of `WAIT_TIMEOUT_SEC` needs to be passed into worker containers as well to avoid them timing out while waiting for other workers to start.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
