### PR TITLE
fix: resolve config.processor relative to the config file

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -236,17 +236,12 @@ function getCustomEngines(context, next) {
 
 function getCustomJsDependencies(context, next) {
   if (context.opts.scriptData.config?.processor) {
-    // When using a separate config file, resolve paths relative to the scenario file
-    // Otherwise, resolve relative to the config file
-    const baseDir = context.opts.scenarioPath
-      ? path.dirname(context.opts.scenarioPath)
-      : path.dirname(context.opts.absoluteScriptPath);
-
     //
     // Path to the main processor file:
     //
+
     const procPath = path.resolve(
-      baseDir,
+      path.dirname(context.opts.absoluteScriptPath),
       context.opts.scriptData.config.processor
     );
     context.localFilePaths.push(procPath);
@@ -254,7 +249,7 @@ function getCustomJsDependencies(context, next) {
     // Get the tree of requires from the main processor file:
     const tree = depTree.toList({
       filename: procPath,
-      directory: baseDir,
+      directory: path.dirname(context.opts.absoluteScriptPath),
       filter: (path) => path.indexOf('node_modules') === -1 // optional
     });
 


### PR DESCRIPTION
## Description

Fixes regression introduced in #3653. `config.processor` should be resolved relative to the path to the main script even if a separate config is used. This keeps it consistent with the behavior when running locally with `artillery run`.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
