### PR TITLE
fix: remove workaround for curl on arm64

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -207,17 +207,6 @@ COPY --from=builder /opt/azure-sdk /opt/azure-sdk
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/azure-storage-helper /usr/local/bin/azure-storage-helper
 RUN chmod +x /usr/local/bin/azure-storage-helper
 
-# --- curl: IPv4 preference + arm64 SSL workaround ---
-# Forces IPv4 to avoid DNS/connectivity issues in some container networks.
-# The arm64 'insecure' flag works around a curl SSL_ERROR_SYSCALL bug:
-# https://github.com/curl/curl/issues/14154
-RUN <<EOT
-echo 'ipv4' >> ~/.curlrc
-if [ "$TARGETARCH" = "arm64" ]; then
-echo 'insecure' >> ~/.curlrc
-fi
-EOT
-
 ARG WORKER_VERSION
 ENV WORKER_VERSION=$WORKER_VERSION
 


### PR DESCRIPTION
## Description

Workaround no longer needed.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
