### PR TITLE
refactor: use AWS SDK v3-style error handling

### DIFF
--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -14,7 +14,9 @@ const {
   GetFunctionConfigurationCommand,
   InvokeCommand,
   CreateFunctionCommand,
-  DeleteFunctionCommand
+  DeleteFunctionCommand,
+  ResourceConflictException,
+  ResourceNotFoundException
 } = require('@aws-sdk/client-lambda');
 const { PutObjectCommand } = require('@aws-sdk/client-s3');
 const { SQSClient, DeleteQueueCommand } = require('@aws-sdk/client-sqs');
@@ -623,7 +625,7 @@ class PlatformLambda {
       });
       return;
     } catch (err) {
-      if (err.code === 'ResourceConflictException') {
+      if (err instanceof ResourceConflictException) {
         debug(
           'Lambda function with this configuration already exists. Using existing function.'
         );
@@ -649,7 +651,7 @@ class PlatformLambda {
 
       return res;
     } catch (err) {
-      if (err.name === 'ResourceNotFoundException') {
+      if (err instanceof ResourceNotFoundException) {
         return null;
       }
 

--- a/packages/artillery/lib/platform/aws/aws-ensure-s3-bucket-exists.js
+++ b/packages/artillery/lib/platform/aws/aws-ensure-s3-bucket-exists.js
@@ -7,7 +7,8 @@ const debug = require('debug')('util:aws:ensureS3BucketExists');
 const {
   S3Client,
   PutBucketLifecycleConfigurationCommand,
-  CreateBucketCommand
+  CreateBucketCommand,
+  NoSuchBucket
 } = require('@aws-sdk/client-s3');
 
 const getAWSAccountId = require('./aws-get-account-id');
@@ -57,7 +58,7 @@ module.exports = async function ensureS3BucketExists(
   try {
     location = await getBucketRegion(bucketName);
   } catch (err) {
-    if (err.name === 'NoSuchBucket') {
+    if (err instanceof NoSuchBucket) {
       await s3.send(new CreateBucketCommand({ Bucket: bucketName }));
     } else {
       throw err;


### PR DESCRIPTION
## Description

Use AWS SDK v3-style error handling consistently.

https://aws.amazon.com/blogs/developer/service-error-handling-modular-aws-sdk-js/

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
