### PR TITLE
fix: maintain original log structure

### DIFF
--- a/packages/artillery/lib/console-capture.js
+++ b/packages/artillery/lib/console-capture.js
@@ -45,7 +45,7 @@ function setupConsoleCapture() {
         orig.apply(console, args);
 
         if (currentSize < MAX_RETAINED_LOG_SIZE) {
-          outputLines = outputLines.concat(args);
+          outputLines = outputLines.concat([args]);
           for (const x of args) {
             currentSize += String(x).length;
           }
@@ -70,7 +70,7 @@ function setupConsoleCapture() {
         orig.apply(console, args);
 
         if (currentSize < MAX_RETAINED_LOG_SIZE) {
-          outputLines = outputLines.concat(args);
+          outputLines = outputLines.concat([args]);
           for (const x of args) {
             currentSize += String(x).length;
           }


### PR DESCRIPTION
## Description

Logs sent to Artillery Cloud will currently have a space character after every character - this is due to a difference between `arguments` in a plain function and spread `...args` in an arrow function. Follow up to #3655.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
