### PR TITLE
feat: add S3 overflow for large SQS payloads in Fargate

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.js
@@ -1424,6 +1424,10 @@ async function generateTaskOverrides(context) {
           {
             name: 'ARTILLERY_TEST_RUN_ID',
             value: global.artillery.testRunId
+          },
+          {
+            name: 'ARTILLERY_S3_BUCKET',
+            value: context.s3Bucket
           }
         ]
       },


### PR DESCRIPTION
## Description

SQS has 1MB message limit. Large metric batches can exceed this.

When payload > 950KB we will now store the payload in S3 instead and fetch it from there in the consumer.

Mirrors existing Azure ACI blob overflow pattern (#3662).

Fixes #3683

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
