### PR TITLE
Performance improvement: avoid useless call to esbuild to re-transpile TS files

### DIFF
--- a/packages/artillery/lib/util/prepare-test-execution-plan.js
+++ b/packages/artillery/lib/util/prepare-test-execution-plan.js
@@ -151,6 +151,8 @@ async function readPayload(script) {
 }
 
 function transpileTypeScript(entryPoint, outputPath, userExternalPackages) {
+  //TODO: move require to top of file when Lambda bundle size issue is solved
+  //must be conditionally required for now as this package is removed in Lambda for now to avoid bigger package sizes
   const esbuild = require('esbuild-wasm');
 
   esbuild.buildSync({
@@ -162,8 +164,6 @@ function transpileTypeScript(entryPoint, outputPath, userExternalPackages) {
     sourcemap: 'inline',
     external: ['@playwright/test', ...userExternalPackages]
   });
-
-  return outputPath;
 }
 
 function replaceProcessorIfTypescript(script, scriptPath) {
@@ -191,20 +191,15 @@ function replaceProcessorIfTypescript(script, scriptPath) {
     `dist/${processorFileName}.js`
   );
 
-  //TODO: move require to top of file when Lambda bundle size issue is solved
-  //must be conditionally required for now as this package is removed in Lambda for now to avoid bigger package sizes
-  const esbuild = require('esbuild-wasm');
+  if (fs.existsSync(newProcessorPath)) {
+    console.log(`Bundled Typescript file "${newProcessorPath}" already exists - Skipping transpilation`)
+    script.config.processor = newProcessorPath
+    global.artillery.hasTypescriptProcessor = newProcessorPath
+    return script
+  }
 
   try {
-    esbuild.buildSync({
-      entryPoints: [actualProcessorPath],
-      outfile: newProcessorPath,
-      bundle: true,
-      platform: 'node',
-      format: 'cjs',
-      sourcemap: 'inline',
-      external: ['@playwright/test', ...userExternalPackages]
-    });
+    transpileTypeScript(actualProcessorPath, newProcessorPath, userExternalPackages)
   } catch (error) {
     throw new Error(`Failed to compile Typescript processor\n${error.message}`);
   }


### PR DESCRIPTION
First, thank you for developping & maintaining this great tool 👍

## Description
I'm using `artillery` in a TypeScript projet, and I noticed repeated log lines like this:
```
Bundled Typescript file into JS. New processor path: .../functions.js
Bundled Typescript file into JS. New processor path: .../functions.js
Bundled Typescript file into JS. New processor path: .../functions.js
```

I checked the source code in `prepare-test-execution-plan.js` and realized that repeated transpilation of the same TS file where occuring.

First, a function named `transpileTypeScript()` has been introduced at some point, and it could be used in `replaceProcessorIfTypescript()` to avoid repeating code, so this light refactoring is included in this PR.

Second and more importantly, given that `transpileTypeScript()` is already called beforehand in `prepareTestExecutionPlan()` at the beggining of a test execution, invoking it again in `replaceProcessorIfTypescript()` does not seem necessery.
In this MR I added a test so that the transpiling step is skipped if the JS output file already exists in the `dist/` directory.
But maybe this transpiling step is simply never needed, you probably know better than me 🙂

Anyway, this PR provides a very substantial performance improvement when using `artillery` with TS hooks.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
