### PR TITLE
fix(apdex): move tap to devDependencies

### DIFF
--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -17,7 +17,7 @@
   "keywords": [],
   "author": "",
   "license": "MPL-2.0",
-  "dependencies": {
-    "tap": "^19.0.2"
+  "devDependencies": {
+    "tap": "^19.2.5"
   }
 }


### PR DESCRIPTION
## Description

`tap` is incorrectly listed under `dependencies`.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
