### PR TITLE
perf: shrink worker Docker image from ~1.7GB to ~700MB

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-venv \
     ca-certificates \
+    xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # --- AWS CLI v2 (standalone installer) ---

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -146,9 +146,12 @@ RUN corepack enable
 
 # --- AWS CLI v2 (copied from builder, ~200MB) ---
 # The standalone v2 installer bundles its own Python runtime, so no system
-# python3 dependency. Only two paths to copy.
+# python3 dependency. Only the install directory needs copying.
+# /usr/local/bin/aws must be a symlink (not a copied binary) because aws
+# is a PyInstaller bundle that locates libpython relative to the real
+# binary path. COPY resolves symlinks, so we recreate it manually.
 COPY --from=builder /usr/local/aws-cli /usr/local/aws-cli
-COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
+RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws
 
 # --- Azure Storage SDK + helper script (copied from builder) ---
 # The venv is self-contained except for the python3 interpreter symlink.

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -125,7 +125,9 @@ RUN npx playwright install --with-deps chromium
 #   curl     - ECS metadata endpoint, general HTTP
 #   git      - user test repos may need it
 #   zip      - leader packs node_modules.zip for follower workers
+#   unzip    - followers unpack node_modules.zip from leader
 #   tree     - debug logging of test directory structure
+#   procps   - pgrep, used to find Artillery CLI PID
 #   python3  - required by azure-storage-helper (its venv references system python3)
 #   bash     - worker scripts are bash (base slim image only has dash)
 # --no-install-recommends avoids pulling in suggested packages we don't need.
@@ -136,7 +138,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
     zip \
+    unzip \
     tree \
+    procps \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -1,15 +1,16 @@
-# ********************************
-# NOTE: Version we use here needs to be kept consistent with that in
-# artillery-engine-playwright.
-# ********************************
-FROM mcr.microsoft.com/playwright:v1.58.1
+# =============================================================================
+# Stage 1: Builder
+#
+# Compiles native Node.js addons (aws-lambda-ric) and installs CLIs.
+# Everything useful is copied to the runtime stage; the rest is discarded.
+# This keeps ~500MB of build toolchain (g++, cmake, headers) out of the
+# final image.
+# =============================================================================
+FROM node:24.14.1-bookworm-slim AS builder
 
-ARG TARGETARCH
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install aws-lambda-ric build dependencies
-RUN apt-get update && apt-get install -y \
+# Build tools required to compile aws-lambda-ric (native C++ addon via
+# node-gyp). This set adds ~500MB but none of it reaches the final image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     make \
     cmake \
@@ -17,13 +18,154 @@ RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     autoconf \
     libtool \
