### PR TITLE
fix: add explicit dependency on @smithy/core/config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5651,20 +5651,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.16",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
+      "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
+        "@aws-crypto/crc32": "5.2.0",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.24",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -20369,6 +20362,7 @@
         "@oclif/core": "^4.8.0",
         "@oclif/plugin-help": "^6.2.36",
         "@oclif/plugin-not-found": "^3.2.73",
+        "@smithy/core": "^3.24.0",
         "@upstash/redis": "^1.36.1",
         "artillery-engine-playwright": "*",
         "artillery-plugin-apdex": "*",

--- a/packages/artillery/lib/platform/aws/aws-get-default-region.js
+++ b/packages/artillery/lib/platform/aws/aws-get-default-region.js
@@ -1,8 +1,8 @@
-const { loadConfig } = require('@smithy/node-config-provider');
 const {
+  loadConfig,
   NODE_REGION_CONFIG_FILE_OPTIONS,
   NODE_REGION_CONFIG_OPTIONS
-} = require('@smithy/config-resolver');
+} = require('@smithy/core/config');
 const debug = require('debug')('util:aws:get-default-region');
 
 let defaultRegionAlreadyChecked = false;

--- a/packages/artillery/package.json
+++ b/packages/artillery/package.json
@@ -123,6 +123,7 @@
     "@oclif/core": "^4.8.0",
     "@oclif/plugin-help": "^6.2.36",
     "@oclif/plugin-not-found": "^3.2.73",
+    "@smithy/core": "^3.24.0",
     "@upstash/redis": "^1.36.1",
     "artillery-engine-playwright": "*",
     "artillery-plugin-apdex": "*",


### PR DESCRIPTION
## Description

Previous requires of `@smithy/node-config-provider` and `@smithy/config-resolver` as undeclared transitive deps of `@aws-sdk/client-*`.

As of `@aws-sdk/client-*@3.1046.0` (2026-05-14) those standalone packages were dropped from the AWS SDK client deps and the same APIs are re-exported from the `@smithy/core/config` subpath (added in `@smithy/core@3.24.0`).

Add `@smithy/core` directly so this require is no longer relying on hoisting of transitive deps.

Fixes #3735

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
