### PR TITLE
feat: replace ngneat/falso with Faker.js in fake-data plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2672,6 +2672,22 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
@@ -4304,16 +4320,6 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "license": "MIT"
-    },
-    "node_modules/@ngneat/falso": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@ngneat/falso/-/falso-8.0.2.tgz",
-      "integrity": "sha512-vhPtuoHoxE5JGWPSPBqEyTXcjI4MAn8GllR+Vs8FfpAQu2sQRd4PJc3e8kc9vdbdhYHx1C9HmbECgtGLK30z4w==",
-      "license": "MIT",
-      "dependencies": {
-        "seedrandom": "3.0.5",
-        "uuid": "8.3.2"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -17786,12 +17792,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/seedrandom": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
-      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -20990,7 +20990,10 @@
       "version": "1.23.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ngneat/falso": "^8.0.2"
+        "@faker-js/faker": "10.4.0"
+      },
+      "devDependencies": {
+        "tap": "^19.0.2"
       }
     },
     "packages/artillery-plugin-memory-inspector": {

--- a/packages/artillery-plugin-fake-data/README.md
+++ b/packages/artillery-plugin-fake-data/README.md
@@ -1,8 +1,14 @@
 # artillery-plugin-fake-data
 
-## Easy randomised test data leveraging falso
+## Easy randomised test data leveraging Faker
 
-With this plugin, you can add random test data using [falso](https://ngneat.github.io/falso/docs) straight into YAML, giving you a wide range of test data options to choose from. You'll also be able to use the same functions in your `beforeRequest`/`afterResponse` hooks. Check the documentation for more information.
+With this plugin, you can add random test data using [Faker](https://fakerjs.dev/api/) straight into YAML, giving you a wide range of test data options to choose from. You'll also be able to use the same functions in your `beforeRequest`/`afterResponse` hooks. Check the documentation for more information.
+
+Faker functions are exposed with flattened names: `faker.internet.email()` becomes `$internetEmail()`, `faker.person.fullName()` becomes `$personFullName()`, and so on.
+
+### Migrating from falso
+
+Earlier versions of this plugin used [falso](https://ngneat.github.io/falso/). The most commonly used falso-style names (e.g. `$randEmail`, `$randFullName`, `$randPassword`) still work as deprecated aliases, but will be removed in a future release. Function configuration options now use Faker's option shapes (e.g. `internetPassword: { length: 5 }` instead of `randPassword: { size: 5 }`). See the [plugin documentation](https://www.artillery.io/docs/reference/extensions/fake-data) for a migration table.
 
 ## Documentation
 

--- a/packages/artillery-plugin-fake-data/index.js
+++ b/packages/artillery-plugin-fake-data/index.js
@@ -1,22 +1,94 @@
-const falso = require('@ngneat/falso');
+const { faker } = require('@faker-js/faker');
 
-const getFalsoFunctions = () =>
-  Object.keys(falso).filter((funcName) => {
-    //functions that have the function signature we expect start with rand and aren't == rand (which takes an array)
-    if (!funcName.startsWith('rand') && funcName !== 'rand') {
-      return false;
+// Modules that don't expose simple data-generation functions
+const SKIPPED_MODULES = new Set(['helpers', 'definitions', 'rawDefinitions']);
+
+// Deprecated falso-style aliases kept for backwards compatibility.
+// Maps legacy `$rand*` names to their faker equivalents (flattened names).
+// NOTE: configuration options are NOT translated - options must be provided
+// using the faker option shape, under the faker function name.
+const DEPRECATED_ALIASES = {
+  randEmail: 'internetEmail',
+  randFullName: 'personFullName',
+  randFirstName: 'personFirstName',
+  randLastName: 'personLastName',
+  randUserName: 'internetUsername',
+  randPassword: 'internetPassword',
+  randUuid: 'stringUuid',
+  randPhoneNumber: 'phoneNumber',
+  randCity: 'locationCity',
+  randCountry: 'locationCountry',
+  randStreetAddress: 'locationStreetAddress',
+  randZipCode: 'locationZipCode',
+  randCompanyName: 'companyName',
+  randNumber: 'numberInt',
+  randBoolean: 'datatypeBoolean',
+  randUrl: 'internetUrl',
+  randIp: 'internetIpv4',
+  randWord: 'loremWord',
+  randSentence: 'loremSentence',
+  randParagraph: 'loremParagraph',
+  randText: 'loremText',
+  randJobTitle: 'personJobTitle',
+  randColor: 'colorHuman',
+  randProductName: 'commerceProductName'
+};
+
+const flattenName = (moduleName, functionName) =>
+  `${moduleName}${functionName[0].toUpperCase()}${functionName.slice(1)}`;
+
+// Builds a map of flattened function names (e.g. `internetEmail`) to
+// zero/one-argument faker functions (e.g. `faker.internet.email`)
+const buildFakerFunctionMap = () => {
+  const functions = {};
+
+  for (const moduleName of Object.keys(faker)) {
+    if (SKIPPED_MODULES.has(moduleName) || moduleName.startsWith('_')) {
+      continue;
     }
 
-    //don't add functions that have more than 1 argument, as we only support 1 argument
-    //we can look into adding support for more arguments later, but most of the functions available use 1 argument anyway
-    if (falso[funcName].length > 1) {
-      return false;
+    const mod = faker[moduleName];
+    if (!mod || typeof mod !== 'object') {
+      continue;
     }
 
-    return true;
-  });
+    // Walk the prototype chain: some faker modules inherit methods
+    // (e.g. DateModule extends SimpleDateModule)
+    let proto = Object.getPrototypeOf(mod);
+    while (proto && proto !== Object.prototype) {
+      for (const functionName of Object.getOwnPropertyNames(proto)) {
+        if (functionName === 'constructor' || functionName.startsWith('_')) {
+          continue;
+        }
 
-const falsoFunctions = getFalsoFunctions();
+        if (typeof mod[functionName] !== 'function') {
+          continue;
+        }
+
+        // Only functions taking at most one argument are supported, as
+        // configuration is passed as a single (object) argument
+        if (mod[functionName].length > 1) {
+          continue;
+        }
+
+        const flatName = flattenName(moduleName, functionName);
+        if (!functions[flatName]) {
+          functions[flatName] = mod[functionName].bind(mod);
+        }
+      }
+
+      proto = Object.getPrototypeOf(proto);
+    }
+  }
+
+  return functions;
+};
+
+const fakerFunctionMap = buildFakerFunctionMap();
+
+const getFakerFunctions = () => Object.keys(fakerFunctionMap);
+
+const warnedAliases = new Set();
 
 function ArtilleryPluginFakeData(script, events) {
   this.script = script;
@@ -25,22 +97,35 @@ function ArtilleryPluginFakeData(script, events) {
   const pluginConfig =
     script.config['fake-data'] || script.config.plugins['fake-data'];
 
-  function falsoHandler(context, _ee, next) {
-    falsoFunctions.forEach((funcName) => {
+  function fakeDataHandler(context, _ee, next) {
+    for (const [funcName, fakerFunc] of Object.entries(fakerFunctionMap)) {
       context.funcs[`$${funcName}`] = () => {
         if (pluginConfig[funcName]) {
-          return falso[funcName](pluginConfig[funcName]);
+          return fakerFunc(pluginConfig[funcName]);
         }
-        return falso[funcName]();
+        return fakerFunc();
       };
-    });
+    }
+
+    for (const [aliasName, funcName] of Object.entries(DEPRECATED_ALIASES)) {
+      context.funcs[`$${aliasName}`] = () => {
+        if (!warnedAliases.has(aliasName)) {
+          warnedAliases.add(aliasName);
+          console.warn(
+            `[fake-data] $${aliasName} is deprecated and will be removed in a future release. Use $${funcName} instead.`
+          );
+        }
+
+        return context.funcs[`$${funcName}`]();
+      };
+    }
 
     next();
   }
 
   script.scenarios = script.scenarios.map((scenario) => {
     scenario.beforeScenario = [].concat(scenario.beforeScenario || []);
-    scenario.beforeScenario.push('falsoHandler');
+    scenario.beforeScenario.push('fakeDataHandler');
     return scenario;
   });
 
@@ -48,12 +133,13 @@ function ArtilleryPluginFakeData(script, events) {
     script.config.processor = {};
   }
 
-  script.config.processor.falsoHandler = falsoHandler;
+  script.config.processor.fakeDataHandler = fakeDataHandler;
 
   return this;
 }
 
 module.exports = {
   Plugin: ArtilleryPluginFakeData,
-  getFalsoFunctions
+  getFakerFunctions,
+  getDeprecatedAliases: () => ({ ...DEPRECATED_ALIASES })
 };

--- a/packages/artillery-plugin-fake-data/package.json
+++ b/packages/artillery-plugin-fake-data/package.json
@@ -7,10 +7,18 @@
     "access": "public"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "tap ./test/*.spec.js --timeout 120"
+  },
+  "tap": {
+    "disable-coverage": true,
+    "allow-empty-coverage": true,
+    "color": true
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "@ngneat/falso": "^8.0.2"
+    "@faker-js/faker": "10.4.0"
+  },
+  "devDependencies": {
+    "tap": "^19.0.2"
   }
 }

--- a/packages/artillery-plugin-fake-data/test/index.spec.js
+++ b/packages/artillery-plugin-fake-data/test/index.spec.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const { test } = require('tap');
+const {
+  Plugin,
+  getFakerFunctions,
+  getDeprecatedAliases
+} = require('../index');
+
+const makeScript = (pluginConfig = {}) => ({
+  config: {
+    plugins: {
+      'fake-data': pluginConfig
+    }
+  },
+  scenarios: [{ name: 'test scenario', flow: [] }]
+});
+
+const runHandler = (script) => {
+  const context = { funcs: {}, vars: {} };
+  let nextCalled = false;
+  script.config.processor.fakeDataHandler(context, null, () => {
+    nextCalled = true;
+  });
+  return { context, nextCalled };
+};
+
+test('exposes faker functions with flattened names', (t) => {
+  const functions = getFakerFunctions();
+
+  t.ok(functions.length > 200, `found ${functions.length} functions`);
+
+  for (const expected of [
+    'internetEmail',
+    'internetPassword',
+    'personFullName',
+    'personFirstName',
+    'stringUuid',
+    'numberInt',
+    'datatypeBoolean',
+    'locationCity',
+    'companyName',
+    'loremSentence',
+    'dateBirthdate', // inherited via prototype chain (SimpleDateModule)
+    'datePast'
+  ]) {
+    t.ok(functions.includes(expected), `includes ${expected}`);
+  }
+
+  t.end();
+});
+
+test('attaches beforeScenario hook and processor function', (t) => {
+  const script = makeScript();
+  new Plugin(script, null);
+
+  t.same(script.scenarios[0].beforeScenario, ['fakeDataHandler']);
+  t.type(script.config.processor.fakeDataHandler, 'function');
+  t.end();
+});
+
+test('injects working $functions into context.funcs', (t) => {
+  const script = makeScript();
+  new Plugin(script, null);
+
+  const { context, nextCalled } = runHandler(script);
+
+  t.ok(nextCalled, 'next() was called');
+  t.type(context.funcs.$internetEmail, 'function');
+
+  const email = context.funcs.$internetEmail();
+  t.match(email, /@/, `generated email: ${email}`);
+
+  const uuid = context.funcs.$stringUuid();
+  t.match(
+    uuid,
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    `generated uuid: ${uuid}`
+  );
+
+  t.end();
+});
+
+test('passes plugin config as function options', (t) => {
+  const script = makeScript({
+    internetPassword: { length: 5 },
+    numberInt: { min: 10, max: 10 }
+  });
+  new Plugin(script, null);
+
+  const { context } = runHandler(script);
+
+  t.equal(context.funcs.$internetPassword().length, 5);
+  t.equal(context.funcs.$numberInt(), 10);
+  t.end();
+});
+
+test('deprecated falso aliases work and warn once', (t) => {
+  const script = makeScript();
+  new Plugin(script, null);
+
+  const { context } = runHandler(script);
+
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (msg) => warnings.push(msg);
+
+  try {
+    for (const [aliasName, funcName] of Object.entries(
+      getDeprecatedAliases()
+    )) {
+      t.type(
+        context.funcs[`$${aliasName}`],
+        'function',
+        `$${aliasName} is exposed`
+      );
+      t.type(
+        context.funcs[`$${funcName}`],
+        'function',
+        `alias target $${funcName} exists`
+      );
+      t.ok(
+        context.funcs[`$${aliasName}`]() !== undefined,
+        `$${aliasName} returns a value`
+      );
+    }
+
+    const email = context.funcs.$randEmail();
+    t.match(email, /@/, `alias generated email: ${email}`);
+
+    const aliasCount = Object.keys(getDeprecatedAliases()).length;
+    t.equal(warnings.length, aliasCount, 'warned once per alias');
+
+    // calling again must not warn again
+    context.funcs.$randEmail();
+    t.equal(warnings.length, aliasCount, 'no duplicate warnings');
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  t.end();
+});
+
+test('reads config from config.fake-data as well as config.plugins.fake-data', (t) => {
+  const script = {
+    config: {
+      'fake-data': { internetPassword: { length: 7 } },
+      plugins: { 'fake-data': {} }
+    },
+    scenarios: [{ flow: [] }]
+  };
+  new Plugin(script, null);
+
+  const { context } = runHandler(script);
+  t.equal(context.funcs.$internetPassword().length, 7);
+  t.end();
+});

--- a/packages/types/schema/plugins/fake-data.js
+++ b/packages/types/schema/plugins/fake-data.js
@@ -1,28 +1,38 @@
 const Joi = require('joi');
-const falso = require('@ngneat/falso');
-const { getFalsoFunctions } = require('artillery-plugin-fake-data');
+const {
+  getFakerFunctions,
+  getDeprecatedAliases
+} = require('artillery-plugin-fake-data');
 
-const buildFalsoObject = () => {
-  const falsoJoiObject = {};
+const buildFakerObject = () => {
+  const fakerJoiObject = {};
 
-  for (const funcName of getFalsoFunctions()) {
-    falsoJoiObject[funcName] = Joi.object()
-      .meta({ title: `Falso Function: ${funcName}` })
+  for (const funcName of getFakerFunctions()) {
+    fakerJoiObject[funcName] = Joi.object()
+      .meta({ title: `Faker Function: ${funcName}` })
       .description(
-        'For information on what parameters this function takes, check the falso documentation: https://ngneat.github.io/falso/docs/getting-started'
+        'For information on what options this function takes, check the Faker documentation: https://fakerjs.dev/api/'
       );
   }
 
-  return falsoJoiObject;
+  for (const aliasName of Object.keys(getDeprecatedAliases())) {
+    fakerJoiObject[aliasName] = Joi.object()
+      .meta({ title: `Deprecated Alias: ${aliasName}` })
+      .description(
+        'Deprecated alias kept for backwards compatibility. Use the equivalent Faker function name instead.'
+      );
+  }
+
+  return fakerJoiObject;
 };
 
 const FakeDataPlugin = Joi.object({
-  ...buildFalsoObject()
+  ...buildFakerObject()
 })
   .unknown(false)
   .meta({ title: 'Fake Data Plugin' })
   .description(
-    'This plugin adds access to random realistic test data generation using falso. You can configure the parameters of each function in the config. \nFor more information, check our documentation: https://www.artillery.io/docs/reference/extensions/fake-data'
+    'This plugin adds access to random realistic test data generation using Faker. You can configure the options of each function in the config. \nFor more information, check our documentation: https://www.artillery.io/docs/reference/extensions/fake-data'
   );
 
 module.exports = {


### PR DESCRIPTION
## Description

Replace `@ngneat/falso` with Faker.js in fake-data plugin.

All GitHub repositories under ngneat organization have been removed/made private recently without any explanation and the npm package now represents a potential supply-chain risk.

- https://www.reddit.com/r/angular/comments/1txtp35/what_happend_to_ngneat/
- https://github.com/ngneat-archive

Fixes #3744 

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
