### PR TITLE
fix: use correct cliOptions key for scenarioName in Fargate workers

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1369,7 +1369,7 @@ async function generateTaskOverrides(context) {
       ? ['--environment', context.cliOptions.environment]
       : [],
     context.cliOptions['scenarioName']
-      ? ['--scenario-name', context.cliOptions['scenario-name']]
+      ? ['--scenario-name', context.cliOptions['scenarioName']]
       : [],
     context.cliOptions.insecure ? ['-k'] : [],
     context.cliOptions.target ? ['-t', context.cliOptions.target] : [],


### PR DESCRIPTION
## Summary

The `--scenario-name` flag was not being passed correctly to Fargate workers, causing them to receive `null` instead of the actual scenario name.

## Root Cause

In `generateTaskOverrides()`, the condition checked `cliOptions['scenarioName']` (camelCase) but the value was read from `cliOptions['scenario-name']` (kebab-case):

```javascript
// Before (bug):
context.cliOptions['scenarioName']
  ? ['--scenario-name', context.cliOptions['scenario-name']]  // reads undefined → "null"
  : [],
```

## Fix

Use the correct camelCase key consistently:

```javascript
// After (fix):
context.cliOptions['scenarioName']
  ? ['--scenario-name', context.cliOptions['scenarioName']]
  : [],
```

## Related

Fixes #3589 - this appears to be a regression or incomplete fix from #3651