-    python3-pip && pip3 install awscli --break-system-packages && pip3 install azure-cli==2.76.0 --break-system-packages
+    curl \
+    python3 \
+    python3-venv \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
+# --- AWS CLI v2 (standalone installer) ---
+# The old Dockerfile installed v1 via pip, which pulls in botocore (~300MB
+# of JSON service definitions for every AWS service). The v2 standalone
+# installer is ~200MB — about 40% smaller — and bundles its own Python
+# so it doesn't need python3 in the runtime image.
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" \
+        -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/awscliv2.zip /tmp/aws
+
+# --- Azure Storage SDK (replaces the full azure-cli) ---
+# The old Dockerfile installed azure-cli==2.76.0 (~800MB-1GB) but only used
+# 6 subcommands: login, blob upload/download/download-batch/delete-batch,
+# and queue send. We replace it with 3 targeted Python SDK packages (~6MB):
+#   azure-storage-blob   - blob operations
+#   azure-storage-queue  - queue message operations
+#   azure-identity       - service principal authentication
+# A small wrapper script (azure-storage-helper) provides the same CLI
+# interface that loadgen-worker expects.
+RUN python3 -m venv /opt/azure-sdk \
+    && /opt/azure-sdk/bin/pip install --no-cache-dir \
+        azure-storage-blob \
+        azure-storage-queue \
+        azure-identity
+
+# --- Artillery application + npm dependencies ---
+ARG FUNCTION_DIR="/artillery"
+RUN mkdir -p ${FUNCTION_DIR}
+WORKDIR ${FUNCTION_DIR}
+
+COPY packages packages
+# Lambda handler JS files are placed at the /artillery/ root for
+# aws-lambda-ric to find them at runtime.
+COPY packages/artillery/lib/platform/aws-lambda/lambda-handler/ .
+# Root package.json is needed for the workspace npm install (-w flag).
+# It gets deleted after install — only the lambda handler files remain.
+COPY package.json package.json
+
+# Install workspace deps. --ignore-scripts skips postinstall hooks
+# (faster, avoids side effects). --omit=dev drops test/build-only deps.
+RUN npm install -w artillery --ignore-scripts --omit=dev
+
+# aws-lambda-ric is installed separately WITHOUT --ignore-scripts because
+# it must run its postinstall step to compile the native C++ addon via
+# node-gyp. This is the whole reason the build toolchain exists.
+RUN npm install aws-lambda-ric
+
+RUN npm cache clean --force && rm ./package.json
+
+
+# =============================================================================
+# Stage 2: Runtime
+#
+# Uses the same slim base as the standalone Artillery Docker image
+# (packages/artillery/Dockerfile). Key size savings vs the old approach:
+#
+# OLD: mcr.microsoft.com/playwright:v1.58.1 base image (~2GB)
+#   - Ships all 3 browsers (Chromium + Firefox + WebKit) + system deps for
+#     all of them. Even after `rm -rf /ms-playwright/firefox* webkit*`, the
+#     system libraries for Firefox and WebKit stay behind.
+#
+# NEW: node:24.14.1-bookworm-slim (~210MB) + chromium-only playwright install
+#   - Installs ONLY Chromium and its specific system deps (X11, NSS, fonts,
+#     ALSA, mesa). No Firefox/WebKit libraries. Saves ~800-900MB.
+# =============================================================================
+FROM node:24.14.1-bookworm-slim
+
+ARG TARGETARCH
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG FUNCTION_DIR="/artillery"
+RUN mkdir -p ${FUNCTION_DIR}
+WORKDIR ${FUNCTION_DIR}
+
+# Copy node_modules first, separately from the rest of the application code.
+# This lets Docker cache the expensive playwright browser install step below
+# — it only re-runs when dependencies change, not when source code changes.
+COPY --from=builder ${FUNCTION_DIR}/node_modules ${FUNCTION_DIR}/node_modules
+
+# ********************************
+# NOTE: Playwright version here comes from the playwright package inside
+# node_modules (currently 1.58.1). This must be kept consistent with the
+# version in artillery-engine-playwright's package.json.
+# ********************************
+#
+# --with-deps installs Chromium's required system libraries via apt:
+# X11 (libx11, libxcomposite, libxdamage...), NSS/NSPR (TLS/certs),
+# fonts/fontconfig/freetype, ALSA (audio), mesa/EGL (graphics).
+# These are the same deps the old Playwright base image provided, minus
+# the Firefox/WebKit ones we never needed.
+RUN npx playwright install --with-deps chromium
+
+# --- Runtime system packages ---
+# These are required by the Fargate worker shell scripts (loadgen-worker):
+#   jq       - JSON parsing for metadata, SQS messages
+#   pwgen    - generate deduplication IDs for SQS messages
+#   curl     - ECS metadata endpoint, general HTTP
+#   git      - user test repos may need it
+#   zip      - leader packs node_modules.zip for follower workers
+#   tree     - debug logging of test directory structure
+#   python3  - required by azure-storage-helper (its venv references system python3)
+#   bash     - worker scripts are bash (base slim image only has dash)
+# --no-install-recommends avoids pulling in suggested packages we don't need.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    jq \
+    pwgen \
+    curl \
+    git \
+    zip \
+    tree \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# The worker script (loadgen-worker) checks for `yarn` in its DEPENDENCIES
+# array. Node 24 ships corepack but `yarn` isn't on $PATH until enabled.
+RUN corepack enable
+
+# --- AWS CLI v2 (copied from builder, ~200MB) ---
+# The standalone v2 installer bundles its own Python runtime, so no system
+# python3 dependency. Only two paths to copy.
+COPY --from=builder /usr/local/aws-cli /usr/local/aws-cli
+COPY --from=builder /usr/local/bin/aws /usr/local/bin/aws
+
+# --- Azure Storage SDK + helper script (copied from builder) ---
+# The venv is self-contained except for the python3 interpreter symlink.
+# python3 was installed above in the runtime packages step.
+# Total size: ~6MB (vs ~800MB for the full azure-cli).
+COPY --from=builder /opt/azure-sdk /opt/azure-sdk
+# The helper script uses #!/opt/azure-sdk/bin/python3 as its shebang,
+# so it automatically picks up the venv's installed packages.
+COPY ./packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper /usr/local/bin/azure-storage-helper
+RUN chmod +x /usr/local/bin/azure-storage-helper
+
+# --- curl: IPv4 preference + arm64 SSL workaround ---
+# Forces IPv4 to avoid DNS/connectivity issues in some container networks.
+# The arm64 'insecure' flag works around a curl SSL_ERROR_SYSCALL bug:
+# https://github.com/curl/curl/issues/14154
 RUN <<EOT
 echo 'ipv4' >> ~/.curlrc
 if [ "$TARGETARCH" = "arm64" ]; then
