### PR TITLE
fix: aci filepath resolution bug with nested test directories (#3560)

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -222,7 +222,7 @@ sync_test_data_azure () {
     # TODO: Exclude node_modules_stream.zip
     # This recreates the directory structure in the container, i.e. we'll have tests/$test_run_id here with all files under it
     # So we need to move them all up two levels to the current directory
-    az storage blob download-batch -d . --account-name "$AZURE_STORAGE_ACCOUNT" -s "$azure_storage_container_name" --pattern "tests/$test_run_id/*"
+    az storage blob download-batch -d . --account-name "$AZURE_STORAGE_ACCOUNT" -s "$azure_storage_container_name" --pattern "tests/$test_run_id/*.*"
     local tmpdir="$(mktemp -d)"
     set +e
     mv tests/$test_run_id/{.,}* $tmpdir


### PR DESCRIPTION
## Description

When running artillery with ACI, the worker is unable to download the test file dependencies from blobstorage if the test contains nested directories. 

This PR should fix this.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
