### PR TITLE
fix: filter out packages that should not be reinstalled from BOM

### DIFF
--- a/packages/artillery/lib/create-bom/create-bom.js
+++ b/packages/artillery/lib/create-bom/create-bom.js
@@ -123,7 +123,12 @@ async function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
 
       return callback(null, {
         files: _.uniqWith(files, _.isEqual),
-        modules: _.uniq(context.npmModules),
+        modules: _.uniq(context.npmModules).filter(
+          (m) =>
+            m !== 'artillery' &&
+            m !== 'playwright' &&
+            !m.startsWith('@playwright/')
+        ),
         pkgDeps: context.pkgDeps
       });
     }

--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -160,7 +160,12 @@ function createBOM(absoluteScriptPath, extraFiles, opts, callback) {
 
       return callback(null, {
         files: _.uniqWith(files, _.isEqual),
-        modules: _.uniq(context.npmModules),
+        modules: _.uniq(context.npmModules).filter(
+          (m) =>
+            m !== 'artillery' &&
+            m !== 'playwright' &&
+            !m.startsWith('@playwright/')
+        ),
         pkgDeps: context.pkgDeps,
         fullyResolvedConfig: context.opts.scriptData.config
       });


### PR DESCRIPTION
## Description

Make sure that we don't end up reinstalling and potentially causing incompatibility issues by installing any Playwright packages or Artillery itself in worker containers on Fargate.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
