### PR TITLE
docs: add an example for loading custom JSON payloads with templating

### DIFF
--- a/examples/using-json-payload-templates/README.md
+++ b/examples/using-json-payload-templates/README.md
@@ -1,0 +1,10 @@
+# Using JSON payloads with optional templating
+
+This examples shows a solution for testing an HTTP API using JSON payloads which are loaded from external JSON files, with optional templating of values inside those JSON files.
+
+It works as follows:
+
+- A custom helper function is used to load the JSON payload from a file and template it. Different request can load and template different JSON payloads.
+- Built in `fake-data` plugin and CSV payloads to provide template variables
+
+The test uses https://practicesoftwaretesting.com by https://www.testsmith.io.

--- a/examples/using-json-payload-templates/credentials.csv
+++ b/examples/using-json-payload-templates/credentials.csv
@@ -1,0 +1,2 @@
+test1@example.net,very-secure-password
+test2@example.net,another-very-secure-password

--- a/examples/using-json-payload-templates/helpers.mjs
+++ b/examples/using-json-payload-templates/helpers.mjs
@@ -1,0 +1,24 @@
+
+import * as path from 'path';
+import Handlebars from 'handlebars';
+import * as fs from 'fs';
+
+export const loadCustomJsonPayload = async function(req, vuContext, _events) {
+  if (!req.jsonFromFile) {
+    return;
+  }
+
+  const relativePath = req.jsonFromFile.path;
+  const fullPath = path.join(vuContext.vars.$dirname, relativePath);
+  const contents = fs.readFileSync(fullPath, 'utf8');
+
+  if (!req.jsonFromFile.withVariables) {
+    const json = JSON.parse(contents);
+    req.json = json;
+  } else {
+    const template = Handlebars.compile(contents);
+    const result = template(req.jsonFromFile.withVariables);
+    const json = JSON.parse(result);
+    req.json = json;
+  }
+}

--- a/examples/using-json-payload-templates/package-lock.json
+++ b/examples/using-json-payload-templates/package-lock.json
@@ -1,0 +1,114 @@
+{
+  "name": "using-json-payload-templates",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "using-json-payload-templates",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "handlebars": "^4.7.8"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+    }
+  },
+  "dependencies": {
+    "handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+    }
+  }
+}

--- a/examples/using-json-payload-templates/package.json
+++ b/examples/using-json-payload-templates/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "using-json-payload-templates",
+  "version": "1.0.0",
+  "description": "This examples shows a solution for testing an HTTP API using JSON payloads which are loaded from external JSON files, with optional templating of values inside those JSON files.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "handlebars": "^4.7.8"
+  }
+}

--- a/examples/using-json-payload-templates/payload1.json
+++ b/examples/using-json-payload-templates/payload1.json
@@ -1,0 +1,13 @@
+{
+  "first_name": "{{ first_name }}",
+  "last_name": "{{ last_name }}",
+  "address": "{{ address }}",
+  "city": "{{ city }}",
+  "state": "{{ state }}",
+  "country": "{{ country }}",
+  "postcode": "{{ postcode }}",
+  "phone": "{{ phone }}",
+  "dob": "{{ dob }}",
+  "email": "{{ email }}",
+  "password": "{{ password }}"
+}

--- a/examples/using-json-payload-templates/test.yml
+++ b/examples/using-json-payload-templates/test.yml
@@ -1,0 +1,63 @@
+config:
+  target: "https://api-with-bugs.practicesoftwaretesting.com"
+  
+  plugins:
+    # built-in plugin to generate data with Falso
+    # https://www.artillery.io/docs/reference/extensions/fake-data
+    fake-data: {}
+    expect: {}
+  
+  # This makes loadCustomJsonPayload() function available which we're using in the scenario
+  processor: './helpers.mjs'
+  
+  # Load email and password fields from a CSV file
+  payload:
+    - path: "./credentials.csv"
+      fields:
+        - email
+        - password
+
+scenarios:
+  - name: Register and login
+    # This will run before every request and load and template a JSON payload if set with jsonFromFile property
+    beforeRequest: loadCustomJsonPayload
+    flow:
+      - post:
+          url: "/users/register"
+          jsonFromFile:
+            path: "./payload1.json"
+            withVariables:
+              first_name: "{{ $randFirstName() }}"
+              # last_name: "{{ $randLastName() }}"
+              last_name: "Doe" # Falso often produces values with non ASCII characters such as "é" which the application seems to reject
+              address: "{{ $randStreetAddress() }}"
+              city: "{{ $randCity() }}"
+              state: "{{ $randState() }}"
+              country:  "{{ $randCountry() }}"
+              postcode: "{{ $randZipCode() }}"
+              phone: "{{ $randPhoneNumber() }}"
+              dob: "1990-01-01"
+              email: "{{ email }}"
+              password: "{{ password }}"
+          capture:
+            - json: $.id
+              as: newUserId
+          expect:
+            statusCode: 201
+
+      - log: "User registered, user id: ${{ newUserId }}"
+
+      - post:
+          url: "/users/login"
+          json:
+            email: "{{ email }}"
+            password: "{{ password }}"
+          capture:
+            - json: $.access_token
+              as: accessToken
+          expect:
+            statusCode: 200
+
+      - log: "user logged in, access token: {{ accessToken }}"
+
+        


### PR DESCRIPTION
## Description

Add an example that shows how to use a custom helper function to load request payloads from an external JSON file, customizable on a per-request basis, and with optional templating.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
