### PR TITLE
fix(tests): account for multiple links to Docs

### DIFF
--- a/examples/browser-load-testing-playwright/browser-load-test.ts
+++ b/examples/browser-load-testing-playwright/browser-load-test.ts
@@ -37,8 +37,7 @@ export const scenarios = [
         const req = await requestPromise;
       });
       await test.step('Go to docs', async () => {
-        const docs = await page.getByRole('link', { name: 'Docs' });
-        await docs.click();
+        await page.getByRole('link', { name: 'Docs' }).first().click();
         await page.waitForURL('https://www.artillery.io/docs');
       });
 

--- a/examples/browser-load-testing-playwright/flows.js
+++ b/examples/browser-load-testing-playwright/flows.js
@@ -15,8 +15,7 @@ async function checkOutArtilleryCoreConceptsFlow(
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page.getByRole('link', { name: 'Docs' });
-    await docs.click();
+    await page.getByRole('link', { name: 'Docs' }).first().click();
     await page.waitForURL('https://www.artillery.io/docs');
   });
 

--- a/examples/browser-playwright-reuse-typescript/e2e/helpers/index.ts
+++ b/examples/browser-playwright-reuse-typescript/e2e/helpers/index.ts
@@ -6,7 +6,7 @@ export const goToDocsAndSearch = async (page: Page, step) => {
   });
 
   await step('go_to_docs', async () => {
-    await page.getByRole('link', { name: 'Docs' }).click();
+    await page.getByRole('link', { name: 'Docs' }).first().click();
     await expect(page).toHaveURL('/docs');
     await expect(
       page.getByText('Get started')

--- a/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
+++ b/packages/artillery/test/cloud-e2e/fargate/fixtures/adot/flow.js
@@ -5,8 +5,7 @@ async function simpleCheck(page, userContext, events, test) {
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page.getByRole('link', { name: 'Docs' });
-    await docs.click();
+    await page.getByRole('link', { name: 'Docs' }).first().click();
     await page.waitForURL('https://www.artillery.io/docs');
   });
 

--- a/packages/artillery/test/publish-metrics/fixtures/flow.js
+++ b/packages/artillery/test/publish-metrics/fixtures/flow.js
@@ -7,8 +7,7 @@ async function simpleCheck(page, userContext, events, test) {
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page.getByRole('link', { name: 'Docs' });
-    await docs.click();
+    await page.getByRole('link', { name: 'Docs' }).first().click();
     await page.waitForURL('https://www.artillery.io/docs');
   });
 
@@ -32,8 +31,7 @@ async function simpleError(page, userContext, events, test) {
     const req = await requestPromise;
   });
   await test.step('Go to docs', async () => {
-    const docs = await page.getByRole('link', { name: 'Docs' });
-    await docs.click();
+    await page.getByRole('link', { name: 'Docs' }).first().click();
     await page.waitForURL('https://www.artillery.io/docs');
   });
 


### PR DESCRIPTION
## Description

Update Playwright-based scripts (some used in e2e tests) to handle multiple links to Docs on the homepage.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
