### PR TITLE
fix: apply default timeout/retry limits to all requests

### DIFF
--- a/packages/artillery/lib/platform/cloud/api.js
+++ b/packages/artillery/lib/platform/cloud/api.js
@@ -1,4 +1,4 @@
-const request = require('got');
+const { cloudHttpClient: request } = require('./http-client');
 
 class Client {
   constructor({ apiKey, baseUrl }) {
@@ -25,11 +25,7 @@ class Client {
 
   async whoami() {
     const res = await request.get(this.whoamiEndpoint, {
-      headers: this.defaultHeaders,
-      throwHttpErrors: false,
-      retry: {
-        limit: 3
-      }
+      headers: this.defaultHeaders
     });
 
     const body = JSON.parse(res.body);
@@ -43,11 +39,7 @@ class Client {
     const res = await request.get(
       `${this.baseUrl}/api/org/${currentOrgId}/stash`,
       {
-        headers: this.defaultHeaders,
-        throwHttpErrors: false,
-        retry: {
-          limit: 3
-        }
+        headers: this.defaultHeaders
       }
     );
 

--- a/packages/artillery/lib/platform/cloud/cloud.js
+++ b/packages/artillery/lib/platform/cloud/cloud.js
@@ -5,7 +5,7 @@
 
 
 const debug = require('debug')('cloud');
-const request = require('got');
+const { cloudHttpClient: request } = require('./http-client');
 const awaitOnEE = require('../../util/await-on-ee');
 const sleep = require('../../util/sleep');
 const util = require('node:util');
@@ -223,10 +223,7 @@ class ArtilleryCloudPlugin {
     try {
       res = await request.get(this.whoamiEndpoint, {
         headers: this.defaultHeaders,
-        throwHttpErrors: false,
-        retry: {
-          limit: 0
-        }
+        retry: { limit: 0 }
       });
 
       body = JSON.parse(res.body);
@@ -247,11 +244,7 @@ class ArtilleryCloudPlugin {
     let postSucceeded = false;
     try {
       res = await request.post(this.pingEndpoint, {
-        headers: this.defaultHeaders,
-        throwHttpErrors: false,
-        retry: {
-          limit: 3
-        }
+        headers: this.defaultHeaders
       });
 
       if (res.statusCode === 200) {
@@ -315,9 +308,9 @@ class ArtilleryCloudPlugin {
 
     let url;
     try {
+      // TODO: This could get rejected if a limit is exceeded so need to handle that case
       const res = await request.post(this.getAssetUploadUrls, {
         headers: this.defaultHeaders,
-        throwHttpErrors: false,
         json: payload
       });
 
@@ -398,8 +391,7 @@ class ArtilleryCloudPlugin {
 
     try {
       const res = await request.get(this.getLoadTestEndpoint, {
-        headers: this.defaultHeaders,
-        throwHttpErrors: false
+        headers: this.defaultHeaders
       });
 
       return JSON.parse(res.body);
@@ -420,11 +412,7 @@ class ArtilleryCloudPlugin {
             testRunId: this.testRunId
           })
         },
-        throwHttpErrors: false,
-        retry: {
-          limit: 2,
-          methods: ['POST']
-        }
+        retry: { limit: 2 }
       });
 
       if (res.statusCode !== 200) {

--- a/packages/artillery/lib/platform/cloud/http-client.js
+++ b/packages/artillery/lib/platform/cloud/http-client.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const got = require('got');
+
+const DEFAULT_TIMEOUT_MS = 20 * 10000;
+const DEFAULT_RETRY_LIMIT = 3;
+
+const cloudHttpClient = got.extend({
+  timeout: { response: DEFAULT_TIMEOUT_MS },
+  retry: {
+    limit: DEFAULT_RETRY_LIMIT,
+    methods: ['GET', 'POST', 'PUT']
+  },
+  throwHttpErrors: false
+});
+
+module.exports = { cloudHttpClient };


### PR DESCRIPTION
## Description

Set explicit timeouts & retry limits for all requests to Artillery Cloud APIs.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
