### PR TITLE
feat: AWS resource tagging

### DIFF
--- a/packages/artillery/lib/cmds/run-fargate.ts
+++ b/packages/artillery/lib/cmds/run-fargate.ts
@@ -32,7 +32,7 @@ class RunCommand extends Command {
 
     // Validate early, before any AWS resources are touched:
     try {
-      parseResourceTags(flags['resource-tags']);
+      parseResourceTags(flags['aws-tags']);
     } catch (err) {
       console.error(err.message);
       process.exit(1);
@@ -190,9 +190,9 @@ RunCommand.flags = {
   'max-duration': Flags.string({
     description: 'Maximum duration of the test run'
   }),
-  'resource-tags': Flags.string({
+  'aws-tags': Flags.string({
     description:
-      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Fargate tasks and SQS queue), for example: --resource-tags "team:perf,cost-center:1234"'
+      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Fargate tasks and SQS queue), for example: --aws-tags "team:perf,cost-center:1234"'
   }),
   'no-assign-public-ip': Flags.boolean({
     description:

--- a/packages/artillery/lib/cmds/run-fargate.ts
+++ b/packages/artillery/lib/cmds/run-fargate.ts
@@ -8,6 +8,7 @@ import { Args, Command, Flags } from '@oclif/core';
 import dotenv from 'dotenv';
 import { CommonRunFlags } from '../cli/common-flags.ts';
 import { ECS_WORKER_ROLE_NAME } from '../platform/aws/constants.ts';
+import { parseResourceTags } from '../platform/aws/resource-tags.ts';
 import PlatformECS from '../platform/aws-ecs/ecs.ts';
 import runCluster from '../platform/aws-ecs/legacy/run-cluster.ts';
 import { supportedRegions } from '../platform/aws-ecs/legacy/util.ts';
@@ -28,6 +29,14 @@ class RunCommand extends Command {
     flags['platform-opt'] = [`region=${flags.region}`];
 
     flags.platform = 'aws:ecs';
+
+    // Validate early, before any AWS resources are touched:
+    try {
+      parseResourceTags(flags['resource-tags']);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
 
     if (flags.dotenv) {
       const dotEnvPath = path.resolve(process.cwd(), flags.dotenv);
@@ -180,6 +189,10 @@ RunCommand.flags = {
   }),
   'max-duration': Flags.string({
     description: 'Maximum duration of the test run'
+  }),
+  'resource-tags': Flags.string({
+    description:
+      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Fargate tasks and SQS queue), for example: --resource-tags "team:perf,cost-center:1234"'
   }),
   'no-assign-public-ip': Flags.boolean({
     description:

--- a/packages/artillery/lib/cmds/run-lambda.ts
+++ b/packages/artillery/lib/cmds/run-lambda.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { CommonRunFlags } from '../cli/common-flags.ts';
+import { parseResourceTags } from '../platform/aws/resource-tags.ts';
 
 import RunCommand from './run.ts';
 
@@ -38,6 +39,17 @@ class RunLambdaCommand extends Command {
     }
 
     flags.platform = 'aws:lambda';
+
+    // NOTE: --resource-tags is passed through as-is via flags (cliArgs),
+    // not via platform-opt. platform-opt values are split on "=" which
+    // would truncate tag values containing "=".
+    // Validate early, before any AWS resources are touched:
+    try {
+      parseResourceTags(flags['resource-tags']);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
 
     RunCommand.runCommandImplementation(flags, argv, args);
   }
@@ -86,6 +98,10 @@ RunLambdaCommand.flags = {
   'subnet-ids': Flags.string({
     description:
       'Comma-separated list of subnet IDs to use for the Lambda function'
+  }),
+  'resource-tags': Flags.string({
+    description:
+      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Lambda function and SQS queue), for example: --resource-tags "team:perf,cost-center:1234"'
   })
 };
 

--- a/packages/artillery/lib/cmds/run-lambda.ts
+++ b/packages/artillery/lib/cmds/run-lambda.ts
@@ -40,12 +40,12 @@ class RunLambdaCommand extends Command {
 
     flags.platform = 'aws:lambda';
 
-    // NOTE: --resource-tags is passed through as-is via flags (cliArgs),
+    // NOTE: --aws-tags is passed through as-is via flags (cliArgs),
     // not via platform-opt. platform-opt values are split on "=" which
     // would truncate tag values containing "=".
     // Validate early, before any AWS resources are touched:
     try {
-      parseResourceTags(flags['resource-tags']);
+      parseResourceTags(flags['aws-tags']);
     } catch (err) {
       console.error(err.message);
       process.exit(1);
@@ -99,9 +99,9 @@ RunLambdaCommand.flags = {
     description:
       'Comma-separated list of subnet IDs to use for the Lambda function'
   }),
-  'resource-tags': Flags.string({
+  'aws-tags': Flags.string({
     description:
-      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Lambda function and SQS queue), for example: --resource-tags "team:perf,cost-center:1234"'
+      'Comma-separated list of tags in key:value format to apply to AWS resources created for the test run (Lambda function and SQS queue), for example: --aws-tags "team:perf,cost-center:1234"'
   })
 };
 

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
@@ -59,6 +59,11 @@ import dotenv from 'dotenv';
 import awaitOnEE from '../../../util/await-on-ee.ts';
 import { setCloudwatchRetention } from '../../aws/aws-cloudwatch.ts';
 import getAccountId from '../../aws/aws-get-account-id.ts';
+import {
+  parseResourceTags,
+  toEcsTags,
+  toTagMap
+} from '../../aws/resource-tags.ts';
 import * as awsUtil from './aws-util.ts';
 import createS3Client from './create-s3-client.ts';
 import { createTest } from './create-test.ts';
@@ -222,6 +227,15 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
   }
 
   context.tags = parseTags(options.tags);
+
+  // AWS resource tags (Fargate tasks, SQS queue). Validated in the
+  // run-fargate command already; parse defensively anyway:
+  try {
+    context.resourceTags = parseResourceTags(options.resourceTags);
+  } catch (err) {
+    console.error(chalk.red(err.message));
+    process.exit(1);
+  }
 
   if (context.tags.length > TEST_RUNS_MAX_TAGS) {
     console.error(
@@ -1316,7 +1330,7 @@ async function createQueue(context) {
     0,
     30
   )}.fifo`;
-  const params = {
+  const params: any = {
     QueueName: queueName,
     Attributes: {
       FifoQueue: 'true',
@@ -1325,6 +1339,10 @@ async function createQueue(context) {
       VisibilityTimeout: '600' // 10 minutes
     }
   };
+
+  if (context.resourceTags?.length > 0) {
+    params.tags = toTagMap(context.resourceTags);
+  }
     const result = await sqs.send(new CreateQueueCommand(params));
     context.sqsQueueUrl = result.QueueUrl;
 
@@ -1520,6 +1538,10 @@ async function setupDefaultECSParams(context) {
     overrides: context.taskOverrides,
     startedBy: context.testId
   };
+
+  if (context.resourceTags?.length > 0) {
+    defaultParams.tags = toEcsTags(context.resourceTags);
+  }
 
   if (context.isFargate) {
     if (context.isCapacitySpot) {

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
@@ -231,7 +231,7 @@ async function tryRunCluster(scriptPath, options, artilleryReporter) {
   // AWS resource tags (Fargate tasks, SQS queue). Validated in the
   // run-fargate command already; parse defensively anyway:
   try {
-    context.resourceTags = parseResourceTags(options.resourceTags);
+    context.resourceTags = parseResourceTags(options.awsTags);
   } catch (err) {
     console.error(chalk.red(err.message));
     process.exit(1);

--- a/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
+++ b/packages/artillery/lib/platform/aws-ecs/legacy/run-cluster.ts
@@ -1330,21 +1330,21 @@ async function createQueue(context) {
     0,
     30
   )}.fifo`;
-  const params: any = {
+  const params = {
     QueueName: queueName,
     Attributes: {
       FifoQueue: 'true',
       ContentBasedDeduplication: 'false',
       MessageRetentionPeriod: '1800',
       VisibilityTimeout: '600' // 10 minutes
-    }
+    },
+    ...(context.resourceTags?.length > 0
+      ? { tags: toTagMap(context.resourceTags) }
+      : {})
   };
 
-  if (context.resourceTags?.length > 0) {
-    params.tags = toTagMap(context.resourceTags);
-  }
-    const result = await sqs.send(new CreateQueueCommand(params));
-    context.sqsQueueUrl = result.QueueUrl;
+  const result = await sqs.send(new CreateQueueCommand(params));
+  context.sqsQueueUrl = result.QueueUrl;
 
   // Wait for the queue to be available:
   let waited = 0;

--- a/packages/artillery/lib/platform/aws-lambda/index.ts
+++ b/packages/artillery/lib/platform/aws-lambda/index.ts
@@ -118,7 +118,7 @@ class PlatformLambda {
 
     // Validated in the run-lambda command already:
     this.resourceTags = parseResourceTags(
-      this.platformOpts.cliArgs['resource-tags']
+      this.platformOpts.cliArgs['aws-tags']
     );
 
     this.s3LifecycleConfigurationRules = [
@@ -630,7 +630,7 @@ class PlatformLambda {
         'Lambda function with this configuration already exists. Using existing function.'
       );
       // Function is shared across test runs with the same configuration.
-      // Tags are overwritten by each run that sets --resource-tags
+      // Tags are overwritten by each run that sets --aws-tags
       // (last-writer-wins):
       await this.tagExistingFunction(existingLambdaConfig.FunctionArn);
       return;

--- a/packages/artillery/lib/platform/aws-lambda/index.ts
+++ b/packages/artillery/lib/platform/aws-lambda/index.ts
@@ -28,7 +28,8 @@ import {
   InvokeCommand,
   LambdaClient,
   ResourceConflictException,
-  ResourceNotFoundException
+  ResourceNotFoundException,
+  TagResourceCommand
 } from '@aws-sdk/client-lambda';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { DeleteQueueCommand, SQSClient } from '@aws-sdk/client-sqs';
@@ -42,6 +43,7 @@ import getAccountId from '../aws/aws-get-account-id.ts';
 import { getBucketRegion } from '../aws/aws-get-bucket-region.ts';
 import awsGetDefaultRegion from '../aws/aws-get-default-region.ts';
 import { SQS_QUEUES_NAME_PREFIX } from '../aws/constants.ts';
+import { parseResourceTags, toTagMap } from '../aws/resource-tags.ts';
 import createS3Client from '../aws-ecs/legacy/create-s3-client.ts';
 import { createAndUploadTestDependencies } from './dependencies.ts';
 import prices from './prices.ts';
@@ -113,6 +115,11 @@ class PlatformLambda {
 
     this.cloudKey =
       this.platformOpts.cliArgs.key || process.env.ARTILLERY_CLOUD_API_KEY;
+
+    // Validated in the run-lambda command already:
+    this.resourceTags = parseResourceTags(
+      this.platformOpts.cliArgs['resource-tags']
+    );
 
     this.s3LifecycleConfigurationRules = [
       {
@@ -218,7 +225,11 @@ class PlatformLambda {
       36
     )}.fifo`;
 
-    const sqsQueueUrl = await createSQSQueue(this.region, queueName);
+    const sqsQueueUrl = await createSQSQueue(
+      this.region,
+      queueName,
+      toTagMap(this.resourceTags)
+    );
     this.sqsQueueUrl = sqsQueueUrl;
 
     if (typeof this.lambdaRoleArn === 'undefined') {
@@ -618,6 +629,10 @@ class PlatformLambda {
       debug(
         'Lambda function with this configuration already exists. Using existing function.'
       );
+      // Function is shared across test runs with the same configuration.
+      // Tags are overwritten by each run that sets --resource-tags
+      // (last-writer-wins):
+      await this.tagExistingFunction(existingLambdaConfig.FunctionArn);
       return;
     }
 
@@ -632,10 +647,39 @@ class PlatformLambda {
         debug(
           'Lambda function with this configuration already exists. Using existing function.'
         );
+        await this.tagExistingFunction(
+          `${this.arnPrefix}:lambda:${this.region}:${this.accountId}:function:${this.functionName}`
+        );
         return;
       }
 
       throw new Error(`Failed to create Lambda Function: \n${err}`);
+    }
+  }
+
+  // Best-effort. Tagging failure must not fail the test run.
+  async tagExistingFunction(functionArn) {
+    if (this.resourceTags.length === 0 || !functionArn) {
+      return;
+    }
+
+    const lambda = new LambdaClient({
+      apiVersion: '2015-03-31',
+      region: this.region
+    });
+
+    try {
+      await lambda.send(
+        new TagResourceCommand({
+          Resource: functionArn,
+          Tags: toTagMap(this.resourceTags)
+        })
+      );
+    } catch (err) {
+      artillery.log(
+        `WARNING: could not apply resource tags to Lambda function: ${err.message}`
+      );
+      debug(err);
     }
   }
 
@@ -728,6 +772,10 @@ class PlatformLambda {
         SecurityGroupIds: this.securityGroupIds,
         SubnetIds: this.subnetIds
       };
+    }
+
+    if (this.resourceTags.length > 0) {
+      lambdaConfig.Tags = toTagMap(this.resourceTags);
     }
 
     await lambda.send(new CreateFunctionCommand(lambdaConfig));

--- a/packages/artillery/lib/platform/aws/aws-create-sqs-queue.ts
+++ b/packages/artillery/lib/platform/aws/aws-create-sqs-queue.ts
@@ -11,12 +11,12 @@ const debug = createDebug('artillery:aws-create-sqs-queue');
 import sleep from '../../util/sleep.ts';
 
 // TODO: Add timestamp to SQS queue name for automatic GC
-async function createSQSQueue(region, queueName) {
+async function createSQSQueue(region, queueName, tags = {}) {
   const sqs = new SQSClient({
     region
   });
 
-  const params = {
+  const params: any = {
     QueueName: queueName,
     Attributes: {
       FifoQueue: 'true',
@@ -25,6 +25,10 @@ async function createSQSQueue(region, queueName) {
       VisibilityTimeout: '600'
     }
   };
+
+  if (Object.keys(tags).length > 0) {
+    params.tags = tags;
+  }
 
   const result = await sqs.send(new CreateQueueCommand(params));
   const sqsQueueUrl = result.QueueUrl;

--- a/packages/artillery/lib/platform/aws/aws-create-sqs-queue.ts
+++ b/packages/artillery/lib/platform/aws/aws-create-sqs-queue.ts
@@ -16,19 +16,16 @@ async function createSQSQueue(region, queueName, tags = {}) {
     region
   });
 
-  const params: any = {
+  const params = {
     QueueName: queueName,
     Attributes: {
       FifoQueue: 'true',
       ContentBasedDeduplication: 'false',
       MessageRetentionPeriod: '1800',
       VisibilityTimeout: '600'
-    }
+    },
+    ...(Object.keys(tags).length > 0 ? { tags } : {})
   };
-
-  if (Object.keys(tags).length > 0) {
-    params.tags = tags;
-  }
 
   const result = await sqs.send(new CreateQueueCommand(params));
   const sqsQueueUrl = result.QueueUrl;

--- a/packages/artillery/lib/platform/aws/iam-cf-templates/aws-iam-fargate-cf-template.yml
+++ b/packages/artillery/lib/platform/aws/iam-cf-templates/aws-iam-fargate-cf-template.yml
@@ -141,6 +141,15 @@ Resources:
                     ecs:cluster:
                       Fn::Sub: "arn:aws:ecs:*:${AWS::AccountId}:cluster/*"
                 Resource: "*"
+              - Sid: "ECSTagResourceOnRunTask"
+                Effect: "Allow"
+                Action:
+                  - "ecs:TagResource"
+                Condition:
+                  StringEquals:
+                    ecs:CreateAction: "RunTask"
+                Resource:
+                  Fn::Sub: "arn:aws:ecs:*:${AWS::AccountId}:task/*"
               - Sid: "S3Permissions"
                 Effect: "Allow"
                 Action:

--- a/packages/artillery/lib/platform/aws/iam-cf-templates/aws-iam-lambda-cf-template.yml
+++ b/packages/artillery/lib/platform/aws/iam-cf-templates/aws-iam-lambda-cf-template.yml
@@ -99,6 +99,7 @@ Resources:
                   - lambda:CreateFunction
                   - lambda:DeleteFunction
                   - lambda:GetFunctionConfiguration
+                  - lambda:TagResource
                 Resource: !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:artilleryio-*"
               - Sid: EcrPullImagePermissions
                 Effect: Allow

--- a/packages/artillery/lib/platform/aws/iam-cf-templates/gh-oidc-fargate.yml
+++ b/packages/artillery/lib/platform/aws/iam-cf-templates/gh-oidc-fargate.yml
@@ -159,6 +159,15 @@ Resources:
                     ecs:cluster:
                       Fn::Sub: "arn:aws:ecs:*:${AWS::AccountId}:cluster/*"
                 Resource: "*"
+              - Sid: "ECSTagResourceOnRunTask"
+                Effect: "Allow"
+                Action:
+                  - "ecs:TagResource"
+                Condition:
+                  StringEquals:
+                    ecs:CreateAction: "RunTask"
+                Resource:
+                  Fn::Sub: "arn:aws:ecs:*:${AWS::AccountId}:task/*"
               - Sid: "S3Permissions"
                 Effect: "Allow"
                 Action:

--- a/packages/artillery/lib/platform/aws/iam-cf-templates/gh-oidc-lambda.yml
+++ b/packages/artillery/lib/platform/aws/iam-cf-templates/gh-oidc-lambda.yml
@@ -122,6 +122,7 @@ Resources:
                   - lambda:CreateFunction
                   - lambda:DeleteFunction
                   - lambda:GetFunctionConfiguration
+                  - lambda:TagResource
                 Resource: !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:artilleryio-*"
               - Sid: EcrPullImagePermissions
                 Effect: Allow

--- a/packages/artillery/lib/platform/aws/resource-tags.ts
+++ b/packages/artillery/lib/platform/aws/resource-tags.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Parsing and formatting of --resource-tags. These tags are applied to
+// AWS resources created for a test run: ECS/Fargate tasks, Lambda
+// functions and SQS queues.
+
+// https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html
+const TAG_KEY_MAX_LENGTH = 128;
+const TAG_VALUE_MAX_LENGTH = 256;
+const MAX_TAGS = 50;
+const VALID_TAG_CHARS = /^[\p{L}\p{N} _.:/=+\-@]*$/u;
+
+interface ResourceTag {
+  key: string;
+  value: string;
+}
+
+// Input format: "key:value,key:value". Values may contain ":" - the
+// entry is split on the first ":" only. Throws on invalid input.
+function parseResourceTags(input?: string): ResourceTag[] {
+  if (!input) {
+    return [];
+  }
+
+  const tags: ResourceTag[] = [];
+  const errors: string[] = [];
+
+  const entries = input
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  for (const entry of entries) {
+    const sepIndex = entry.indexOf(':');
+    if (sepIndex === -1) {
+      errors.push(`"${entry}" - expected key:value format`);
+      continue;
+    }
+
+    const key = entry.slice(0, sepIndex).trim();
+    const value = entry.slice(sepIndex + 1).trim();
+
+    if (key.length === 0) {
+      errors.push(`"${entry}" - tag key is empty`);
+    } else if (key.length > TAG_KEY_MAX_LENGTH) {
+      errors.push(
+        `"${entry}" - tag key exceeds ${TAG_KEY_MAX_LENGTH} characters`
+      );
+    } else if (key.toLowerCase().startsWith('aws:')) {
+      errors.push(`"${entry}" - the "aws:" tag key prefix is reserved by AWS`);
+    } else if (!VALID_TAG_CHARS.test(key)) {
+      errors.push(`"${entry}" - tag key contains invalid characters`);
+    } else if (value.length > TAG_VALUE_MAX_LENGTH) {
+      errors.push(
+        `"${entry}" - tag value exceeds ${TAG_VALUE_MAX_LENGTH} characters`
+      );
+    } else if (!VALID_TAG_CHARS.test(value)) {
+      errors.push(`"${entry}" - tag value contains invalid characters`);
+    } else if (tags.some((t) => t.key === key)) {
+      errors.push(`"${entry}" - duplicate tag key`);
+    } else {
+      tags.push({ key, value });
+    }
+  }
+
+  if (tags.length > MAX_TAGS) {
+    errors.push(`a maximum of ${MAX_TAGS} tags is allowed`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid --resource-tags value:\n  - ${errors.join('\n  - ')}`
+    );
+  }
+
+  return tags;
+}
+
+// SQS CreateQueue and Lambda CreateFunction/TagResource take a map
+function toTagMap(tags: ResourceTag[]): Record<string, string> {
+  return Object.fromEntries(tags.map((t) => [t.key, t.value]));
+}
+
+// ECS RunTask takes [{ key, value }]
+function toEcsTags(tags: ResourceTag[]): ResourceTag[] {
+  return tags.map((t) => ({ key: t.key, value: t.value }));
+}
+
+export { parseResourceTags, toTagMap, toEcsTags };
+export type { ResourceTag };

--- a/packages/artillery/lib/platform/aws/resource-tags.ts
+++ b/packages/artillery/lib/platform/aws/resource-tags.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Parsing and formatting of --resource-tags. These tags are applied to
+// Parsing and formatting of --aws-tags. These tags are applied to
 // AWS resources created for a test run: ECS/Fargate tasks, Lambda
 // functions and SQS queues.
 
@@ -71,7 +71,7 @@ function parseResourceTags(input?: string | null): ResourceTag[] {
 
   if (errors.length > 0) {
     throw new Error(
-      `Invalid --resource-tags value:\n  - ${errors.join('\n  - ')}`
+      `Invalid --aws-tags value:\n  - ${errors.join('\n  - ')}`
     );
   }
 

--- a/packages/artillery/lib/platform/aws/resource-tags.ts
+++ b/packages/artillery/lib/platform/aws/resource-tags.ts
@@ -19,7 +19,7 @@ interface ResourceTag {
 
 // Input format: "key:value,key:value". Values may contain ":" - the
 // entry is split on the first ":" only. Throws on invalid input.
-function parseResourceTags(input?: string): ResourceTag[] {
+function parseResourceTags(input?: string | null): ResourceTag[] {
   if (!input) {
     return [];
   }

--- a/packages/artillery/test/unit/resource-tags.test.js
+++ b/packages/artillery/test/unit/resource-tags.test.js
@@ -1,0 +1,137 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  parseResourceTags,
+  toTagMap,
+  toEcsTags
+} = require('../../lib/platform/aws/resource-tags.ts');
+
+test('parseResourceTags - empty input returns empty array', (_t) => {
+  assert.deepEqual(parseResourceTags(undefined), []);
+  assert.deepEqual(parseResourceTags(''), []);
+  assert.deepEqual(parseResourceTags(null), []);
+});
+
+test('parseResourceTags - parses key:value pairs', (_t) => {
+  assert.deepEqual(parseResourceTags('team:perf'), [
+    { key: 'team', value: 'perf' }
+  ]);
+
+  assert.deepEqual(parseResourceTags('team:perf,cost-center:1234'), [
+    { key: 'team', value: 'perf' },
+    { key: 'cost-center', value: '1234' }
+  ]);
+});
+
+test('parseResourceTags - trims whitespace around entries, keys and values', (_t) => {
+  assert.deepEqual(parseResourceTags(' team : perf , env : load '), [
+    { key: 'team', value: 'perf' },
+    { key: 'env', value: 'load' }
+  ]);
+});
+
+test('parseResourceTags - ignores empty entries from stray commas', (_t) => {
+  assert.deepEqual(parseResourceTags('team:perf,,env:load,'), [
+    { key: 'team', value: 'perf' },
+    { key: 'env', value: 'load' }
+  ]);
+});
+
+test('parseResourceTags - splits on first colon only, values may contain colons', (_t) => {
+  assert.deepEqual(parseResourceTags('env:load:test'), [
+    { key: 'env', value: 'load:test' }
+  ]);
+});
+
+test('parseResourceTags - allows empty value', (_t) => {
+  assert.deepEqual(parseResourceTags('team:'), [{ key: 'team', value: '' }]);
+});
+
+test('parseResourceTags - allows AWS tag special characters', (_t) => {
+  assert.deepEqual(parseResourceTags('a_b.c/d:x=y+z-w@v'), [
+    { key: 'a_b.c/d', value: 'x=y+z-w@v' }
+  ]);
+});
+
+test('parseResourceTags - rejects entry without separator', (_t) => {
+  assert.throws(
+    () => parseResourceTags('noseparator'),
+    /expected key:value format/
+  );
+});
+
+test('parseResourceTags - rejects empty key', (_t) => {
+  assert.throws(() => parseResourceTags(':value'), /tag key is empty/);
+});
+
+test('parseResourceTags - rejects duplicate keys', (_t) => {
+  assert.throws(() => parseResourceTags('dup:1,dup:2'), /duplicate tag key/);
+});
+
+test('parseResourceTags - rejects invalid characters', (_t) => {
+  assert.throws(
+    () => parseResourceTags('bad<key>:x'),
+    /tag key contains invalid characters/
+  );
+
+  assert.throws(
+    () => parseResourceTags('key:bad"value"'),
+    /tag value contains invalid characters/
+  );
+});
+
+test('parseResourceTags - rejects key longer than 128 characters', (_t) => {
+  const longKey = 'k'.repeat(129);
+  assert.throws(
+    () => parseResourceTags(`${longKey}:v`),
+    /tag key exceeds 128 characters/
+  );
+
+  // 128 exactly is fine:
+  assert.equal(parseResourceTags(`${'k'.repeat(128)}:v`).length, 1);
+});
+
+test('parseResourceTags - rejects value longer than 256 characters', (_t) => {
+  const longValue = 'v'.repeat(257);
+  assert.throws(
+    () => parseResourceTags(`k:${longValue}`),
+    /tag value exceeds 256 characters/
+  );
+
+  // 256 exactly is fine:
+  assert.equal(parseResourceTags(`k:${'v'.repeat(256)}`).length, 1);
+});
+
+test('parseResourceTags - rejects more than 50 tags', (_t) => {
+  const fifty = Array.from({ length: 50 }, (_, i) => `k${i}:v`).join(',');
+  assert.equal(parseResourceTags(fifty).length, 50);
+
+  const fiftyOne = Array.from({ length: 51 }, (_, i) => `k${i}:v`).join(',');
+  assert.throws(
+    () => parseResourceTags(fiftyOne),
+    /maximum of 50 tags is allowed/
+  );
+});
+
+test('parseResourceTags - reports all errors at once', (_t) => {
+  try {
+    parseResourceTags('noseparator,:empty,dup:1,dup:2');
+    assert.fail('expected to throw');
+  } catch (err) {
+    assert.match(err.message, /expected key:value format/);
+    assert.match(err.message, /tag key is empty/);
+    assert.match(err.message, /duplicate tag key/);
+  }
+});
+
+test('toTagMap - converts to key/value map', (_t) => {
+  assert.deepEqual(toTagMap(parseResourceTags('a:1,b:2')), { a: '1', b: '2' });
+  assert.deepEqual(toTagMap([]), {});
+});
+
+test('toEcsTags - converts to ECS tag shape', (_t) => {
+  assert.deepEqual(toEcsTags(parseResourceTags('a:1')), [
+    { key: 'a', value: '1' }
+  ]);
+  assert.deepEqual(toEcsTags([]), []);
+});


### PR DESCRIPTION
## Description

Add `--resource-tags` flag for adding AWS resource tags to Lambda functions/Fargate containers created for tests.

## Pre-merge checklist

**This is for use by the Artillery team. Please leave this in if you're contributing to Artillery.**

- [ ] Does this require an update to the docs? Yes
- [ ] Does this require a changelog entry? Yes