-# Temporal fix for SSL_ERROR_SYSCALL error on arm64
-# see: https://github.com/curl/curl/issues/14154
 echo 'insecure' >> ~/.curlrc
 fi
 EOT
@@ -31,34 +173,20 @@ EOT
 ARG WORKER_VERSION
 ENV WORKER_VERSION=$WORKER_VERSION
 
-# Additional dependencies for Fargate
-RUN apt-get install -y bash jq pwgen curl git zip tree
+# --- Application code ---
+# Copy packages and lambda handler files from the builder stage.
+# node_modules was already copied above for caching reasons.
+COPY --from=builder ${FUNCTION_DIR}/packages ${FUNCTION_DIR}/packages
+COPY --from=builder ${FUNCTION_DIR}/a9-handler-dependencies.js ${FUNCTION_DIR}/
+COPY --from=builder ${FUNCTION_DIR}/a9-handler-helpers.js ${FUNCTION_DIR}/
+COPY --from=builder ${FUNCTION_DIR}/a9-handler-index.js ${FUNCTION_DIR}/
 
-# Define custom function directory
-ARG FUNCTION_DIR="/artillery"
-RUN mkdir -p ${FUNCTION_DIR}
-WORKDIR ${FUNCTION_DIR}
-
-COPY packages packages
-COPY packages/artillery/lib/platform/aws-lambda/lambda-handler/ .
-COPY package.json package.json
-
-## Copy Fargate worker files
+# Fargate worker scripts — copied from the build context (not builder stage)
+# because they may change independently of npm dependencies.
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker /artillery/loadgen-worker
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/helpers.sh /artillery/helpers.sh
 
-# Install dependencies
-RUN npm install -w artillery --ignore-scripts --omit=dev
-RUN npm install aws-lambda-ric
-
-RUN npm cache clean --force \
-    && rm ./package.json \
-    && rm -rf /root/.cache \
-    && ln -s /artillery/node_modules/.bin/artillery /usr/local/bin/artillery \
-    && rm -rf /ms-playwright/firefox* \
-    && rm -rf /ms-playwright/webkit* \
-    && echo "ok"
-
-RUN chmod +x /artillery/loadgen-worker
+RUN ln -s /artillery/node_modules/.bin/artillery /usr/local/bin/artillery \
+    && chmod +x /artillery/loadgen-worker
 
 ENTRYPOINT ["/artillery/packages/artillery/bin/run"]

