### PR TITLE
refactor: build TypeScript packages to dist and point main at built output

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -50,7 +50,19 @@ jobs:
         with:
           ref: ${{ env.WORKER_VERSION }}
           fetch-depth: 0
-      
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 24.x
+
+      # The worker image copies workspace sources; TypeScript packages
+      # resolve their main from dist/, which must be built beforehand
+      - name: Build packages
+        run: |
+          npm install
+          npm run build
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
 
@@ -157,7 +169,19 @@ jobs:
         with:
           ref: ${{ env.WORKER_VERSION }}
           fetch-depth: 0
-      
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 24.x
+
+      # The worker image copies workspace sources; TypeScript packages
+      # resolve their main from dist/, which must be built beforehand
+      - name: Build packages
+        run: |
+          npm install
+          npm run build
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Build packages
+        run: npm run build
+
       # Uses the version from packages/artillery-engine-playwright
       - name: Install Playwright Browsers
         run: npm exec --workspace artillery-engine-playwright -- playwright install chromium --with-deps
@@ -62,6 +65,10 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Build packages
+        run: npm run build
+        working-directory: ${{ github.workspace }}
+
       - name: Test
         uses: artilleryio/action-cli@v1
         with:
@@ -91,6 +98,10 @@ jobs:
 
       - name: Install
         run: npm ci
+
+      - name: Build packages
+        run: npm run build
+        working-directory: ${{ github.workspace }}
 
       - name: Run armadillo scenario
         uses: artilleryio/action-cli@v1
@@ -131,6 +142,10 @@ jobs:
 
       - name: Install
         run: npm ci
+
+      - name: Build packages
+        run: npm run build
+        working-directory: ${{ github.workspace }}
 
       - name: Test
         uses: artilleryio/action-cli@v1

--- a/.github/workflows/npm-publish-all-packages-canary.yml
+++ b/.github/workflows/npm-publish-all-packages-canary.yml
@@ -57,6 +57,10 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.sha }}
       # It must be published in this specific order to account for order of dependencies (e.g. artillery depends on commons, core, etc), in case failures happen in publishing.
+      - name: Install dependencies and build packages
+        run: |
+          npm install
+          npm run build
       - run: npm -w @artilleryio/int-commons publish --tag canary
       - run: npm -w @artilleryio/int-core publish --tag canary
       - run: npm -w artillery-plugin-expect publish --tag canary

--- a/.github/workflows/npm-publish-all-packages.yml
+++ b/.github/workflows/npm-publish-all-packages.yml
@@ -60,6 +60,10 @@ jobs:
           scope: '@artilleryio'
       - run: node .github/workflows/scripts/replace-package-versions.js
       # It must be published in this specific order to account for order of dependencies (e.g. artillery depends on commons, core, etc), in case failures happen in publishing.
+      - name: Install dependencies and build packages
+        run: |
+          npm install
+          npm run build
       - run: npm -w @artilleryio/int-commons publish
       - run: npm -w @artilleryio/int-core publish
       - run: npm -w artillery-plugin-expect publish

--- a/.github/workflows/npm-publish-artillery-engine-posthog.yml
+++ b/.github/workflows/npm-publish-artillery-engine-posthog.yml
@@ -19,6 +19,10 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
+      - name: Install dependencies and build packages
+        run: |
+          npm install
+          npm run build
       - run: npm -w artillery-engine-posthog publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-artillery-plugin-memory-inspector.yml
+++ b/.github/workflows/npm-publish-artillery-plugin-memory-inspector.yml
@@ -19,6 +19,10 @@ jobs:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@artilleryio'
+      - name: Install dependencies and build packages
+        run: |
+          npm install
+          npm run build
       - run: npm -w artillery-plugin-memory-inspector publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-specific-package.yml
+++ b/.github/workflows/npm-publish-specific-package.yml
@@ -58,6 +58,10 @@ jobs:
       - run: npm install -w skytrace --ignore-scripts && npm run build -w skytrace
         if: ${{ inputs.PACKAGE_FOLDER_NAME == 'skytrace'}}
         
+      - name: Install dependencies and build packages
+        run: |
+          npm install
+          npm run build
       - run: npm -w ${{ env.PACKAGE_NAME }} publish --tag ${{ inputs.CHANNEL }}
 
   publish-official-docker-image:

