### PR TITLE
fix: remove top-level (monorepo) package.json from Dockerfile

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -54,6 +54,7 @@ RUN npm install -w artillery --ignore-scripts --omit=dev
 RUN npm install aws-lambda-ric
 
 RUN npm cache clean --force \
+    && rm ./package.json \
     && rm -rf /root/.cache \
     && ln -s /artillery/node_modules/.bin/artillery /usr/local/bin/artillery \
     && rm -rf /ms-playwright/firefox* \


### PR DESCRIPTION
## Description

The `packageManager` field in the top-level `package.json` file can cause issues with projects using Yarn, see: https://github.com/yarnpkg/yarn/issues/9015

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
