### PR TITLE
fix: pass --scenario-name through on Fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1426,7 +1426,7 @@ async function generateTaskOverrides(context) {
     context.cliOptions.environment
       ? ['--environment', context.cliOptions.environment]
       : [],
-    context.cliOptions['scenario-name']
+    context.cliOptions['scenarioName']
       ? ['--scenario-name', context.cliOptions['scenario-name']]
       : [],
     context.cliOptions.insecure ? ['-k'] : [],


### PR DESCRIPTION
## Description

`--scenario-name` is not currently passed through correctly into Fargate workers, because CLI flags are converted to camelCase in: https://github.com/artilleryio/artillery/blob/aa9e68771afd4666da58d6f3938e861869f72d98/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js#L136-L140.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
