### PR TITLE
feat: retain blob storage by default

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -38,8 +38,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" \
 
 # --- Azure Storage SDK (replaces the full azure-cli) ---
 # The old Dockerfile installed azure-cli==2.76.0 (~800MB-1GB) but only used
-# 6 subcommands: login, blob upload/download/download-batch/delete-batch,
-# and queue send. We replace it with 3 targeted Python SDK packages (~6MB):
+# 5 subcommands: login, blob upload/download/download-batch, and queue send.
+# We replace it with 3 targeted Python SDK packages (~6MB):
 #   azure-storage-blob   - blob operations
 #   azure-storage-queue  - queue message operations
 #   azure-identity       - service principal authentication

--- a/packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper
+++ b/packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper
@@ -3,12 +3,11 @@
 Lightweight replacement for the `az` CLI commands used by the Artillery
 Fargate worker (loadgen-worker).
 
-Implements only the 6 subcommands actually used:
+Implements only the 5 subcommands actually used:
   login                    - validate service principal credentials
   blob upload              - upload a local file as a blob
   blob download            - download a single blob to a local file
   blob download-batch      - download blobs matching a glob pattern
-  blob delete-batch        - delete blobs matching a glob pattern
   queue send               - send a message to Azure Queue Storage
 
 Uses the azure-storage-blob, azure-storage-queue, and azure-identity
@@ -130,25 +129,6 @@ def cmd_blob_download_batch(args):
             blob_client.download_blob().readinto(f)
 
 
-def cmd_blob_delete_batch(args):
-    """Delete blobs matching a glob pattern.
-
-    Usage: blob delete-batch <container> --pattern <pattern>
-    Replaces: az storage blob delete-batch --account-name X
-              -s C --pattern P
-
-    Silently succeeds if no blobs match (same as az CLI behavior).
-    """
-    container = args[0]
-    pattern = _extract_flag(args, "--pattern")
-
-    container_client = get_blob_service_client().get_container_client(container)
-    for blob in container_client.list_blobs():
-        if pattern and not fnmatch.fnmatch(blob.name, pattern):
-            continue
-        container_client.delete_blob(blob.name)
-
-
 def cmd_queue_send(args):
     """Send a message to Azure Queue Storage.
 
@@ -180,7 +160,6 @@ Commands:
   blob upload <file> <container> <name>
   blob download <container> <name> <dest>
   blob download-batch <container> <dest> --pattern <pat>
-  blob delete-batch <container> --pattern <pat>
   queue send <queue-name> <message>
 """
 
@@ -188,7 +167,6 @@ BLOB_DISPATCH = {
     "upload": cmd_blob_upload,
     "download": cmd_blob_download,
     "download-batch": cmd_blob_download_batch,
-    "delete-batch": cmd_blob_delete_batch,
 }
 
 

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -672,17 +672,10 @@ cleanup () {
     if [[ $CLEANING_UP = "no" ]] ; then
         CLEANING_UP="yes"
 
-        if [[ "$is_azure" = "yes" ]] ; then
-            if [[ "$is_leader" = "true" ]] ; then
-                if [[ -z "${AZURE_RETAIN_BLOBS:-""}" ]] ; then
-                    # This exits with 0 regardless of whether the pattern matches any
-                    # blobs or not so it's OK to run this multiple times
-                    azure-storage-helper blob delete-batch \
-                        "$azure_storage_container_name" \
-                        --pattern "tests/$test_run_id/*"
-                fi
-            fi
-        fi
+        # Note: workers no longer clean up test artifacts from blob/object
+        # storage. On Fargate, S3 lifecycle rules handle retention. On Azure,
+        # users are expected to configure a blob lifecycle management policy
+        # on the storage account (see the Azure setup docs).
 
         # Abnormal exit:
         if [[ $CLI_RUNNING = "yes" ]] ; then

--- a/packages/artillery/lib/platform/az/aci.js
+++ b/packages/artillery/lib/platform/az/aci.js
@@ -278,7 +278,7 @@ class PlatformAzureACI {
                 this.blobContainerClient.getBlockBlobClient(
                   payload._overflowRef
                 );
-              const downloadResponse = await blobClient.download(0);
+              const downloadResponse = await blobClient.download();
               const downloaded = await streamToString(
                 downloadResponse.readableStreamBody
               );


### PR DESCRIPTION
## Description

Test-related artifacts stored in Blob Storage are indefinitely retained by default now. A storage account-level lifecycle management policy can be configured to automatically remove Artillery test data.


## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
