### PR TITLE
fix: take distributed phases into account in TypeScript scripts

### DIFF
--- a/packages/artillery/lib/platform/local/artillery-worker-local.js
+++ b/packages/artillery/lib/platform/local/artillery-worker-local.js
@@ -109,7 +109,8 @@ class ArtilleryWorker {
     if (script.__transpiledTypeScriptPath && script.__originalScriptPath) {
       scriptForWorker = {
         __transpiledTypeScriptPath: script.__transpiledTypeScriptPath,
-        __originalScriptPath: script.__originalScriptPath
+        __originalScriptPath: script.__originalScriptPath,
+        __phases: script.config?.phases
       };
     }
 

--- a/packages/artillery/lib/platform/local/worker.js
+++ b/packages/artillery/lib/platform/local/worker.js
@@ -125,6 +125,10 @@ async function prepare(opts) {
   const { payload, options } = opts;
   const script = await loadProcessor(_script, options);
 
+  if (opts.script.__phases) {
+    script.config.phases = opts.script.__phases;
+  }
+
   global.artillery.testRunId = opts.testRunId;
 
   //


### PR DESCRIPTION
## Description

When the main script is a TypeScript file it gets transpiled in the main thread, and each worker thread then loads the transpiled module. This "resets" the results of divideWork() call, i.e. each worker runs with the original values of config.phases rather than the ones adjusted to distribute the work across all workers.

With this change, each worker receives a phase configuration for a subset of overall phase profile.

Fixes https://github.com/artilleryio/artillery/issues/3546

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