--- a/packages/artillery-engine-playwright/package.json
+++ b/packages/artillery-engine-playwright/package.json
@@ -2,11 +2,12 @@
   "name": "artillery-engine-playwright",
   "version": "1.30.0",
   "description": "",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
     "test": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.test.js\"",
     "test:aws": "node --test --test-timeout=420000 --require ./test/setup-env.cjs \"test/*.aws.js\"",
-    "test:aws:ci": "node --test --test-timeout=420000 --require ./test/setup-env.cjs"
+    "test:aws:ci": "node --test --test-timeout=420000 --require ./test/setup-env.cjs",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-engine-playwright/tsconfig.build.json
+++ b/packages/artillery-engine-playwright/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-engine-posthog/package.json
+++ b/packages/artillery-engine-posthog/package.json
@@ -2,9 +2,10 @@
   "name": "artillery-engine-posthog",
   "version": "0.0.1",
   "description": "Load test PostHog with Artillery",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
-    "test": "node --test --require ./test/setup-env.cjs test/index.js"
+    "test": "node --test --require ./test/setup-env.cjs test/index.js",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [
     "posthog",

--- a/packages/artillery-engine-posthog/tsconfig.build.json
+++ b/packages/artillery-engine-posthog/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-apdex/package.json
+++ b/packages/artillery-plugin-apdex/package.json
@@ -2,9 +2,10 @@
   "name": "artillery-plugin-apdex",
   "version": "1.24.0",
   "description": "Calculate and report Apdex scores",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
-    "test": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\""
+    "test": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [],
   "author": "",

--- a/packages/artillery-plugin-apdex/tsconfig.build.json
+++ b/packages/artillery-plugin-apdex/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-ensure/package.json
+++ b/packages/artillery-plugin-ensure/package.json
@@ -2,11 +2,12 @@
   "name": "artillery-plugin-ensure",
   "version": "1.27.0",
   "description": "",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
     "test": "npm run test:unit && npm run test:acceptance",
     "test:acceptance": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\"",
-    "test:unit": "node --test --require ./test/setup-env.cjs \"test/*.unit.js\""
+    "test:unit": "node --test --require ./test/setup-env.cjs \"test/*.unit.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [],
   "author": "Artillery.io <team@artillery.io>",

--- a/packages/artillery-plugin-ensure/tsconfig.build.json
+++ b/packages/artillery-plugin-ensure/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-expect/package.json
+++ b/packages/artillery-plugin-expect/package.json
@@ -2,9 +2,10 @@
   "name": "artillery-plugin-expect",
   "version": "2.27.0",
   "description": "Expectations and assertions for HTTP scenarios",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
-    "test": "bash test/run.sh"
+    "test": "bash test/run.sh",
+    "build": "tsc -p tsconfig.build.json"
   },
   "author": "Hassy Veldstra <h@artillery.io>",
   "license": "SEE LICENSE IN LICENSE.txt",

--- a/packages/artillery-plugin-expect/tsconfig.build.json
+++ b/packages/artillery-plugin-expect/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-fake-data/package.json
+++ b/packages/artillery-plugin-fake-data/package.json
@@ -2,12 +2,13 @@
   "name": "artillery-plugin-fake-data",
   "version": "1.24.0",
   "description": "Add fake test data easily to your Artillery test scripts.",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "node --test --test-timeout=120000 \"test/*.spec.js\""
