### PR TITLE
feat: improve Playwright trace capture

### DIFF
--- a/packages/artillery-engine-playwright/index.js
+++ b/packages/artillery-engine-playwright/index.js
@@ -74,7 +74,7 @@ class PlaywrightEngine {
 
     // We use this to make sure only one VU is recording at one time:
     this.MAX_CONCURRENT_RECORDINGS =
-      this.tracingConfig.maxConcurrentRecordings || 3; // maximum number of VUs that can record at the same time
+      this.tracingConfig.maxConcurrentRecordings || 5; // maximum number of VUs that can record at the same time
     this.vusRecording = 0; // number of VUs currently recording
 
     //

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -190,7 +190,7 @@ class ArtilleryCloudPlugin {
           );
         }
 
-        await this.waitOnUnprocessedLogs(30 * 1000); //just waiting for ee is not enough, as the api call takes time
+        await this.waitOnUnprocessedLogs(5 * 60 * 1000); //just waiting for ee is not enough, as the api call takes time
 
         if (isInteractiveUse) {
           await this._event('testrun:end', {


### PR DESCRIPTION
## Description

- Increase max wait time for assets to be uploaded to 5m up from 30s. This helps in cases where there may be several large trace files that need to be uploaded.
- Increase the default number of concurrent recordings to 5 from 3 - this helps increase the probability that a recording from a failed VU will be captured

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
