### PR TITLE
feat: expose Docker image dependencies to custom scripts

### DIFF
--- a/.github/workflows/docker-ecs-worker-image.yml
+++ b/.github/workflows/docker-ecs-worker-image.yml
@@ -105,6 +105,18 @@ jobs:
           DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
         run: |
           docker build . --platform linux/amd64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+
+      - name: Smoke test Playwright imports (Public ECR)
+        if: matrix.registry == 'public'
+        env:
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
+        run: |
+          docker run --rm --platform linux/amd64 \
+            --entrypoint node \
+            --workdir /tmp \
+            --mount type=bind,source="$PWD/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs",target=/tmp/smoke-test.mjs,readonly \
+            public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} \
+            /tmp/smoke-test.mjs
       
       - name: Push Docker image (Public ECR)
         if: matrix.registry == 'public'
@@ -134,6 +146,18 @@ jobs:
           DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
         run: |
           docker build . --platform linux/amd64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+
+      - name: Smoke test Playwright imports (Private ECR)
+        if: matrix.registry == 'private'
+        env:
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-x86_64
+        run: |
+          docker run --rm --platform linux/amd64 \
+            --entrypoint node \
+            --workdir /tmp \
+            --mount type=bind,source="$PWD/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs",target=/tmp/smoke-test.mjs,readonly \
+            248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} \
+            /tmp/smoke-test.mjs
 
       - name: Push Docker image (Private ECR)
         if: matrix.registry == 'private'
@@ -212,6 +236,18 @@ jobs:
           DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
         run: |
           docker build . --platform linux/arm64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+
+      - name: Smoke test Playwright imports (Public ECR)
+        if: matrix.registry == 'public'
+        env:
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
+        run: |
+          docker run --rm --platform linux/arm64 \
+            --entrypoint node \
+            --workdir /tmp \
+            --mount type=bind,source="$PWD/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs",target=/tmp/smoke-test.mjs,readonly \
+            public.ecr.aws/d8a4z9o5/artillery-worker:${{ env.DOCKER_TAG }} \
+            /tmp/smoke-test.mjs
       
       - name: Push Docker image (Public ECR)
         if: matrix.registry == 'public'
@@ -242,11 +278,21 @@ jobs:
         run: |
           docker build . --platform linux/arm64 --build-arg="WORKER_VERSION=${{ env.WORKER_VERSION }}" --tag 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} -f ./packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
 
+      - name: Smoke test Playwright imports (Private ECR)
+        if: matrix.registry == 'private'
+        env:
+          DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
+        run: |
+          docker run --rm --platform linux/arm64 \
+            --entrypoint node \
+            --workdir /tmp \
+            --mount type=bind,source="$PWD/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs",target=/tmp/smoke-test.mjs,readonly \
+            248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }} \
+            /tmp/smoke-test.mjs
+
       - name: Push Docker image (Private ECR)
         if: matrix.registry == 'private'
         env: 
           DOCKER_TAG: ${{ env.WORKER_VERSION }}-arm64
         run: |
           docker push 248481025674.dkr.ecr.eu-west-1.amazonaws.com/artillery-worker:${{ env.DOCKER_TAG }}
-        
-      

--- a/.github/workflows/docker-publish-artillery.yml
+++ b/.github/workflows/docker-publish-artillery.yml
@@ -52,10 +52,28 @@ jobs:
             type=semver,pattern={{version}},value=${{env.ARTILLERY_VERSION}}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build release candidate Docker image
         uses: useblacksmith/build-push-action@v2
         with:
           context: ./packages/artillery
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          load: true
+          tags: artilleryio/artillery:release-candidate
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke test Playwright imports from user code
+        run: |
+          docker run --rm \
+            --entrypoint node \
+            --workdir /tmp \
+            --mount type=bind,source="$PWD/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs",target=/tmp/smoke-test.mjs,readonly \
+            artilleryio/artillery:release-candidate \
+            /tmp/smoke-test.mjs
+
+      - name: Publish Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          while IFS= read -r tag; do
+            docker tag artilleryio/artillery:release-candidate "$tag"
+            docker push "$tag"
+          done <<< "$DOCKER_TAGS"

--- a/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs
+++ b/.github/workflows/scripts/smoke-test-artillery-docker-image.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+
+const playwright = await import('playwright');
+const playwrightTest = await import('@playwright/test');
+const playwrightCore = await import('playwright-core');
+
+assert.equal(typeof playwright.chromium.launch, 'function');
+assert.equal(typeof playwrightTest.test, 'function');
+assert.equal(typeof playwrightTest.expect, 'function');
+assert.equal(typeof playwrightCore.chromium.launch, 'function');
+
+console.log('Playwright libraries are importable from user code');

--- a/packages/artillery/Dockerfile
+++ b/packages/artillery/Dockerfile
@@ -8,6 +8,10 @@ COPY package*.json ./
 RUN npm --ignore-scripts --production install
 RUN npx playwright install --with-deps chromium
 
+# Make Artillery's dependencies available to scripts mounted anywhere in the
+# container.
+RUN ln -s /home/node/artillery/node_modules /node_modules
+
 COPY . ./
 
 # Transpile TypeScript sources to dist/ (package main, bin and oclif

--- a/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
+++ b/packages/artillery/lib/platform/aws-ecs/worker/Dockerfile
@@ -237,9 +237,10 @@ COPY --from=builder ${FUNCTION_DIR}/a9-handler-index.js ${FUNCTION_DIR}/
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker /artillery/loadgen-worker
 COPY ./packages/artillery/lib/platform/aws-ecs/worker/helpers.sh /artillery/helpers.sh
 
-RUN ln -s /artillery/node_modules/.bin/artillery /usr/local/bin/artillery \
+RUN ln -s /artillery/node_modules /node_modules \
+    && ln -s /artillery/node_modules/.bin/artillery /usr/local/bin/artillery \
     && chmod +x /artillery/loadgen-worker
 
-ENV NODE_PATH="/home/node/artillery/node_modules"
+ENV NODE_PATH="/artillery/node_modules"
 
 ENTRYPOINT ["/artillery/packages/artillery/bin/run"]

--- a/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
+++ b/packages/artillery/lib/platform/aws-ecs/worker/loadgen-worker
@@ -258,7 +258,7 @@ install_dependencies () {
     debug "$(cat $METADATA_FILE || true)"
 
     # Needed to install all packages to the dir of the test files.
-    export NODE_PATH="$TEST_DATA:${NODE_PATH:-""}"
+    export NODE_PATH="$TEST_DATA/node_modules:${NODE_PATH:-""}"
 
     generate_npmrc >> ~/.npmrc
 


### PR DESCRIPTION
## Description

Make Artillery's own dependencies (e.g. Playwright) available to user scripts running in the container.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [x] Does this require an update to the docs? No
- [x] Does this require a changelog entry? No
