### PR TITLE
ci: run tests on Node.js 22 and 24

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run example
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - name: Install dependencies
         run: npm ci
       - name: Run test

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: node .github/workflows/scripts/replace-package-versions.js

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: node .github/workflows/scripts/replace-package-versions.js

--- a/.github/workflows/npm-publish-artillery-engine-posthog.yml
+++ b/.github/workflows/npm-publish-artillery-engine-posthog.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-engine-posthog publish --tag latest

--- a/.github/workflows/npm-publish-artillery-plugin-memory-inspector.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-memory-inspector.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: npm -w artillery-plugin-memory-inspector publish

--- a/.github/workflows/npm-publish-artillery-types.yml
+++ b/.github/workflows/npm-publish-artillery-types.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: node .github/workflows/scripts/replace-package-versions.js

--- a/.github/workflows/npm-publish-specific-package.yml
+++ b/.github/workflows/npm-publish-specific-package.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
       - run: node .github/workflows/scripts/replace-package-versions.js

--- a/.github/workflows/run-distributed-tests.yml
+++ b/.github/workflows/run-distributed-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - id: generate-matrix
         run: |
           RESULT=$(node .github/workflows/scripts/get-tests-in-package-location.js)
@@ -84,7 +84,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: .github/workflows/scripts/npm-command-retry.sh install
       - run: npm run build
       - name: Install Specific Artillery Version if needed
@@ -135,7 +135,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: .github/workflows/scripts/npm-command-retry.sh install
       - run: npm run build
       - name: Install Specific Artillery Version if needed

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -15,10 +15,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm install
       - run: npm run build
       - name: Configure AWS Credentials

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - id: generate-matrix
         run: |
           RESULT=$(node .github/workflows/scripts/get-all-packages-by-name.js)
@@ -29,7 +29,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
         package: ${{fromJson(needs.generate-matrix-with-packages.outputs.matrix)}}
       fail-fast: false
     steps:
@@ -62,10 +62,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
       - run: npm install
       - run: npm run build
       - name: Run windows tests and capture exit code


### PR DESCRIPTION
## Description

v22 is now LTS, and v24 is current.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
