### PR TITLE
fix(core): mirror http.timeout into agent socket timeout

### DIFF
--- a/packages/core/lib/engine_http.js
+++ b/packages/core/lib/engine_http.js
@@ -58,6 +58,21 @@ const DEFAULT_AGENT_OPTIONS = {
   keepAliveMsec: 1000
 };
 
+// agentkeepalive defaults `timeout` (active socket inactivity) to a hardcoded
+// floor of 8000ms (Math.max(freeSocketTimeout * 2, 8000)). When a request's
+// origin doesn't send response bytes within 8s, the socket is destroyed with
+// `error.code = 'ERR_SOCKET_TIMEOUT'` regardless of the user's configured
+// `http.timeout`. Mirror `http.timeout` (or top-level `timeout`) into the agent
+// so the YAML config becomes the actual binding constraint.
+function deriveAgentTimeoutMs(scriptConfig) {
+  const timeoutSec =
+    scriptConfig?.timeout || scriptConfig?.http?.timeout;
+  if (typeof timeoutSec !== 'number') return undefined;
+  // Never go below the existing 8s floor — preserves current behaviour for
+  // users who explicitly configure a smaller http.timeout.
+  return Math.max(8000, timeoutSec * 1000);
+}
+
 function createAgents(proxies, opts) {
   const agentOpts = Object.assign({}, DEFAULT_AGENT_OPTIONS, opts);
 
@@ -129,6 +144,10 @@ function HttpEngine(script) {
     maxSockets: this.maxSockets,
     maxFreeSockets: this.maxSockets
   });
+  const agentTimeoutMs = deriveAgentTimeoutMs(script.config);
+  if (agentTimeoutMs !== undefined) {
+    agentOpts.timeout = agentTimeoutMs;
+  }
 
   const agents = createAgents(
     {
@@ -1003,6 +1022,10 @@ HttpEngine.prototype.setInitialContext = function (initialContext) {
       maxSockets: 1,
       maxFreeSockets: 1
     });
+    const agentTimeoutMs = deriveAgentTimeoutMs(this.config);
+    if (agentTimeoutMs !== undefined) {
+      agentOpts.timeout = agentTimeoutMs;
+    }
 
     const agents = createAgents(
       {

--- a/packages/core/test/unit/engine_http.test.js
+++ b/packages/core/test/unit/engine_http.test.js
@@ -1410,6 +1410,79 @@ test('HTTP engine', (tap) => {
   });
 
   tap.test(
+    'agent socket timeout - mirrors http.timeout',
+    async (t) => {
+      // agentkeepalive defaults its socket-inactivity `timeout` to a hardcoded
+      // 8000ms floor (Math.max(freeSocketTimeout * 2, 8000)). Without this fix,
+      // any request whose origin took >8s to send the first response byte
+      // would be killed with ERR_SOCKET_TIMEOUT regardless of http.timeout.
+      // The agent should now mirror http.timeout (or top-level timeout).
+
+      t.test('without timeout config, falls back to agentkeepalive default', async (t) => {
+        const engine = new HttpEngine({
+          config: { target: 'http://localhost:8888' },
+          scenarios: [{ flow: [] }]
+        });
+        await engine.init();
+        // agentkeepalive default: Math.max(freeSocketTimeout * 2, 8000) = 8000
+        t.equal(
+          engine._httpsAgent.options.timeout,
+          8000,
+          'agent timeout should fall back to agentkeepalive default (8000ms)'
+        );
+        t.end();
+      });
+
+      t.test('http.timeout sets agent timeout', async (t) => {
+        const engine = new HttpEngine({
+          config: { target: 'http://localhost:8888', http: { timeout: 30 } },
+          scenarios: [{ flow: [] }]
+        });
+        await engine.init();
+        t.equal(
+          engine._httpsAgent.options.timeout,
+          30000,
+          'agent timeout should be 30000ms when http.timeout is 30'
+        );
+        t.end();
+      });
+
+      t.test('top-level timeout also sets agent timeout', async (t) => {
+        const engine = new HttpEngine({
+          config: { target: 'http://localhost:8888', timeout: 45 },
+          scenarios: [{ flow: [] }]
+        });
+        await engine.init();
+        t.equal(
+          engine._httpsAgent.options.timeout,
+          45000,
+          'agent timeout should be 45000ms when top-level timeout is 45'
+        );
+        t.end();
+      });
+
+      t.test('http.timeout < 8s preserves the 8s floor', async (t) => {
+        // Backward-compat: never go below the pre-existing 8s floor, even if
+        // http.timeout is configured smaller (got's response timeout will
+        // fire first in that case).
+        const engine = new HttpEngine({
+          config: { target: 'http://localhost:8888', http: { timeout: 3 } },
+          scenarios: [{ flow: [] }]
+        });
+        await engine.init();
+        t.equal(
+          engine._httpsAgent.options.timeout,
+          8000,
+          'agent timeout should not drop below 8000ms (pre-existing floor)'
+        );
+        t.end();
+      });
+
+      t.end();
+    }
+  );
+
+  tap.test(
     'GOT_OPTION_NAMES - unknown options do not cause errors',
     async (t) => {
       const target = nock('http://localhost:8888')


### PR DESCRIPTION
###  Problem

agentkeepalive's default socket-inactivity timeout is `Math.max(freeSocketTimeout * 2, 8000) = 8000ms` minimum. When a request's origin takes >8s to send the first response byte, agentkeepalive destroys the socket with `ERR_SOCKET_TIMEOUT` regardless of the user's configured `http.timeout`. 
`http.timeout` is mapped to got's response timeout — a different layer that never fires because the socket is already destroyed. 

### Result

`http.timeout` is silently capped at 8s for any slow origin. We hit this in production debugging a backed endpoint that takes 6-25s to respond; despite `http.timeout: 30`, every long request failed at exactly 8s.                                                                                          
                                                                                                                                                                
### Fix

Derive the agent's socket-inactivity timeout from the existing `http.timeout` config and pass it through to agentkeepalive. No new schema, backward-compatible (never below 8s floor). 

### Tests

Four new unit tests covering:   
  - http.timeout: N → agent timeout = N*1000                                                                                                                    
  - top-level timeout: N → agent timeout = N*1000           
  - no timeout config → agent timeout = 8000 (existing default preserved)                                                                                     
  - http.timeout: 3 → agent timeout = 8000 (floor preserved)
   
  All 84 asserts in `engine_http.test.js ` pass.
                                                                                                                                                        
###   Reproduction (without fix)                                                                                                                                    

A self-hosted slow server is the cleanest way to reproduce:

   ```js
   // slow-server.js
   const http = require('http');
   http.createServer((req, res) => {
     setTimeout(() => {
       res.writeHead(200);
       res.end('ok');
     }, 15000);  // 15s delay
   }).listen(8765);
   ```

   ```yaml
   # repro.yml
   config:
     target: http://localhost:8765
     http:
       timeout: 30
     phases: [{ duration: 1, arrivalCount: 1 }]
   scenarios:
     - flow:
         - get:
             url: "/"
             expect: [{ statusCode: 200 }]
   ```

   `node slow-server.js & artillery run repro.yml`

   Without fix: 1 ERR_SOCKET_TIMEOUT at ~8s (configured 30s timeout ignored).
   With fix: 1 statusCode 200 at ~15s.