--- a/packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper
+++ b/packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper
@@ -1,0 +1,224 @@
+#!/opt/azure-sdk/bin/python3
+"""
+Lightweight replacement for the `az` CLI commands used by the Artillery
+Fargate worker (loadgen-worker).
+
+Implements only the 6 subcommands actually used:
+  login                    - validate service principal credentials
+  blob upload              - upload a local file as a blob
+  blob download            - download a single blob to a local file
+  blob download-batch      - download blobs matching a glob pattern
+  blob delete-batch        - delete blobs matching a glob pattern
+  queue send               - send a message to Azure Queue Storage
+
+Uses the azure-storage-blob, azure-storage-queue, and azure-identity
+Python SDKs (~6MB installed) instead of the full azure-cli (~800MB).
+
+Auth: reads AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, and
+AZURE_STORAGE_ACCOUNT from the environment — the same env vars that the
+worker already sets for `az login --service-principal`.
+"""
+
+import fnmatch
+import os
+import sys
+
+from azure.identity import ClientSecretCredential
+from azure.storage.blob import BlobServiceClient
+from azure.storage.queue import QueueClient
+
+
+# ---------------------------------------------------------------------------
+# Auth / client helpers
+# ---------------------------------------------------------------------------
+
+def get_credential():
+    """Service principal credential from env vars."""
+    return ClientSecretCredential(
+        tenant_id=os.environ["AZURE_TENANT_ID"],
+        client_id=os.environ["AZURE_CLIENT_ID"],
+        client_secret=os.environ["AZURE_CLIENT_SECRET"],
+    )
+
+
+def get_blob_service_client():
+    account = os.environ["AZURE_STORAGE_ACCOUNT"]
+    return BlobServiceClient(
+        account_url=f"https://{account}.blob.core.windows.net",
+        credential=get_credential(),
+    )
+
+
+def get_queue_client(queue_name):
+    account = os.environ["AZURE_STORAGE_ACCOUNT"]
+    return QueueClient(
+        account_url=f"https://{account}.queue.core.windows.net",
+        queue_name=queue_name,
+        credential=get_credential(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_login():
+    """Validate credentials by fetching a token.
+
+    Replaces: az login --service-principal -u $ID -p $SECRET --tenant $TENANT
+    The SDK doesn't need a separate login step — each client authenticates
+    on first use. This command exists so the worker can fail fast if creds
+    are invalid, before starting any real work.
+    """
+    cred = get_credential()
+    cred.get_token("https://storage.azure.com/.default")
+
+
+def cmd_blob_upload(args):
+    """Upload a local file to a blob (overwrites if exists).
+
+    Usage: blob upload <local-file> <container> <blob-name>
+    Replaces: az storage blob upload --overwrite --account-name X
+              --container-name C --file F --name N
+    """
+    local_file, container, blob_name = args[0], args[1], args[2]
+    blob = get_blob_service_client().get_blob_client(
+        container=container, blob=blob_name
+    )
+    with open(local_file, "rb") as f:
+        blob.upload_blob(f, overwrite=True)
+
+
+def cmd_blob_download(args):
+    """Download a single blob to a local file.
+
+    Usage: blob download <container> <blob-name> <dest-file>
+    Replaces: az storage blob download --account-name X
+              --container-name C --name N --file F
+    """
+    container, blob_name, dest = args[0], args[1], args[2]
+    blob = get_blob_service_client().get_blob_client(
+        container=container, blob=blob_name
+    )
+    with open(dest, "wb") as f:
+        data = blob.download_blob()
+        data.readinto(f)
+
+
+def cmd_blob_download_batch(args):
+    """Download blobs matching a glob pattern, preserving directory structure.
+
+    Usage: blob download-batch <container> <dest-dir> --pattern <pattern>
+    Replaces: az storage blob download-batch -d . --account-name X
+              -s C --pattern P
+
+    Blob names like "tests/abc123/foo.yaml" are written to
+    <dest-dir>/tests/abc123/foo.yaml, matching az CLI behavior.
+    """
+    container = args[0]
+    dest_dir = args[1]
+    pattern = _extract_flag(args, "--pattern")
+
+    container_client = get_blob_service_client().get_container_client(container)
+    for blob in container_client.list_blobs():
+        if pattern and not fnmatch.fnmatch(blob.name, pattern):
+            continue
+        dest_path = os.path.join(dest_dir, blob.name)
+        os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+        blob_client = container_client.get_blob_client(blob.name)
+        with open(dest_path, "wb") as f:
+            blob_client.download_blob().readinto(f)
+
+
+def cmd_blob_delete_batch(args):
+    """Delete blobs matching a glob pattern.
+
+    Usage: blob delete-batch <container> --pattern <pattern>
+    Replaces: az storage blob delete-batch --account-name X
+              -s C --pattern P
+
+    Silently succeeds if no blobs match (same as az CLI behavior).
+    """
+    container = args[0]
+    pattern = _extract_flag(args, "--pattern")
+
+    container_client = get_blob_service_client().get_container_client(container)
+    for blob in container_client.list_blobs():
+        if pattern and not fnmatch.fnmatch(blob.name, pattern):
+            continue
+        container_client.delete_blob(blob.name)
+
+
+def cmd_queue_send(args):
+    """Send a message to Azure Queue Storage.
+
+    Usage: queue send <queue-name> <message-content>
+    Replaces: az storage message put --content M --queue-name Q
+              --account-name X
+    """
+    queue_name, content = args[0], args[1]
+    get_queue_client(queue_name).send_message(content)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract_flag(args, flag):
+    """Extract a --flag value from an args list."""
+    for i, a in enumerate(args):
+        if a == flag and i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+USAGE = """\
+Usage: azure-storage-helper <command> [args...]
+
+Commands:
+  login
+  blob upload <file> <container> <name>
+  blob download <container> <name> <dest>
+  blob download-batch <container> <dest> --pattern <pat>
+  blob delete-batch <container> --pattern <pat>
+  queue send <queue-name> <message>
+"""
+
+BLOB_DISPATCH = {
+    "upload": cmd_blob_upload,
+    "download": cmd_blob_download,
+    "download-batch": cmd_blob_download_batch,
+    "delete-batch": cmd_blob_delete_batch,
+}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(USAGE, file=sys.stderr)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    rest = sys.argv[2:]
+
+    if cmd in ("-h", "--help"):
+        print(USAGE)
+        sys.exit(0)
+    elif cmd == "login":
+        cmd_login()
+    elif cmd == "blob":
+        if not rest or rest[0] not in BLOB_DISPATCH:
+            print(USAGE, file=sys.stderr)
+            sys.exit(1)
+        BLOB_DISPATCH[rest[0]](rest[1:])
+    elif cmd == "queue":
+        if not rest or rest[0] != "send":
+            print(USAGE, file=sys.stderr)
+            sys.exit(1)
+        cmd_queue_send(rest[1:])
+    else:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -62,7 +62,7 @@ s3_run_data_path=
 worker_id=
 is_leader=${IS_LEADER:-false} # true or false
 
-declare -r DEPENDENCIES=(jq aws az pwgen node npm yarn tree)
+declare -r DEPENDENCIES=(jq aws azure-storage-helper pwgen node npm yarn tree)
 
 send_message () {
     local body="$1" # body of the message, a string
@@ -85,10 +85,9 @@ send_message_aqs () {
     local aqs_message_payload="{\"msg\":\"$body\",\"type\":\"$type\"}"
     local aqs_message_attributes="{\"testId\": \"${test_run_id}\", \"workerId\": \"${worker_id}\"}"
 
-    >/dev/null az storage message put \
-        --content "{ \"payload\": $aqs_message_payload, \"attributes\": $aqs_message_attributes }" \
-        --queue-name "$AQS_QUEUE_NAME" \
-        --account-name "$AZURE_STORAGE_ACCOUNT" || true
+    >/dev/null azure-storage-helper queue send \
+        "$AQS_QUEUE_NAME" \
+        "{ \"payload\": $aqs_message_payload, \"attributes\": $aqs_message_attributes }" || true
 
     set -e
     set -o pipefail
@@ -151,10 +150,9 @@ send_event_aqs () {
 
     local aqs_message_attributes="{\"testId\": \"${test_run_id}\", \"workerId\": \"${worker_id}\"}"
 
-    >/dev/null az storage message put \
-        --content "{ \"payload\": $payload, \"attributes\": $aqs_message_attributes }" \
-        --queue-name "$AQS_QUEUE_NAME" \
-        --account-name "$AZURE_STORAGE_ACCOUNT"
+    >/dev/null azure-storage-helper queue send \
+        "$AQS_QUEUE_NAME" \
+        "{ \"payload\": $payload, \"attributes\": $aqs_message_attributes }"
 }
 
 
@@ -224,7 +222,7 @@ sync_test_data_azure () {
     # TODO: Exclude node_modules_stream.zip
     # This recreates the directory structure in the container, i.e. we'll have tests/$test_run_id here with all files under it
     # So we need to move them all up two levels to the current directory
-    az storage blob download-batch -d . --account-name "$AZURE_STORAGE_ACCOUNT" -s "$azure_storage_container_name" --pattern "tests/$test_run_id/*"
+    azure-storage-helper blob download-batch "$azure_storage_container_name" . --pattern "tests/$test_run_id/*"
     local tmpdir="$(mktemp -d)"
     set +e
     mv tests/$test_run_id/{.,}* $tmpdir
@@ -274,7 +272,7 @@ install_dependencies () {
         # aws s3 mv "$s3_test_data_path/node_modules_stream.zip" "$s3_test_data_path/node_modules.zip"
 
         if [[ "$is_azure" = "yes" ]] ; then
-            az storage blob upload --overwrite --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$azure_storage_container_name" --file node_modules.zip --name "tests/$test_run_id/node_modules.zip"
+            azure-storage-helper blob upload node_modules.zip "$azure_storage_container_name" "tests/$test_run_id/node_modules.zip"
         else
             aws s3 cp node_modules.zip "$s3_test_data_path/node_modules.zip"
         fi
@@ -309,7 +307,7 @@ signal_ready () {
         send_event "{\"event\": \"workerReady\"}"
 
         synced_dest="${azure_storage_container_name}/$synced_filename"
-        az storage blob upload --overwrite --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$azure_storage_container_name" --file "$synced_filename" --name "tests/$test_run_id/$synced_filename"
+        azure-storage-helper blob upload "$synced_filename" "$azure_storage_container_name" "tests/$test_run_id/$synced_filename"
         cp_status=$?
     else
         synced_dest="${s3_run_data_path}/${synced_filename}"
@@ -343,7 +341,7 @@ wait_for_go () {
         set +e
 
         if [[ "$is_azure" = "yes" ]] ; then
-            az storage blob download --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$azure_storage_container_name" --name "$objpath" --file "$(basename $objpath)" 1>/dev/null 2>/dev/null
+            azure-storage-helper blob download "$azure_storage_container_name" "$objpath" "$(basename $objpath)" 1>/dev/null 2>/dev/null
         else
             aws s3 cp "$objpath" . 1>/dev/null 2>/dev/null
         fi
@@ -371,10 +369,9 @@ wait_for_go () {
 send_no_license_message () {
     set +e
 
-    az storage message put \
-        --content "{\"payload\":{\"event\":\"workerError\",\"reason\":\"License not found - https://docs.art/az/license\", \"exitCode\":$ERR_NO_LICENSE},\"attributes\":{\"testId\": \"${test_run_id}\", \"workerId\": \"${worker_id}\"}}" \
-        --queue-name "$AQS_QUEUE_NAME" \
-        --account-name "$AZURE_STORAGE_ACCOUNT" || true
+    azure-storage-helper queue send \
+        "$AQS_QUEUE_NAME" \
+        "{\"payload\":{\"event\":\"workerError\",\"reason\":\"License not found - https://docs.art/az/license\", \"exitCode\":$ERR_NO_LICENSE},\"attributes\":{\"testId\": \"${test_run_id}\", \"workerId\": \"${worker_id}\"}}" || true
 
     set -e
 }
@@ -646,7 +643,9 @@ if [[ "$is_azure" = "yes" ]] ; then
     # Remap for convenience
     azure_storage_container_name="$s3_test_data_path"
 
-    az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+    # SDK authenticates lazily per-request, but we validate creds upfront
+    # to fail fast if they're invalid (same purpose as the old az login call)
+    azure-storage-helper login
 fi
 
 if [[ "$is_azure" != "yes" ]] ; then
@@ -678,9 +677,8 @@ cleanup () {
                 if [[ -z "${AZURE_RETAIN_BLOBS:-""}" ]] ; then
                     # This exits with 0 regardless of whether the pattern matches any
                     # blobs or not so it's OK to run this multiple times
-                    az storage blob delete-batch \
-                        --account-name "$AZURE_STORAGE_ACCOUNT" \
-                        -s "$azure_storage_container_name" \
+                    azure-storage-helper blob delete-batch \
+                        "$azure_storage_container_name" \
                         --pattern "tests/$test_run_id/*"
                 fi
             fi

--- a/packages/artillery/lib/platform/aws-lambda/index.js
+++ b/packages/artillery/lib/platform/aws-lambda/index.js
@@ -701,7 +701,7 @@ class PlatformLambda {
       },
       ImageConfig: {
         Command: ['a9-handler-index.handler'],
-        EntryPoint: ['/usr/bin/npx', 'aws-lambda-ric']
+        EntryPoint: ['/usr/local/bin/npx', 'aws-lambda-ric']
       },
       FunctionName: functionName,
       Description: 'Artillery.io test',


### PR DESCRIPTION
## Description

A set of optimizations for the worker image to reduce its size.

Multi-stage build: compile aws-lambda-ric in builder stage, discard ~500MB build toolchain (g++, cmake, headers) from final image.

Base image: swap mcr.microsoft.com/playwright:v1.58.1 (~2GB, all 3 browsers + all system deps) for node:24.14.1-bookworm-slim + targeted `npx playwright install --with-deps chromium` (~560MB). Saves ~900MB.

AWS CLI: pip-installed v1 (~350MB, botocore JSON bloat) replaced with v2 standalone installer (~200MB, bundles own Python).

Azure CLI: full azure-cli==2.76.0 (~800MB, 200+ transitive packages) replaced with azure-storage-blob + azure-storage-queue + azure-identity SDKs (~6MB). A new azure-storage-helper Python script wraps the 6 az subcommands actually used by loadgen-worker.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs?
- [ ] Does this require a changelog entry?
