### PR TITLE
fix: use China partition-aware ARNs and principals

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/ecs.js
+++ b/packages/artillery/lib/platform/aws-ecs/ecs.js
@@ -28,6 +28,10 @@ class PlatformECS {
     this.opts = opts;
     this.platformOpts = platformOpts;
 
+    this.arnPrefx = this.platformOpts.region.startsWith('cn-')
+      ? 'arn:aws-cn'
+      : 'arn:aws';
+
     this.testRunId = platformOpts.testRunId;
     if (!this.testRunId) {
       throw new Error('testRunId is required');
@@ -174,24 +178,8 @@ async function createWorkerRole(accountId, taskRoleName) {
           'ssm:DescribeParameters',
           'ssm:GetParametersByPath'
         ],
-        Resource: [`arn:aws:ssm:*:${accountId}:parameter/artilleryio/*`]
-      },
-      {
-        Effect: 'Allow',
-        Action: [
-          'ecr:BatchCheckLayerAvailability',
-          'ecr:GetDownloadUrlForLayer',
-          'ecr:BatchGetImage',
-          'ecr:ListImages'
-        ],
         Resource: [
-          // TODO: All supported regions
-          'arn:aws:ecr:us-east-1:301676560329:repository/artillery-pro/aws-ecs-node',
-          'arn:aws:ecr:us-west-1:301676560329:repository/artillery-pro/aws-ecs-node',
-          'arn:aws:ecr:eu-west-1:301676560329:repository/artillery-pro/aws-ecs-node',
-          'arn:aws:ecr:eu-central-1:301676560329:repository/artillery-pro/aws-ecs-node',
-          'arn:aws:ecr:ap-south-1:301676560329:repository/artillery-pro/aws-ecs-node',
-          'arn:aws:ecr:ap-northeast-1:301676560329:repository/artillery-pro/aws-ecs-node'
+          `${this.arnPrefx}:ssm:*:${accountId}:parameter/artilleryio/*`
         ]
       },
       {
@@ -203,20 +191,20 @@ async function createWorkerRole(accountId, taskRoleName) {
         Effect: 'Allow',
         Action: ['logs:*'],
         Resource: [
-          `arn:aws:logs:*:${accountId}:log-group:artilleryio-log-group*:*`
+          `${this.arnPrefx}:logs:*:${accountId}:log-group:artilleryio-log-group*:*`
         ]
       },
       {
         Effect: 'Allow',
         Action: ['sqs:*'],
-        Resource: [`arn:aws:sqs:*:${accountId}:artilleryio*`]
+        Resource: [`${this.arnPrefx}:sqs:*:${accountId}:artilleryio*`]
       },
       {
         Effect: 'Allow',
         Action: ['s3:*'],
         Resource: [
-          `arn:aws:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}`,
-          `arn:aws:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}/*`
+          `${this.arnPrefx}:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}`,
+          `${this.arnPrefx}:s3:::${S3_BUCKET_NAME_PREFIX}-${accountId}/*`
         ]
       },
       {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -361,7 +361,10 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     // Allow ARNs for convenience
     // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html
     // We split by :role because role names may contain slash characters (subpaths)
-    if (customRoleName.startsWith('arn:aws:iam')) {
+    if (
+      customRoleName.startsWith('arn:aws:iam') ||
+      customRoleName.startsWith('arn:aws-cn:iam')
+    ) {
       customRoleName = customRoleName.split(':role/')[1];
     }
     context.customTaskRoleName = customRoleName;
@@ -502,6 +505,7 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
     originalScriptPath: scriptPath,
     count: count,
     region: options.region,
+    arnPrefix: options.region.startsWith('cn-') ? 'arn:aws-cn' : 'arn:aws',
     taskName: `${TASK_NAME}_${
       IS_FARGATE ? 'fargate' : ''
     }_${clusterName}_${IMAGE_VERSION.replace(/\./g, '-')}_${Math.floor(
@@ -1092,7 +1096,7 @@ async function createADOTDefinitionIfNeeded(context) {
       secrets: [
         {
           name: 'AOT_CONFIG_CONTENT',
-          valueFrom: `arn:aws:ssm:${context.region}:${context.accountId}:parameter${context.adot.SSMParameterPath}`
+          valueFrom: `${context.arnPrefix}:ssm:${context.region}:${context.accountId}:parameter${context.adot.SSMParameterPath}`
         }
       ],
       logConfiguration: {
@@ -1187,7 +1191,7 @@ async function ensureTaskExists(context) {
     .map((secretName) => {
       return {
         name: secretName,
-        valueFrom: `arn:aws:ssm:${context.region}:${context.accountId}:parameter/artilleryio/${secretName}`
+        valueFrom: `${context.arnPrefix}:ssm:${context.region}:${context.accountId}:parameter/artilleryio/${secretName}`
       };
     });
 


### PR DESCRIPTION
## Description

Fixes instances of non-China aware uses of ARNs and principals.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