+    "test": "node --test --test-timeout=120000 \"test/*.spec.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "license": "MPL-2.0",
   "dependencies": {

--- a/packages/artillery-plugin-fake-data/tsconfig.build.json
+++ b/packages/artillery-plugin-fake-data/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-memory-inspector/package.json
+++ b/packages/artillery-plugin-memory-inspector/package.json
@@ -2,9 +2,10 @@
   "name": "artillery-plugin-memory-inspector",
   "version": "1.1.1",
   "description": "Inspect the memory of processes running together with your load tests!",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
-    "test": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\""
+    "test": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "author": "",
   "license": "MPL-2.0",

--- a/packages/artillery-plugin-memory-inspector/tsconfig.build.json
+++ b/packages/artillery-plugin-memory-inspector/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-metrics-by-endpoint/package.json
+++ b/packages/artillery-plugin-metrics-by-endpoint/package.json
@@ -2,11 +2,12 @@
   "name": "artillery-plugin-metrics-by-endpoint",
   "version": "1.27.0",
   "description": "Per-endpoint breakdown of latency and response codes for Artillery HTTP tests.",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "scripts": {
     "test": "npm run test:unit && npm run test:acceptance",
     "test:acceptance": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/*.spec.js\"",
-    "test:unit": "node --test --require ./test/setup-env.cjs \"test/*.unit.js\""
+    "test:unit": "node --test --require ./test/setup-env.cjs \"test/*.unit.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [],
   "author": "Hassy Veldstra <h@artillery.io>",

--- a/packages/artillery-plugin-metrics-by-endpoint/tsconfig.build.json
+++ b/packages/artillery-plugin-metrics-by-endpoint/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/artillery-plugin-slack/package.json
+++ b/packages/artillery-plugin-slack/package.json
@@ -2,12 +2,13 @@
   "name": "artillery-plugin-slack",
   "version": "1.22.0",
   "description": "Send Artillery.io test notifications to Slack",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "echo \"Error: no test specified\" && exit 0",
+    "build": "tsc -p tsconfig.build.json"
   },
   "keywords": [],
   "license": "MPL-2.0",

--- a/packages/artillery-plugin-slack/tsconfig.build.json
+++ b/packages/artillery-plugin-slack/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -2,7 +2,7 @@
   "name": "@artilleryio/int-commons",
   "version": "2.24.0",
   "type": "module",
-  "main": "./index.ts",
+  "main": "./dist/index.js",
   "license": "MPL-2.0",
   "dependencies": {
     "async": "^2.6.4",
@@ -17,7 +17,8 @@
   "scripts": {
     "lint": "npx @biomejs/biome check .",
     "lint-fix": "npx @biomejs/biome check --write .",
-    "test": "echo \"No test specified\" && exit 0"
+    "test": "echo \"No test specified\" && exit 0",
+    "build": "tsc -p tsconfig.build.json"
   },
   "types": "./types.d.ts"
 }

--- a/packages/commons/tsconfig.build.json
+++ b/packages/commons/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@artilleryio/int-core",
   "version": "2.28.0",
   "type": "module",
-  "main": "./index.ts",
+  "main": "./dist/index.js",
   "license": "MPL-2.0",
   "dependencies": {
     "@artilleryio/int-commons": "*",
@@ -40,7 +40,8 @@
     "lint-fix": "npx @biomejs/biome check --write .",
     "test": "npm run test:unit && npm run test:acceptance",
     "test:unit": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/unit/*.test.js\"",
-    "test:acceptance": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/acceptance/*.test.js\" \"test/acceptance/**/*.test.js\""
+    "test:acceptance": "node --test --test-timeout=300000 --require ./test/setup-env.cjs \"test/acceptance/*.test.js\" \"test/acceptance/**/*.test.js\"",
+    "build": "tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@hapi/basic": "^6.0.0",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build-base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist"
+  },
+  "include": ["./**/*.ts", "../../globals.d.ts"],
+  "exclude": ["node_modules", "dist", "test", "examples", "**/*.d.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -2,25 +2,29 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        ".next/**",
+        "dist/**"
+      ]
     },
     "test": {
-      "dependsOn": ["build"],
+      "dependsOn": [
+        "build"
+      ],
       "outputs": [],
       "inputs": [
         "src/**/*.js",
         "src/**/*.tsx",
         "src/**/*.ts",
-
         "test/**/*.ts",
         "test/**/*.tsx",
         "test/**/*.js",
-
         "lib/**/*.js",
         "lib/**/*.ts",
         "lib/**/*.tsx",
-
         "core/**/*.js",
         "core/**/*.ts",
         "core/**/*.tsx"


### PR DESCRIPTION
## Description

- each TypeScript package gets tsconfig.build.json (extends the shared base) emitting to dist/; rewriteRelativeImportExtensions turns ./x.ts import specifiers into ./x.js
- build wired into turbo (dist/** cached output); test already depends on build
- npm publish workflows run npm install && npm run build before publishing
- examples and ECS worker image workflows gain a build step: they run the CLI from a checkout, where package mains now resolve to dist/

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
