### PR TITLE
feat: add --no-assign-public-ip flag for Fargate

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.js
+++ b/packages/artillery/lib/cmds/run-fargate.js
@@ -177,6 +177,11 @@ RunCommand.flags = {
   }),
   'max-duration': Flags.string({
     description: 'Maximum duration of the test run'
+  }),
+  'no-assign-public-ip': Flags.boolean({
+    description:
+      'Turn off the default behavior of assigning public IPs to Fargate worker tasks. When this option is used you must make sure tasks have a route to the internet, i.e. via a NAT gateway attached to a private subnet',
+    default: false
   })
 };
 

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1600,6 +1600,10 @@ async function setupDefaultECSParams(context) {
         subnets: context.fargatePublicSubnetIds
       }
     };
+
+    if (context.cliOptions.noAssignPublicIp) {
+      defaultParams.awsvpcConfiguration.assignPublicIp = 'DISABLED';
+    }
   } else {
     defaultParams.launchType = 'EC2';
   }


### PR DESCRIPTION
## Description

By default Artillery enables the `assignPublicIp` ENI option for worker tasks which assigns a public IP to each task. This is to make sure that tasks always have a route to the internet, which is required for pulling the container image.

This option is for use-cases where tasks need to run from a private subnet which has a NAT gateway attached to make sure that requests by VUs come from a known IP address.

More info: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-networking.html

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
