### PR TITLE
fix: stop BOM classifying relative imports as npm packages

### DIFF
--- a/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/bom.js
@@ -334,32 +334,35 @@ function ensureEsbuildInitialized(esbuild) {
 async function traceDependencies(entries, resolveRoot) {
   const unresolved = [];
 
+  // Marker used to break recursion when we re-enter our own onResolve via
+  // build.resolve() below.
+  const RESOLVING = { artilleryRecoverResolving: true };
+
   const recoverPlugin = {
     name: 'artillery-recover-unresolved',
     setup(build) {
-      build.onResolve({ filter: /^\.{1,2}\// }, (args) => {
-        const candidate = path.resolve(args.resolveDir, args.path);
-        const exts = [
-          '',
-          '.js',
-          '.mjs',
-          '.cjs',
-          '.ts',
-          '.tsx',
-          '.json',
-          '/index.js',
-          '/index.mjs',
-          '/index.cjs',
-          '/index.ts',
-          '/index.tsx'
-        ];
-        for (const ext of exts) {
-          try {
-            if (fs.statSync(candidate + ext).isFile()) {
-              return null;
-            }
-          } catch (_e) {}
+      // Intercept relative imports ('.', '..', './x', '../x') only to
+      // recover from resolution failures: delegate to esbuild's own
+      // resolver first, and mark the import as external (so the build
+      // doesn't fail) only if esbuild itself can't resolve it.
+      build.onResolve({ filter: /^\.{1,2}(\/|$)/ }, async (args) => {
+        if (args.pluginData === RESOLVING) {
+          // Re-entered via build.resolve() — let esbuild's default
+          // resolver handle it.
+          return null;
         }
+
+        const result = await build.resolve(args.path, {
+          resolveDir: args.resolveDir,
+          importer: args.importer,
+          kind: args.kind,
+          pluginData: RESOLVING
+        });
+
+        if (result.errors.length === 0) {
+          return result;
+        }
+
         unresolved.push({
           name: args.path,
           reason: 'unresolved-relative',
@@ -419,6 +422,13 @@ async function traceDependencies(entries, resolveRoot) {
 }
 
 function extractPackageName(spec) {
+  // Relative or absolute specifiers are never npm packages. Without this
+  // guard an unresolved '../x' import (kept external by recoverPlugin)
+  // becomes a "package" named '..' and ends up npm-installed on remote
+  // workers.
+  if (spec.startsWith('.') || spec.startsWith('/') || path.isAbsolute(spec)) {
+    return null;
+  }
   if (spec.startsWith('@')) {
     const parts = spec.split('/');
     return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;

--- a/packages/artillery/test/unit/bom-trace.test.js
+++ b/packages/artillery/test/unit/bom-trace.test.js
@@ -39,6 +39,39 @@ test('Processor with missing relative import surfaces in externals', async (t) =
   t.equal(unresolved[0].name, './not-here', 'records the original specifier');
 });
 
+// Regression: relative imports that a naive resolver probe misses (ESM-style
+// '.js' specifier for a '.ts' file, directory import via package.json "main")
+// used to be marked external and then classified as an npm package named
+// '..' — which remote workers would try to `npm install`.
+test('relative imports resolved by esbuild never become npm modules', async (t) => {
+  const script = path.join(FIXTURES, 'processor-relative-resolve', 'script.yml');
+  const bom = await createBOMAsync(script, [], {
+    scenarioPath: script,
+    flags: {}
+  });
+
+  t.equal(
+    bom.modules.filter((m) => m.startsWith('.') || m.startsWith('/')).length,
+    0,
+    'no relative/absolute specifiers in modules'
+  );
+  t.equal(bom.externals.length, 0, 'no unresolved imports');
+
+  const fileNames = bom.files.map((f) => f.noPrefix).sort();
+  t.ok(
+    fileNames.includes('scenarios/processor.ts'),
+    'processor included'
+  );
+  t.ok(
+    fileNames.includes('shared/helper.ts'),
+    ".js specifier resolved to .ts file and included"
+  );
+  t.ok(
+    fileNames.includes('lib/src.js'),
+    'directory import resolved via package.json main and included'
+  );
+});
+
 test('npm module imported but not declared in package.json', async (t) => {
   const script = path.join(FIXTURES, 'processor-undeclared-pkg', 'script.yml');
   const bom = await createBOMAsync(script, [], {

--- a/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/lib/package.json
+++ b/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/lib/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "lib",
+  "main": "src.js"
+}

--- a/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/lib/src.js
+++ b/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/lib/src.js
@@ -1,0 +1,3 @@
+module.exports.mark = (ctx) => {
+  ctx.vars.marked = true;
+};

--- a/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/scenarios/processor.ts
+++ b/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/scenarios/processor.ts
@@ -1,0 +1,12 @@
+// NodeNext/ESM-style specifier: '.js' on disk is actually '.ts'.
+// esbuild resolves this natively; a naive extension probe does not.
+import { tag } from '../shared/helper.js';
+// Directory import resolved via package.json "main" — another case a
+// naive extension/index probe misses.
+import { mark } from '../lib';
+
+export function before(req: any, ctx: any, _ee: any, done: () => void) {
+  tag(ctx);
+  mark(ctx);
+  return done();
+}

--- a/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/script.yml
+++ b/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/script.yml
@@ -1,0 +1,10 @@
+config:
+  target: "http://example.com"
+  phases:
+    - duration: 1
+      arrivalRate: 1
+  processor: "./scenarios/processor.ts"
+scenarios:
+  - flow:
+      - get:
+          url: "/"

--- a/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/shared/helper.ts
+++ b/packages/artillery/test/unit/fixtures/bom-trace/processor-relative-resolve/shared/helper.ts
@@ -1,0 +1,3 @@
+export function tag(ctx: any) {
+  ctx.vars.tagged = true;
+}


### PR DESCRIPTION
## Description

Fix relative imports being turned into `..` package by BOM, resulting in test run failures.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? No
- [ ] Does this require a changelog entry? Yes
