### PR TITLE
fix: pass ARTILLERY_CLOUD_ENDPOINT into Lambda if set

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -428,6 +428,10 @@ class PlatformLambda {
       ARTILLERY_CLOUD_API_KEY: this.cloudKey
     };
 
+    if (process.env.ARTILLERY_CLOUD_ENDPOINT) {
+      event.ARTILLERY_CLOUD_ENDPOINT = process.env.ARTILLERY_CLOUD_ENDPOINT;
+    }
+
     debug('Lambda event payload:');
     debug({ event });
 

--- a/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
+++ b/packages/artillery/lib/platform/aws-lambda/lambda-handler/a9-handler-index.js
@@ -52,7 +52,8 @@ async function handler(event, context) {
     BUCKET,
     ENV,
     WAIT_FOR_GREEN,
-    ARTILLERY_CLOUD_API_KEY
+    ARTILLERY_CLOUD_API_KEY,
+    ARTILLERY_CLOUD_ENDPOINT
   } = event;
 
   console.log('TEST_RUN_ID: ', TEST_RUN_ID);
@@ -147,7 +148,8 @@ async function handler(event, context) {
       ARTILLERY_ARGS,
       TEST_DATA_LOCATION,
       ENV,
-      ARTILLERY_CLOUD_API_KEY
+      ARTILLERY_CLOUD_API_KEY,
+      ARTILLERY_CLOUD_ENDPOINT
     });
 
     if (err || code !== 0) {
@@ -186,7 +188,8 @@ async function execArtillery(options) {
     NODE_BINARY_PATH,
     ARTILLERY_BINARY_PATH,
     TEST_DATA_LOCATION,
-    ARTILLERY_CLOUD_API_KEY
+    ARTILLERY_CLOUD_API_KEY,
+    ARTILLERY_CLOUD_ENDPOINT
   } = options;
 
   const env = Object.assign(
@@ -206,6 +209,7 @@ async function execArtillery(options) {
       // SHIP_LOGS: 'true',
     },
     ARTILLERY_CLOUD_API_KEY ? { ARTILLERY_CLOUD_API_KEY } : {},
+    ARTILLERY_CLOUD_ENDPOINT ? { ARTILLERY_CLOUD_ENDPOINT } : {},
     ENV
   );
 


### PR DESCRIPTION
## Description

If `ARTILLERY_CLOUD_ENDPOINT` env var is set, make it available inside AWS Lambda workers.

Should fix E2E test failures on main.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
